### PR TITLE
chore: update spotless-plugin to 3.0.0 and palantir-java-format to 2.74.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The feature-service microservice manages products, releases and features.
 * Maven, JUnit 5, Testcontainers
 
 ## Prerequisites
-* JDK 21 or later
+* JDK 24 or later
 * Docker ([installation instructions](https://docs.docker.com/engine/install/))
 * [IntelliJ IDEA](https://www.jetbrains.com/idea/)
 * PostgreSQL and Keycloak 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <springdoc.version>2.8.9</springdoc.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
-        <spotless-maven-plugin.version>2.45.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
+        <palantir-java-format.version>2.74.0</palantir-java-format.version>
         <dockerImageName>sivaprasadreddy/ft-feature-service</dockerImageName>
     </properties>
     <dependencies>
@@ -216,7 +217,7 @@
                         <importOrder />
                         <removeUnusedImports />
                         <palantirJavaFormat>
-                            <version>2.50.0</version>
+                            <version>${palantir-java-format.version}</version>
                         </palantirJavaFormat>
                         <formatAnnotations />
                     </java>


### PR DESCRIPTION
Current configuration yields `NoSuchMethodError` upon compilation when using java 25, which is now fixed in `palantir-java-format:2.71.0`: https://github.com/palantir/palantir-java-format/pull/1305

That only change would be sufficient, but I updated the palantir version to `2.74.0` and also the spotless plugin to `3.0.0` to comply with this change in the original repo: https://github.com/feature-tracker/feature-service/commit/1e2fca6a7d7d74278b3222ffe729754b517c6613

Also fixes readme that still mentioned java 21 as prerequisite, when in fact it is now java 24.