### PR TITLE
Use a database-backed user password authentication system instead of the current OAuth2 implementation #40

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/api/utils/SecurityUtils.java
+++ b/src/main/java/com/sivalabs/ft/features/api/utils/SecurityUtils.java
@@ -1,12 +1,10 @@
 package com.sivalabs.ft.features.api.utils;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
 
 public class SecurityUtils {
 
@@ -22,26 +20,16 @@ public class SecurityUtils {
     static Map<String, Object> getLoginUserDetails() {
         Map<String, Object> map = new HashMap<>();
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (!(authentication instanceof JwtAuthenticationToken jwtAuth)) {
+        if (authentication == null || !authentication.isAuthenticated()) {
             return map;
         }
-        Jwt jwt = (Jwt) jwtAuth.getPrincipal();
 
-        map.put("username", jwt.getClaimAsString("preferred_username"));
-        map.put("email", jwt.getClaimAsString("email"));
-        map.put("name", jwt.getClaimAsString("name"));
-        map.put("token", jwt.getTokenValue());
-        map.put("authorities", authentication.getAuthorities());
-        map.put("roles", getRoles(jwt));
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetails userDetails) {
+            map.put("username", userDetails.getUsername());
+            map.put("authorities", authentication.getAuthorities());
+        }
 
         return map;
-    }
-
-    private static List<String> getRoles(Jwt jwt) {
-        Map<String, Object> realm_access = (Map<String, Object>) jwt.getClaims().get("realm_access");
-        if (realm_access != null && !realm_access.isEmpty()) {
-            return (List<String>) realm_access.get("roles");
-        }
-        return List.of();
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/RoleRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Role;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(String name);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/UserRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/UserRepository.java
@@ -1,0 +1,17 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Role.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Role.java
@@ -1,0 +1,86 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Entity
+@Table(name = "roles")
+public class Role implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @SequenceGenerator(name = "roles_id_seq", sequenceName = "roles_id_seq", allocationSize = 50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "roles_id_seq")
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    public Role() {}
+
+    public Role(String name) {
+        this.name = name;
+    }
+
+    public Role(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Role role = (Role) o;
+        return Objects.equals(name, role.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "Role{" + "id=" + id + ", name='" + name + '\'' + ", description='" + description + '\'' + '}';
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,0 +1,219 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @SequenceGenerator(name = "users_id_seq", sequenceName = "users_id_seq", allocationSize = 50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "users_id_seq")
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled = true;
+
+    @Column(name = "account_non_expired", nullable = false)
+    private boolean accountNonExpired = true;
+
+    @Column(name = "account_non_locked", nullable = false)
+    private boolean accountNonLocked = true;
+
+    @Column(name = "credentials_non_expired", nullable = false)
+    private boolean credentialsNonExpired = true;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updatedAt;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"))
+    private Set<Role> roles = new HashSet<>();
+
+    public User() {}
+
+    public User(String username, String password, String email) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isAccountNonExpired() {
+        return accountNonExpired;
+    }
+
+    public void setAccountNonExpired(boolean accountNonExpired) {
+        this.accountNonExpired = accountNonExpired;
+    }
+
+    public boolean isAccountNonLocked() {
+        return accountNonLocked;
+    }
+
+    public void setAccountNonLocked(boolean accountNonLocked) {
+        this.accountNonLocked = accountNonLocked;
+    }
+
+    public boolean isCredentialsNonExpired() {
+        return credentialsNonExpired;
+    }
+
+    public void setCredentialsNonExpired(boolean credentialsNonExpired) {
+        this.credentialsNonExpired = credentialsNonExpired;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
+    }
+
+    public void addRole(Role role) {
+        this.roles.add(role);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(username, user.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username);
+    }
+
+    @Override
+    public String toString() {
+        return "User{" + "id="
+                + id + ", username='"
+                + username + '\'' + ", email='"
+                + email + '\'' + ", firstName='"
+                + firstName + '\'' + ", lastName='"
+                + lastName + '\'' + ", enabled="
+                + enabled + ", roles="
+                + roles + '}';
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/security/CustomUserDetailsService.java
+++ b/src/main/java/com/sivalabs/ft/features/security/CustomUserDetailsService.java
@@ -1,0 +1,48 @@
+package com.sivalabs.ft.features.security;
+
+import com.sivalabs.ft.features.domain.UserRepository;
+import com.sivalabs.ft.features.domain.entities.Role;
+import com.sivalabs.ft.features.domain.entities.User;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository
+                .findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                user.isEnabled(),
+                user.isAccountNonExpired(),
+                user.isCredentialsNonExpired(),
+                user.isAccountNonLocked(),
+                getAuthorities(user));
+    }
+
+    private Collection<? extends GrantedAuthority> getAuthorities(User user) {
+        return user.getRoles().stream()
+                .map(Role::getName)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,11 +22,6 @@ spring.jpa.open-in-view=false
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 
-####### OAuth2 Configuration  #########
-OAUTH2_SERVER_URL=http://localhost:9191
-REALM_URL=${OAUTH2_SERVER_URL}/realms/feature-tracker
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${REALM_URL}
-
 ######## Kafka Configuration  #########
 KAFKA_BROKER=localhost:9092
 spring.kafka.bootstrap-servers=${KAFKA_BROKER}

--- a/src/main/resources/db/migration/V5__create_users_and_roles_tables.sql
+++ b/src/main/resources/db/migration/V5__create_users_and_roles_tables.sql
@@ -1,0 +1,51 @@
+-- Create users table
+CREATE SEQUENCE users_id_seq START WITH 100 INCREMENT BY 50;
+
+CREATE TABLE users (
+    id BIGINT NOT NULL DEFAULT nextval('users_id_seq'),
+    username VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    first_name VARCHAR(50),
+    last_name VARCHAR(50),
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    account_non_expired BOOLEAN NOT NULL DEFAULT TRUE,
+    account_non_locked BOOLEAN NOT NULL DEFAULT TRUE,
+    credentials_non_expired BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+    updated_at TIMESTAMP,
+    PRIMARY KEY (id)
+);
+
+-- Create roles table
+CREATE SEQUENCE roles_id_seq START WITH 100 INCREMENT BY 50;
+
+CREATE TABLE roles (
+    id BIGINT NOT NULL DEFAULT nextval('roles_id_seq'),
+    name VARCHAR(50) NOT NULL UNIQUE,
+    description VARCHAR(255),
+    PRIMARY KEY (id)
+);
+
+-- Create user_roles join table for many-to-many relationship
+CREATE TABLE user_roles (
+    user_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    PRIMARY KEY (user_id, role_id),
+    CONSTRAINT fk_user_roles_user_id FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_user_roles_role_id FOREIGN KEY (role_id) REFERENCES roles (id)
+);
+
+-- Insert default roles
+INSERT INTO roles (name, description) VALUES 
+('ROLE_USER', 'Regular user with basic privileges'),
+('ROLE_ADMIN', 'Administrator with all privileges');
+
+-- Insert a default admin user with password 'admin' (BCrypt encoded)
+INSERT INTO users (username, password, email, first_name, last_name) VALUES
+('admin', '$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG', 'admin@example.com', 'Admin', 'User');
+
+-- Assign admin role to admin user
+INSERT INTO user_roles (user_id, role_id)
+SELECT u.id, r.id FROM users u, roles r
+WHERE u.username = 'admin' AND r.name = 'ROLE_ADMIN';

--- a/src/test/java/com/sivalabs/ft/features/security/SecurityIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/security/SecurityIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.sivalabs.ft.features.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sivalabs.ft.features.AbstractIT;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+class SecurityIntegrationTest extends AbstractIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private DaoAuthenticationProvider authenticationProvider;
+
+    @Test
+    void shouldAllowAccessToPublicEndpoints() throws Exception {
+        mockMvc.perform(get("/api/products/SAMPLE")).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldDenyAccessForUnauthorizedUser() throws Exception {
+        mockMvc.perform(post("/api/products")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                                """
+                                        {
+                                            "code":"TEST",
+                                            "prefix":"TST",
+                                            "name":"Test Product",
+                                            "imageUrl":"http://example.com/image.jpg"
+                                        }
+                                        """
+                                        .stripIndent()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldAllowAccessToAdminEndpointsForAdminRole() throws Exception {
+        mockMvc.perform(get("/api/products/SAMPLE").with(csrf())).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldAuthenticateWithValidCredentials() throws Exception {
+        mockMvc.perform(get("/api/products/SAMPLE")
+                        .with(user("admin").password("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectInvalidCredentials() throws Exception {
+        mockMvc.perform(get("/api/products/SAMPLE")
+                        .with(user("invalid").password("invalid").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldVerifyPasswordEncoderIsBCrypt() {
+        assertThat(passwordEncoder).isInstanceOf(BCryptPasswordEncoder.class);
+    }
+
+    @Test
+    void shouldVerifyPasswordEncodingAndMatching() {
+        // Given
+        String rawPassword = "testPassword";
+
+        // When
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        // Then
+        assertThat(encodedPassword).startsWith("$2a$");
+        assertThat(passwordEncoder.matches(rawPassword, encodedPassword)).isTrue();
+        assertThat(passwordEncoder.matches("wrongPassword", encodedPassword)).isFalse();
+    }
+
+    @Test
+    void shouldVerifyAuthenticationProviderIsDaoAuthenticationProvider() {
+        assertThat(authenticationProvider).isNotNull();
+        assertThat(authenticationProvider).isInstanceOf(DaoAuthenticationProvider.class);
+    }
+}


### PR DESCRIPTION
Use a database-backed user password authentication system instead of the current OAuth2 implementation #40

Modify the existing Spring Boot application to use a database-backed user password authentication system instead of the current OAuth2 implementation. Create the necessary database schema, entities, and repositories to store user credentials and roles. Create an init script to create an admin user with admin username and admin password. Create ADMIN and USER predefined roles. Implement a UserDetailsService to convert database entities to Spring Security UserDetails objects. Configure a DaoAuthenticationProvider with BCryptPasswordEncoder.

FAIL_TO_PASS: SecurityIntegrationTest