### PR TITLE
Configure Asynchronous Event Listeners with Custom Thread Pool for Feature Events #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,51 @@ $ ./mvnw spotless:apply
 # Once the dependent services (PostgreSQL, Keycloak, etc) are started, 
 # you can run/debug FeatureServiceApplication.java from your IDE.
 ```
+
+## Asynchronous Event Handling
+
+The feature-service uses asynchronous event processing for feature-related events. This improves system responsiveness and scalability by processing events in the background.
+
+### How It Works
+
+1. When a feature is created, updated, or deleted, an event is published
+2. Event listeners annotated with `@Async` process these events asynchronously
+3. A dedicated thread pool handles the asynchronous processing
+4. The ApplicationEventMulticaster routes events to the appropriate listeners
+
+### Configuration
+
+Thread pool settings can be configured in `application.properties`:
+
+```properties
+# Core number of threads in the thread pool
+ft.async.core-pool-size=2
+
+# Maximum number of threads in the thread pool
+ft.async.max-pool-size=5
+
+# Queue capacity for tasks before blocking
+ft.async.queue-capacity=100
+
+# Prefix for thread names in the pool
+ft.async.thread-name-prefix=feature-async-
+```
+
+### Tuning Guidelines
+
+- **Core Pool Size**: Set based on the average number of concurrent events you expect
+- **Max Pool Size**: Set higher than core pool size to handle bursts of activity
+- **Queue Capacity**: Determines how many tasks can wait when all threads are busy
+- **Thread Name Prefix**: Useful for identifying threads in logs and monitoring tools
+
+For high-throughput environments, consider increasing both pool sizes and queue capacity.
+
+### Observing Async Behavior
+
+You can observe the asynchronous processing through application logs. When a feature event is processed, the log will include the thread name:
+
+```
+INFO c.s.f.f.d.e.FeatureEventListener : Feature created event received - ID: 123, Name: Example Feature, Thread: feature-async-1
+```
+
+The thread name (e.g., `feature-async-1`) confirms that the event is being processed by the dedicated thread pool rather than the main application thread.

--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -3,7 +3,22 @@ package com.sivalabs.ft.features;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "ft")
-public record ApplicationProperties(EventsProperties events) {
+public record ApplicationProperties(EventsProperties events, AsyncProperties async) {
 
     public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
+    
+    public record AsyncProperties(
+            int corePoolSize, 
+            int maxPoolSize, 
+            int queueCapacity, 
+            String threadNamePrefix) {
+        
+        // Default values if not specified in properties
+        public AsyncProperties {
+            if (corePoolSize <= 0) corePoolSize = 2;
+            if (maxPoolSize <= 0) maxPoolSize = 5;
+            if (queueCapacity <= 0) queueCapacity = 100;
+            if (threadNamePrefix == null) threadNamePrefix = "feature-async-";
+        }
+    }
 }

--- a/src/main/java/com/sivalabs/ft/features/config/AsyncConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/AsyncConfig.java
@@ -1,0 +1,57 @@
+package com.sivalabs.ft.features.config;
+
+import com.sivalabs.ft.features.ApplicationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Configuration class for asynchronous event processing.
+ * This class defines a ThreadPoolTaskExecutor bean and configures
+ * the ApplicationEventMulticaster to use this executor for async event delivery.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    private final ApplicationProperties properties;
+
+    public AsyncConfig(ApplicationProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Creates a ThreadPoolTaskExecutor bean with configurable properties.
+     * This executor is used for processing @Async annotated methods.
+     *
+     * @return a configured ThreadPoolTaskExecutor
+     */
+    @Bean("taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(properties.async().corePoolSize());
+        executor.setMaxPoolSize(properties.async().maxPoolSize());
+        executor.setQueueCapacity(properties.async().queueCapacity());
+        executor.setThreadNamePrefix(properties.async().threadNamePrefix());
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Creates an ApplicationEventMulticaster bean that uses the taskExecutor
+     * for asynchronous event delivery.
+     *
+     * @return a configured SimpleApplicationEventMulticaster
+     */
+    @Bean
+    public ApplicationEventMulticaster applicationEventMulticaster() {
+        SimpleApplicationEventMulticaster eventMulticaster = new SimpleApplicationEventMulticaster();
+        eventMulticaster.setTaskExecutor(taskExecutor());
+        return eventMulticaster;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
@@ -4,11 +4,12 @@ import com.sivalabs.ft.features.domain.entities.Feature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 /**
  * Component that listens for Feature-related application events.
- * This listener handles events synchronously within the application.
+ * This listener handles events asynchronously using the configured thread pool.
  */
 @Component
 public class FeatureEventListener {
@@ -16,16 +17,17 @@ public class FeatureEventListener {
 
     /**
      * Handles FeatureCreatedApplicationEvent.
-     * This method is called synchronously when a new Feature is created.
+     * This method is called asynchronously when a new Feature is created.
      * It logs feature details and can perform additional business logic as needed.
      *
      * @param event the FeatureCreatedApplicationEvent containing the created Feature
      */
+    @Async("taskExecutor")
     @EventListener
     public void handleFeatureCreatedEvent(FeatureCreatedApplicationEvent event) {
         Feature feature = event.getFeature();
-        logger.info("Feature created event received - ID: {}, Name: {}", 
-                feature.getId(), feature.getTitle());
+        logger.info("Feature created event received - ID: {}, Name: {}, Thread: {}", 
+                feature.getId(), feature.getTitle(), Thread.currentThread().getName());
         
         // Additional business logic can be added here
         // For example:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,16 @@ ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
 
+####### Async Event Processing Configuration #########
+# Core number of threads in the thread pool
+ft.async.core-pool-size=2
+# Maximum number of threads in the thread pool
+ft.async.max-pool-size=5
+# Queue capacity for tasks before blocking
+ft.async.queue-capacity=100
+# Prefix for thread names in the pool
+ft.async.thread-name-prefix=feature-async-
+
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}
 spring.datasource.username=${DB_USERNAME:postgres}


### PR DESCRIPTION
Enhance the event handling system to support asynchronous execution using @async on event listeners for feature-related events. Configure a custom ThreadPoolTaskExecutor bean and set up ApplicationEventMulticaster to use this executor for async event delivery. Validate that feature event listeners run on dedicated threads by inspecting logs, and ensure system stability and scalability by tuning thread pool settings in application properties.