### PR TITLE
User Notification System: In-App Notifications (CRUD & API)

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationController.java
@@ -1,0 +1,124 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.api.utils.SecurityUtils;
+import com.sivalabs.ft.features.domain.NotificationService;
+import com.sivalabs.ft.features.domain.dtos.NotificationDto;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@Tag(name = "Notifications API")
+class NotificationController {
+    private static final Logger log = LoggerFactory.getLogger(NotificationController.class);
+
+    private final NotificationService notificationService;
+
+    NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping("")
+    @Operation(
+            summary = "Get user notifications",
+            description = "Get all notifications for the current user",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = NotificationDto.class)))),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    ResponseEntity<Page<NotificationDto>> getNotifications(Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        if (username == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Page<NotificationDto> notifications = notificationService.getNotificationsForUser(username, pageable);
+        return ResponseEntity.ok(notifications);
+    }
+
+    @PutMapping("/{id}/read")
+    @Operation(
+            summary = "Mark notification as read",
+            description = "Mark a specific notification as read for the current user",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = NotificationDto.class))),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "404", description = "Notification not found or access denied")
+            })
+    ResponseEntity<NotificationDto> markAsRead(@PathVariable UUID id) {
+        String username = SecurityUtils.getCurrentUsername();
+        if (username == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            NotificationDto notification = notificationService.markAsRead(id, username);
+            log.info("User {} marked notification {} as read", username, id);
+            return ResponseEntity.ok(notification);
+        } catch (ResourceNotFoundException e) {
+            log.warn("Failed to mark notification {} as read for user {}: {}", id, username, e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PutMapping("/{id}/unread")
+    @Operation(
+            summary = "Mark notification as unread",
+            description = "Mark a specific notification as unread for the current user",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = NotificationDto.class))),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "404", description = "Notification not found or access denied")
+            })
+    ResponseEntity<NotificationDto> markAsUnread(@PathVariable UUID id) {
+        String username = SecurityUtils.getCurrentUsername();
+        if (username == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            NotificationDto notification = notificationService.markAsUnread(id, username);
+            log.info("User {} marked notification {} as unread", username, id);
+            return ResponseEntity.ok(notification);
+        } catch (ResourceNotFoundException e) {
+            log.warn("Failed to mark notification {} as unread for user {}: {}", id, username, e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -1,5 +1,7 @@
 package com.sivalabs.ft.features.domain;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sivalabs.ft.features.domain.Commands.CreateFeatureCommand;
 import com.sivalabs.ft.features.domain.Commands.DeleteFeatureCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateFeatureCommand;
@@ -10,17 +12,22 @@ import com.sivalabs.ft.features.domain.entities.Release;
 import com.sivalabs.ft.features.domain.events.EventPublisher;
 import com.sivalabs.ft.features.domain.mappers.FeatureMapper;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class FeatureService {
+    private static final Logger logger = LoggerFactory.getLogger(FeatureService.class);
     public static final String FEATURE_SEPARATOR = "-";
     private final FavoriteFeatureService favoriteFeatureService;
     private final ReleaseRepository releaseRepository;
@@ -29,6 +36,9 @@ public class FeatureService {
     private final FavoriteFeatureRepository favoriteFeatureRepository;
     private final EventPublisher eventPublisher;
     private final FeatureMapper featureMapper;
+    private final NotificationService notificationService;
+    private final NotificationRecipientService recipientService;
+    private final ObjectMapper objectMapper;
 
     FeatureService(
             FavoriteFeatureService favoriteFeatureService,
@@ -37,7 +47,10 @@ public class FeatureService {
             ProductRepository productRepository,
             FavoriteFeatureRepository favoriteFeatureRepository,
             EventPublisher eventPublisher,
-            FeatureMapper featureMapper) {
+            FeatureMapper featureMapper,
+            NotificationService notificationService,
+            NotificationRecipientService recipientService,
+            ObjectMapper objectMapper) {
         this.favoriteFeatureService = favoriteFeatureService;
         this.releaseRepository = releaseRepository;
         this.featureRepository = featureRepository;
@@ -45,6 +58,9 @@ public class FeatureService {
         this.eventPublisher = eventPublisher;
         this.favoriteFeatureRepository = favoriteFeatureRepository;
         this.featureMapper = featureMapper;
+        this.notificationService = notificationService;
+        this.recipientService = recipientService;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional(readOnly = true)
@@ -106,6 +122,12 @@ public class FeatureService {
         feature.setCreatedAt(Instant.now());
         featureRepository.save(feature);
         eventPublisher.publishFeatureCreatedEvent(feature);
+
+        // Create notifications synchronously
+        // Pass createdBy as excludeUser to filter out self-notifications
+        // (e.g., when user creates feature and assigns it to themselves)
+        createNotificationsForFeature(feature, NotificationEventType.FEATURE_CREATED, "created", cmd.createdBy());
+
         return code;
     }
 
@@ -126,13 +148,55 @@ public class FeatureService {
         feature.setUpdatedAt(Instant.now());
         featureRepository.save(feature);
         eventPublisher.publishFeatureUpdatedEvent(feature);
+
+        // Create notifications synchronously
+        // Pass updatedBy as excludeUser to filter out self-notifications
+        // (e.g., when user updates feature they're assigned to)
+        createNotificationsForFeature(feature, NotificationEventType.FEATURE_UPDATED, "updated", cmd.updatedBy());
     }
 
     @Transactional
     public void deleteFeature(DeleteFeatureCommand cmd) {
         Feature feature = featureRepository.findByCode(cmd.code()).orElseThrow();
+
+        // Create notifications before deletion
+        // Pass deletedBy as excludeUser to filter out self-notifications
+        // (e.g., when user deletes feature they're assigned to or created)
+        createNotificationsForFeature(feature, NotificationEventType.FEATURE_DELETED, "deleted", cmd.deletedBy());
+
         favoriteFeatureRepository.deleteByFeatureCode(cmd.code());
         featureRepository.deleteByCode(cmd.code());
         eventPublisher.publishFeatureDeletedEvent(feature, cmd.deletedBy(), Instant.now());
+    }
+
+    private void createNotificationsForFeature(
+            Feature feature, NotificationEventType eventType, String action, String excludeUser) {
+        FeatureDto featureDto = featureMapper.toDto(feature);
+        Set<String> recipients = recipientService.getFeatureNotificationRecipients(featureDto, excludeUser);
+
+        if (recipients.isEmpty()) {
+            return;
+        }
+
+        // Prepare event details once (same for all recipients)
+        Map<String, Object> eventDetails = new HashMap<>();
+        eventDetails.put("action", action);
+        eventDetails.put("featureCode", feature.getCode());
+        eventDetails.put("title", feature.getTitle());
+        if (feature.getStatus() != null) {
+            eventDetails.put("status", feature.getStatus().name());
+        }
+
+        try {
+            String eventDetailsJson = objectMapper.writeValueAsString(eventDetails);
+            String link = "/features/" + feature.getCode();
+
+            for (String recipientUserId : recipients) {
+                notificationService.createNotification(recipientUserId, eventType, eventDetailsJson, link);
+                logger.debug("Created notification for user {} about feature {}", recipientUserId, feature.getCode());
+            }
+        } catch (JsonProcessingException e) {
+            logger.error("Failed to serialize event details for feature {}", feature.getCode(), e);
+        }
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationRecipientService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationRecipientService.java
@@ -1,0 +1,38 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.FeatureDto;
+import java.util.HashSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service to determine notification recipients based on business rules
+ * Returns all potential recipients (createdBy + assignedTo), filtering via excludeUser parameter
+ */
+@Service
+public class NotificationRecipientService {
+    private static final Logger log = LoggerFactory.getLogger(NotificationRecipientService.class);
+    /**
+     * Get notification recipients for feature events from DTO
+     * Returns createdBy and assignedTo users
+     * Use excludeUser parameter to filter out the user who triggered the action
+     */
+    public Set<String> getFeatureNotificationRecipients(FeatureDto featureDto, String excludeUser) {
+        Set<String> recipients = new HashSet<>();
+
+        // Add creator if not excluded
+        if (featureDto.createdBy() != null && !featureDto.createdBy().equals(excludeUser)) {
+            recipients.add(featureDto.createdBy());
+        }
+
+        // Add assignee if not excluded
+        if (featureDto.assignedTo() != null && !featureDto.assignedTo().equals(excludeUser)) {
+            recipients.add(featureDto.assignedTo());
+        }
+
+        log.debug("Feature {} notification recipients (excluding {}): {}", featureDto.code(), excludeUser, recipients);
+        return recipients;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
@@ -1,0 +1,35 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Notification;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
+
+interface NotificationRepository extends ListCrudRepository<Notification, UUID> {
+
+    /**
+     * Find all notifications for a specific user with pagination, ordered by creation date (newest first)
+     */
+    @Query("SELECT n FROM Notification n WHERE n.recipientUserId = :recipientUserId ORDER BY n.createdAt DESC")
+    Page<Notification> findByRecipientUserIdOrderByCreatedAtDesc(String recipientUserId, Pageable pageable);
+
+    /**
+     * Mark notification as read
+     */
+    @Modifying
+    @Query(
+            "UPDATE Notification n SET n.read = true, n.readAt = :readAt WHERE n.id = :id AND n.recipientUserId = :recipientUserId")
+    int markAsRead(UUID id, String recipientUserId, Instant readAt);
+
+    /**
+     * Mark notification as unread
+     */
+    @Modifying
+    @Query(
+            "UPDATE Notification n SET n.read = false, n.readAt = null WHERE n.id = :id AND n.recipientUserId = :recipientUserId")
+    int markAsUnread(UUID id, String recipientUserId);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
@@ -1,0 +1,107 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.NotificationDto;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import com.sivalabs.ft.features.domain.mappers.NotificationMapper;
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
+import java.time.Instant;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class NotificationService {
+    private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
+
+    public NotificationService(NotificationRepository notificationRepository, NotificationMapper notificationMapper) {
+        this.notificationRepository = notificationRepository;
+        this.notificationMapper = notificationMapper;
+    }
+
+    /**
+     * Create a new notification
+     */
+    @Transactional
+    public NotificationDto createNotification(
+            String recipientUserId, NotificationEventType eventType, String eventDetails, String link) {
+
+        var notification = new Notification();
+        notification.setRecipientUserId(recipientUserId);
+        notification.setEventType(eventType);
+        notification.setEventDetails(eventDetails);
+        notification.setLink(link);
+        notification.setCreatedAt(Instant.now());
+        notification.setRead(false);
+        notification.setDeliveryStatus(DeliveryStatus.PENDING);
+
+        notification = notificationRepository.save(notification);
+
+        log.info("Created notification {} for user {}", notification.getId(), recipientUserId);
+
+        return notificationMapper.toDto(notification);
+    }
+
+    /**
+     * Get notifications for a user with pagination
+     */
+    @Transactional(readOnly = true)
+    public Page<NotificationDto> getNotificationsForUser(String recipientUserId, Pageable pageable) {
+        Page<Notification> notifications =
+                notificationRepository.findByRecipientUserIdOrderByCreatedAtDesc(recipientUserId, pageable);
+        return notifications.map(notificationMapper::toDto);
+    }
+
+    /**
+     * Mark notification as read
+     * Only the recipient can mark their own notifications as read
+     */
+    @Transactional
+    public NotificationDto markAsRead(UUID notificationId, String recipientUserId) {
+        Instant readAt = Instant.now();
+        int updated = notificationRepository.markAsRead(notificationId, recipientUserId, readAt);
+
+        if (updated == 0) {
+            throw new ResourceNotFoundException("Notification not found or access denied");
+        }
+
+        // Fetch updated notification
+        Notification notification = notificationRepository
+                .findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        log.info("Marked notification {} as read for user {}", notificationId, recipientUserId);
+
+        return notificationMapper.toDto(notification);
+    }
+
+    /**
+     * Mark notification as unread
+     * Only the recipient can mark their own notifications as unread
+     */
+    @Transactional
+    public NotificationDto markAsUnread(UUID notificationId, String recipientUserId) {
+        int updated = notificationRepository.markAsUnread(notificationId, recipientUserId);
+
+        if (updated == 0) {
+            throw new ResourceNotFoundException("Notification not found or access denied");
+        }
+
+        // Fetch updated notification
+        Notification notification = notificationRepository
+                .findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        log.info("Marked notification {} as unread for user {}", notificationId, recipientUserId);
+
+        return notificationMapper.toDto(notification);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/NotificationDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/NotificationDto.java
@@ -1,0 +1,43 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+        UUID id,
+        String recipientUserId,
+        NotificationEventType eventType,
+        String eventDetails,
+        String link,
+        Instant createdAt,
+        boolean read,
+        Instant readAt,
+        DeliveryStatus deliveryStatus)
+        implements Serializable {
+
+    /**
+     * Create a copy with read status updated
+     */
+    public NotificationDto markAsRead(Instant readAt) {
+        return new NotificationDto(
+                id, recipientUserId, eventType, eventDetails, link, createdAt, true, readAt, deliveryStatus);
+    }
+
+    /**
+     * Create a copy with unread status
+     */
+    public NotificationDto markAsUnread() {
+        return new NotificationDto(
+                id, recipientUserId, eventType, eventDetails, link, createdAt, false, null, deliveryStatus);
+    }
+
+    /**
+     * Create a copy with updated delivery status
+     */
+    public NotificationDto withDeliveryStatus(DeliveryStatus status) {
+        return new NotificationDto(id, recipientUserId, eventType, eventDetails, link, createdAt, read, readAt, status);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Notification.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Notification.java
@@ -1,0 +1,143 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Size(max = 255) @NotNull @Column(name = "recipient_user_id", nullable = false)
+    private String recipientUserId;
+
+    @NotNull @Column(name = "event_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private NotificationEventType eventType;
+
+    @Column(name = "event_details", length = Integer.MAX_VALUE)
+    private String eventDetails;
+
+    @Size(max = 500) @Column(name = "link", length = 500)
+    private String link;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @NotNull @ColumnDefault("false")
+    @Column(name = "read", nullable = false)
+    private Boolean read;
+
+    @Column(name = "read_at")
+    private Instant readAt;
+
+    @NotNull @Column(name = "delivery_status", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'PENDING'")
+    private DeliveryStatus deliveryStatus;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getRecipientUserId() {
+        return recipientUserId;
+    }
+
+    public void setRecipientUserId(String recipientUserId) {
+        this.recipientUserId = recipientUserId;
+    }
+
+    public NotificationEventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(NotificationEventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getEventDetails() {
+        return eventDetails;
+    }
+
+    public void setEventDetails(String eventDetails) {
+        this.eventDetails = eventDetails;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Boolean getRead() {
+        return read;
+    }
+
+    public void setRead(Boolean read) {
+        this.read = read;
+    }
+
+    public Instant getReadAt() {
+        return readAt;
+    }
+
+    public void setReadAt(Instant readAt) {
+        this.readAt = readAt;
+    }
+
+    public DeliveryStatus getDeliveryStatus() {
+        return deliveryStatus;
+    }
+
+    public void setDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+    }
+
+    /**
+     * Mark notification as read and set readAt timestamp
+     */
+    public void markAsRead() {
+        this.read = true;
+        this.readAt = Instant.now();
+    }
+
+    /**
+     * Mark notification as unread and clear readAt timestamp
+     */
+    public void markAsUnread() {
+        this.read = false;
+        this.readAt = null;
+    }
+
+    /**
+     * Update delivery status
+     */
+    public void updateDeliveryStatus(DeliveryStatus status) {
+        this.deliveryStatus = status;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/NotificationMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/NotificationMapper.java
@@ -1,0 +1,12 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.NotificationDto;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+    NotificationDto toDto(Notification notification);
+
+    Notification toEntity(NotificationDto notificationDto);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/DeliveryStatus.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/DeliveryStatus.java
@@ -1,0 +1,22 @@
+package com.sivalabs.ft.features.domain.models;
+
+/**
+ * Delivery status for notifications
+ * Tracks the delivery state of email notifications
+ */
+public enum DeliveryStatus {
+    /**
+     * Notification is pending delivery
+     */
+    PENDING,
+
+    /**
+     * Notification was successfully delivered
+     */
+    DELIVERED,
+
+    /**
+     * Notification delivery failed
+     */
+    FAILED
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/NotificationEventType.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/NotificationEventType.java
@@ -1,0 +1,14 @@
+package com.sivalabs.ft.features.domain.models;
+
+/**
+ * Event types for notifications
+ * Defines what kind of events trigger notifications
+ */
+public enum NotificationEventType {
+    FEATURE_CREATED,
+    FEATURE_UPDATED,
+    FEATURE_DELETED,
+    RELEASE_CREATED,
+    RELEASE_UPDATED,
+    RELEASE_DELETED
+}

--- a/src/main/resources/db/migration/V8__create_notifications_table.sql
+++ b/src/main/resources/db/migration/V8__create_notifications_table.sql
@@ -1,0 +1,35 @@
+-- Create notifications table for user notification system
+-- Supports both in-app and email notifications with delivery tracking
+
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    recipient_user_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(50) NOT NULL CHECK (event_type IN ('FEATURE_CREATED', 'FEATURE_UPDATED', 'FEATURE_DELETED', 'RELEASE_CREATED', 'RELEASE_UPDATED', 'RELEASE_DELETED')),
+    event_details TEXT,
+    link VARCHAR(500),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    read BOOLEAN NOT NULL DEFAULT FALSE,
+    read_at TIMESTAMP,
+    delivery_status VARCHAR(50) NOT NULL DEFAULT 'PENDING' CHECK (delivery_status IN ('PENDING', 'DELIVERED', 'FAILED'))
+);
+
+-- Create indexes for efficient queries
+CREATE INDEX idx_notifications_recipient_user_id ON notifications(recipient_user_id);
+CREATE INDEX idx_notifications_created_at ON notifications(created_at);
+CREATE INDEX idx_notifications_read ON notifications(read);
+CREATE INDEX idx_notifications_delivery_status ON notifications(delivery_status);
+
+-- Create composite index for user's unread notifications (most common query)
+CREATE INDEX idx_notifications_recipient_unread ON notifications(recipient_user_id, read, created_at DESC);
+
+-- Add comments for documentation
+COMMENT ON TABLE notifications IS 'Stores user notifications for features and releases with delivery tracking';
+COMMENT ON COLUMN notifications.id IS 'Unique notification identifier (UUID)';
+COMMENT ON COLUMN notifications.recipient_user_id IS 'User ID who should receive this notification';
+COMMENT ON COLUMN notifications.event_type IS 'Type of event that triggered the notification';
+COMMENT ON COLUMN notifications.event_details IS 'JSON or text payload with structured event details';
+COMMENT ON COLUMN notifications.link IS 'URL link to the relevant feature/release';
+COMMENT ON COLUMN notifications.created_at IS 'When the notification was created';
+COMMENT ON COLUMN notifications.read IS 'Whether the notification has been read by the user';
+COMMENT ON COLUMN notifications.read_at IS 'When the notification was marked as read';
+COMMENT ON COLUMN notifications.delivery_status IS 'Email delivery status: PENDING, DELIVERED, or FAILED';

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationIntegrationTest.java
@@ -1,0 +1,520 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.MockOAuth2UserContextFactory;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Integration tests for notification system
+ * Tests that notifications are created synchronously when features are created/updated/deleted
+ */
+@Sql("/test-data.sql")
+class NotificationIntegrationTest extends AbstractIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final MockOAuth2UserContextFactory contextFactory = new MockOAuth2UserContextFactory();
+
+    @BeforeEach
+    void setUp() {
+        // Clean up tables before each test
+        jdbcTemplate.execute("DELETE FROM notifications");
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clean up tables after each test
+        jdbcTemplate.execute("DELETE FROM notifications");
+    }
+
+    private void setAuthenticationContext(String username) {
+        WithMockOAuth2User mockUser = new WithMockOAuth2User() {
+            @Override
+            public Class<WithMockOAuth2User> annotationType() {
+                return WithMockOAuth2User.class;
+            }
+
+            @Override
+            public String value() {
+                return username;
+            }
+
+            @Override
+            public String username() {
+                return username;
+            }
+
+            @Override
+            public long id() {
+                return username.hashCode();
+            }
+
+            @Override
+            public String[] roles() {
+                return new String[] {"USER"};
+            }
+        };
+        SecurityContextHolder.setContext(contextFactory.createSecurityContext(mockUser));
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "testuser")
+    void shouldCreateNotificationWhenFeatureIsCreated() throws Exception {
+        // Given - Create feature as testuser with assignedTo different from creator
+        CreateFeaturePayload payload = new CreateFeaturePayload(
+                "intellij", "Feature for Notification", "Test notification creation", null, "assignee");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Verify testuser (creator) does NOT receive notification (no self-notifications)
+        var apiResponse = mvc.get().uri("/api/notifications").exchange();
+        assertThat(apiResponse).hasStatus2xxSuccessful();
+
+        String responseBody = apiResponse.getResponse().getContentAsString();
+        Map<String, Object> pageResponse = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        List<Map<String, Object>> notifications = (List<Map<String, Object>>) pageResponse.get("content");
+
+        assertThat(notifications)
+                .as("Creator should NOT receive self-notification")
+                .isEmpty();
+
+        // Verify only assignee receives notification via database
+        Integer assigneeCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "assignee");
+        assertThat(assigneeCount).isEqualTo(1);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "testuser")
+    void shouldCreateMultipleNotificationsForDifferentFeatures() throws Exception {
+        // Given - Create two different features
+        CreateFeaturePayload payload1 =
+                new CreateFeaturePayload("intellij", "Feature 1", "First feature", null, "assignee");
+        CreateFeaturePayload payload2 =
+                new CreateFeaturePayload("intellij", "Feature 2", "Second feature", null, "assignee");
+
+        // When - Create two features
+        var result1 = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload1))
+                .exchange();
+
+        var result2 = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload2))
+                .exchange();
+
+        assertThat(result1).hasStatus(HttpStatus.CREATED);
+        assertThat(result2).hasStatus(HttpStatus.CREATED);
+
+        // Verify creator (testuser) does NOT receive notifications (no self-notifications)
+        var apiResponse = mvc.get().uri("/api/notifications").exchange();
+        assertThat(apiResponse).hasStatus2xxSuccessful();
+
+        String responseBody = apiResponse.getResponse().getContentAsString();
+        Map<String, Object> pageResponse = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        List<Map<String, Object>> notifications = (List<Map<String, Object>>) pageResponse.get("content");
+
+        assertThat(notifications)
+                .as("Creator should NOT receive self-notifications")
+                .isEmpty();
+
+        // Verify only assignee received 2 notifications via database
+        Integer assigneeCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "assignee");
+        assertThat(assigneeCount).isEqualTo(2);
+    }
+
+    @Test
+    void shouldMarkNotificationAsRead() throws Exception {
+        // Given - Create a feature as creator, assigned to assignee
+        setAuthenticationContext("creator");
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Read Test Feature", "Test read functionality", null, "assignee");
+
+        mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Get notification ID for assignee via database
+        UUID notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1",
+                UUID.class,
+                "assignee");
+
+        // When - Mark as read via API (as assignee, using .with(jwt()) for MockMvc authentication)
+        var readResult = mvc.put()
+                .uri("/api/notifications/{id}/read", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+
+        assertThat(readResult).hasStatus2xxSuccessful();
+
+        // Then - Verify notification is marked as read via API (as assignee)
+        var updatedResponse = mvc.get()
+                .uri("/api/notifications")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+        assertThat(updatedResponse).hasStatus2xxSuccessful();
+
+        String updatedBody = updatedResponse.getResponse().getContentAsString();
+        Map<String, Object> updatedPage = objectMapper.readValue(updatedBody, new TypeReference<>() {});
+        List<Map<String, Object>> updatedNotifications = (List<Map<String, Object>>) updatedPage.get("content");
+
+        assertThat(updatedNotifications).hasSize(1);
+        assertThat(updatedNotifications.get(0).get("read")).isEqualTo(true);
+        assertThat(updatedNotifications.get(0).get("readAt")).isNotNull();
+    }
+
+    @Test
+    void shouldMarkNotificationAsUnread() throws Exception {
+        // Given - Create a feature as creator, assigned to assignee
+        setAuthenticationContext("creator");
+        CreateFeaturePayload payload = new CreateFeaturePayload(
+                "intellij", "Unread Test Feature", "Test unread functionality", null, "assignee");
+
+        mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Get notification ID for assignee via database
+        UUID notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1",
+                UUID.class,
+                "assignee");
+
+        // Mark as read first via API (as assignee, using .with(jwt()) for MockMvc authentication)
+        var readResult = mvc.put()
+                .uri("/api/notifications/{id}/read", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+        assertThat(readResult).hasStatus2xxSuccessful();
+
+        // Verify it's marked as read via API (as assignee)
+        var readResponse = mvc.get()
+                .uri("/api/notifications")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+        String readBody = readResponse.getResponse().getContentAsString();
+        Map<String, Object> readPage = objectMapper.readValue(readBody, new TypeReference<>() {});
+        List<Map<String, Object>> readNotifications = (List<Map<String, Object>>) readPage.get("content");
+
+        assertThat(readNotifications.get(0).get("read")).isEqualTo(true);
+        assertThat(readNotifications.get(0).get("readAt")).isNotNull();
+
+        // When - Mark as unread via API (as assignee)
+        var unreadResult = mvc.put()
+                .uri("/api/notifications/{id}/unread", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+
+        assertThat(unreadResult).hasStatus2xxSuccessful();
+
+        // Then - Verify notification is marked as unread via API (as assignee)
+        var unreadResponse = mvc.get()
+                .uri("/api/notifications")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+        String unreadBody = unreadResponse.getResponse().getContentAsString();
+        Map<String, Object> unreadPage = objectMapper.readValue(unreadBody, new TypeReference<>() {});
+        List<Map<String, Object>> unreadNotifications = (List<Map<String, Object>>) unreadPage.get("content");
+
+        assertThat(unreadNotifications).hasSize(1);
+        assertThat(unreadNotifications.get(0).get("read")).isEqualTo(false);
+        assertThat(unreadNotifications.get(0).get("readAt")).isNull();
+
+        // Verify in database directly
+        Integer unreadCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE id = ? AND read = false AND read_at IS NULL",
+                Integer.class,
+                notificationId);
+        assertThat(unreadCount).isEqualTo(1);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "testuser")
+    void shouldGetNotificationsViaApiWithPagination() throws Exception {
+        // Given - Create multiple features as testuser with assignedTo different from creator
+        for (int i = 0; i < 5; i++) {
+            CreateFeaturePayload payload =
+                    new CreateFeaturePayload("intellij", "Feature " + i, "Description " + i, null, "assignee");
+
+            mvc.post()
+                    .uri("/api/features")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .exchange();
+        }
+
+        // Verify testuser (creator) does NOT receive notifications
+        var creatorResponse = mvc.get().uri("/api/notifications").exchange();
+        String creatorBody = creatorResponse.getResponse().getContentAsString();
+        Map<String, Object> creatorPage = objectMapper.readValue(creatorBody, new TypeReference<>() {});
+        List<Map<String, Object>> creatorNotifications = (List<Map<String, Object>>) creatorPage.get("content");
+        assertThat(creatorNotifications).isEmpty();
+
+        // Verify assignee received 5 notifications via database
+        Integer assigneeCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "assignee");
+        assertThat(assigneeCount).isEqualTo(5);
+
+        // Verify pagination via database (can't test API with setAuthenticationContext)
+        Integer totalCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "assignee");
+        assertThat(totalCount).isEqualTo(5);
+
+        // Verify first 3 notifications exist
+        List<Map<String, Object>> firstPage = jdbcTemplate.queryForList(
+                "SELECT * FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 3", "assignee");
+        assertThat(firstPage).hasSize(3);
+    }
+
+    @Test
+    void shouldOnlyShowNotificationsToRecipient() throws Exception {
+        // Create feature as user1 with no assignedTo (no one gets notification - self-notification filtered)
+        setAuthenticationContext("user1");
+        CreateFeaturePayload payload1 =
+                new CreateFeaturePayload("intellij", "User1 Feature", "Feature created by user1", null, null);
+        mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload1))
+                .exchange();
+
+        // Create feature as user1 assigned to user2 (only user2 gets notification)
+        CreateFeaturePayload payload2 =
+                new CreateFeaturePayload("intellij", "User2 Feature", "Feature assigned to user2", null, "user2");
+        mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload2))
+                .exchange();
+
+        // Verify user1 (creator) does NOT receive notifications
+        var user1Response = mvc.get().uri("/api/notifications").exchange();
+        assertThat(user1Response).hasStatusOk();
+
+        String user1Body = user1Response.getResponse().getContentAsString();
+        Map<String, Object> user1Page = objectMapper.readValue(user1Body, new TypeReference<>() {});
+        List<Map<String, Object>> user1Notifications = (List<Map<String, Object>>) user1Page.get("content");
+
+        assertThat(user1Notifications).isEmpty(); // Creator does NOT receive self-notifications
+
+        // Verify user2 (assignee) received 1 notification via database
+        Integer user2Count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "user2");
+        assertThat(user2Count).isEqualTo(1);
+
+        // Verify user2's notification details via database
+        Map<String, Object> user2Notification = jdbcTemplate.queryForMap(
+                "SELECT * FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1", "user2");
+        assertThat(user2Notification.get("recipient_user_id")).isEqualTo("user2");
+        assertThat(user2Notification.get("event_type")).isEqualTo("FEATURE_CREATED");
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "testuser")
+    void shouldNotCreateSelfNotificationWhenCreatingFeatureWithoutAssignee() throws Exception {
+        // Given - Create feature without assignedTo
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Self Feature", "Feature without assignee", null, null);
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Then - Verify creator does NOT receive notification via API
+        var apiResponse = mvc.get().uri("/api/notifications").exchange();
+        assertThat(apiResponse).hasStatus2xxSuccessful();
+
+        String responseBody = apiResponse.getResponse().getContentAsString();
+        Map<String, Object> pageResponse = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        List<Map<String, Object>> notifications = (List<Map<String, Object>>) pageResponse.get("content");
+
+        assertThat(notifications)
+                .as("Creator should NOT receive self-notification")
+                .isEmpty();
+
+        // Verify no notifications created at all
+        Integer totalCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
+        assertThat(totalCount).isEqualTo(0);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "testuser")
+    void shouldNotCreateSelfNotificationWhenDeletingOwnFeature() throws Exception {
+        // Given - Create feature assigned to testuser
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Feature to Delete", "Will be deleted", null, "testuser");
+
+        var createResult = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(createResult).hasStatus(HttpStatus.CREATED);
+        String location = createResult.getMvcResult().getResponse().getHeader("Location");
+        String featureCode = location.substring(location.lastIndexOf("/") + 1);
+
+        // Clear notifications from creation
+        jdbcTemplate.execute("DELETE FROM notifications");
+
+        // When - Delete feature as testuser (who is also assignee)
+        var deleteResult = mvc.delete().uri("/api/features/{code}", featureCode).exchange();
+
+        assertThat(deleteResult).hasStatus2xxSuccessful();
+
+        // Then - Verify testuser does NOT receive deletion notification via API
+        var apiResponse = mvc.get().uri("/api/notifications").exchange();
+        assertThat(apiResponse).hasStatus2xxSuccessful();
+
+        String responseBody = apiResponse.getResponse().getContentAsString();
+        Map<String, Object> pageResponse = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        List<Map<String, Object>> notifications = (List<Map<String, Object>>) pageResponse.get("content");
+
+        assertThat(notifications)
+                .as("Deleter should NOT receive self-notification when deleting own feature")
+                .isEmpty();
+
+        // Verify no notifications created
+        Integer totalCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
+        assertThat(totalCount).isEqualTo(0);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "testuser")
+    void shouldNotCreateSelfNotificationWhenCreatingFeatureWithSelfAssignee() throws Exception {
+        // Given - Create feature assigned to self (testuser creates and assigns to testuser)
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Self Feature", "Feature with self-assignee", null, "testuser");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Then - Verify testuser does NOT receive notification via API (self-notification filtered)
+        var apiResponse = mvc.get().uri("/api/notifications").exchange();
+        assertThat(apiResponse).hasStatus2xxSuccessful();
+
+        String responseBody = apiResponse.getResponse().getContentAsString();
+        Map<String, Object> pageResponse = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        List<Map<String, Object>> notifications = (List<Map<String, Object>>) pageResponse.get("content");
+
+        assertThat(notifications)
+                .as("Creator should NOT receive self-notification when assigning to self")
+                .isEmpty();
+
+        // Verify no notifications created at all
+        Integer totalCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
+        assertThat(totalCount).isEqualTo(0);
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenNotAuthenticated() throws Exception {
+        // When - Try to access notifications without authentication
+        var response = mvc.get().uri("/api/notifications").exchange();
+
+        // Then - Should return 401 Unauthorized
+        assertThat(response).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "testuser")
+    void shouldReturnNotFoundForNonExistentNotification() throws Exception {
+        // Given - Random UUID that doesn't exist
+        UUID nonExistentId = UUID.randomUUID();
+
+        // When - Try to mark non-existent notification as read
+        var readResponse =
+                mvc.put().uri("/api/notifications/{id}/read", nonExistentId).exchange();
+
+        // Then - Should return 404 Not Found
+        assertThat(readResponse).hasStatus4xxClientError();
+
+        // When - Try to mark non-existent notification as unread
+        var unreadResponse =
+                mvc.put().uri("/api/notifications/{id}/unread", nonExistentId).exchange();
+
+        // Then - Should return 404 Not Found
+        assertThat(unreadResponse).hasStatus4xxClientError();
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenTryingToAccessOtherUsersNotification() throws Exception {
+        // Given - Create notification for otheruser via API (creator creates, otheruser is assignee)
+
+        setAuthenticationContext("creator");
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Other User Feature", "Feature for otheruser", null, "otheruser");
+        mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Get the notification ID for otheruser via database (created synchronously)
+        UUID notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1",
+                UUID.class,
+                "otheruser");
+
+        // When - Try to mark other user's notification as read (authenticated as testuser)
+        setAuthenticationContext("testuser");
+        var readResponse =
+                mvc.put().uri("/api/notifications/{id}/read", notificationId).exchange();
+
+        // Then - Should return 4xx (not found/access denied)
+        assertThat(readResponse).hasStatus4xxClientError();
+
+        // Verify database state unchanged - notification should still be unread
+        Boolean isRead = jdbcTemplate.queryForObject(
+                "SELECT read FROM notifications WHERE id = ?", Boolean.class, notificationId);
+        assertThat(isRead).isFalse();
+    }
+}


### PR DESCRIPTION
Ref to #122 

**Parent:** Implement User Notification System

**Objective**
Implement a notification system part for feature related only events with entity persistence and API endpoints to manage in-app user notifications
**Requirements**

* **Notification Data Structure**: create notifications table with :
  - `id` (UUID) - unique notification identifier
  - `recipientUserId` (String) - user who receives the notification
  - `eventType` (enum) - type of event (FEATURE_CREATED, FEATURE_UPDATED, FEATURE_DELETED, RELEASE_CREATED, RELEASE_UPDATED, RELEASE_DELETED)
  - `eventDetails` (String) - human-readable description of the event
  - `link` (String) - URL link to the related resource
  - `createdAt` (Instant) - when notification was created
  - `read` (boolean) - whether notification has been read
  - `readAt` (Instant) - when notification was marked as read
  - `deliveryStatus` (enum) - delivery status (PENDING, DELIVERED, FAILED)

* **API Endpoints**:
  - `GET /api/notifications` → list user notifications with pagination support
  - `PUT /api/notifications/{id}/read` → mark notification as read
  - `PUT /api/notifications/{id}/unread` → mark notification as unread

* **CRUD Logic**: Services to handle creation, retrieval, and status changes

* **Access Control**: Enforce recipient-only access to their notifications. Restrict access to authenticated users.

**Test Coverage**

* Integration tests for CRUD logic with database state verification.
* Security boundary testing for unauthorized access attempts.

**Acceptance Criteria**

* Users can retrieve and update the status of their notifications via the API.
* Notifications must be visible only to their recipients.
* Protect all notification APIs with authentication-based access control.
* Support pagination for notification listing.
* Filter out the user who triggered the action to avoid self-notifications
* Proper error handling with appropriate HTTP status codes.

FAIL_TO_PASS: com.sivalabs.ft.features.api.controllers.NotificationIntegrationTest

