### PR TITLE
Implement Efficient Bulk and Batch Processing of Feature Events

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -16,12 +16,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class FeatureService {
     public static final String FEATURE_SEPARATOR = "-";
+    private static final Logger log = LoggerFactory.getLogger(FeatureService.class);
     private final FavoriteFeatureService favoriteFeatureService;
     private final ReleaseRepository releaseRepository;
     private final FeatureRepository featureRepository;
@@ -134,5 +137,11 @@ public class FeatureService {
         favoriteFeatureRepository.deleteByFeatureCode(cmd.code());
         featureRepository.deleteByCode(cmd.code());
         eventPublisher.publishFeatureDeletedEvent(feature, cmd.deletedBy(), Instant.now());
+    }
+
+    public void handleFeatureEvent(Object event) {
+        log.info("Handling feature event: {}", event);
+        // Business logic for handling feature events would go here
+        // For now, this is just a placeholder for event processing
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
@@ -1,0 +1,40 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.domain.FeatureService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeatureEventListener {
+    private static final Logger log = LoggerFactory.getLogger(FeatureEventListener.class);
+    private final FeatureService featureService;
+
+    public FeatureEventListener(FeatureService featureService) {
+        this.featureService = featureService;
+    }
+
+    @KafkaListener(
+            topics = {"${ft.events.new-features}", "${ft.events.updated-features}", "${ft.events.deleted-features}"},
+            groupId = "${spring.kafka.consumer.group-id}")
+    public void onFeatureEvents(ConsumerRecords<String, Object> records) {
+        long startTime = System.currentTimeMillis();
+        log.info("Received batch of {} events", records.count());
+
+        for (ConsumerRecord<String, Object> record : records) {
+            log.info(
+                    "Processing event - Topic: {}, Partition: {}, Offset: {}, Payload: {}",
+                    record.topic(),
+                    record.partition(),
+                    record.offset(),
+                    record.value());
+            featureService.handleFeatureEvent(record.value());
+        }
+
+        long processingTime = System.currentTimeMillis() - startTime;
+        log.info("Successfully processed batch of {} events in {} ms", records.count(), processingTime);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,3 +42,9 @@ spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.seria
 spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
 spring.kafka.producer.properties.spring.json.add.type.headers=true
 spring.kafka.consumer.properties.spring.json.trusted.packages=*
+
+# Batch consumer configuration
+spring.kafka.listener.type=batch
+spring.kafka.consumer.max-poll-records=100
+spring.kafka.consumer.fetch-min-size=1
+spring.kafka.consumer.fetch-max-wait=500ms

--- a/src/test/java/com/sivalabs/ft/features/AbstractIT.java
+++ b/src/test/java/com/sivalabs/ft/features/AbstractIT.java
@@ -1,18 +1,23 @@
 package com.sivalabs.ft.features;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 @Import(TestcontainersConfiguration.class)
 @Sql(scripts = {"/test-data.sql"})
+@DirtiesContext(classMode = AFTER_CLASS)
 public abstract class AbstractIT {
     @Autowired
     protected MockMvcTester mvc;

--- a/src/test/java/com/sivalabs/ft/features/FeatureServiceApplicationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/FeatureServiceApplicationTests.java
@@ -1,12 +1,8 @@
 package com.sivalabs.ft.features;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 
-@SpringBootTest
-@Import(TestcontainersConfiguration.class)
-class FeatureServiceApplicationTests {
+class FeatureServiceApplicationTests extends AbstractIT {
 
     @Test
     void contextLoads() {}

--- a/src/test/java/com/sivalabs/ft/features/domain/ProductRepositoryTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/ProductRepositoryTest.java
@@ -2,17 +2,13 @@ package com.sivalabs.ft.features.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.sivalabs.ft.features.TestcontainersConfiguration;
+import com.sivalabs.ft.features.AbstractIT;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(TestcontainersConfiguration.class)
-class ProductRepositoryTest {
+class ProductRepositoryTest extends AbstractIT {
 
     @Autowired
     private ProductRepository productRepository;

--- a/src/test/java/com/sivalabs/ft/features/domain/ProductServiceTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/ProductServiceTest.java
@@ -3,7 +3,7 @@ package com.sivalabs.ft.features.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.sivalabs.ft.features.TestcontainersConfiguration;
+import com.sivalabs.ft.features.AbstractIT;
 import com.sivalabs.ft.features.domain.Commands.CreateProductCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateProductCommand;
 import com.sivalabs.ft.features.domain.dtos.ProductDto;
@@ -11,14 +11,8 @@ import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.jdbc.Sql;
 
-@SpringBootTest
-@Import(TestcontainersConfiguration.class)
-@Sql(scripts = {"/test-data.sql"})
-class ProductServiceTest {
+class ProductServiceTest extends AbstractIT {
 
     @Autowired
     private ProductService productService;

--- a/src/test/java/com/sivalabs/ft/features/domain/events/FeatureEventListenerTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/events/FeatureEventListenerTest.java
@@ -1,0 +1,326 @@
+package com.sivalabs.ft.features.domain.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.ApplicationProperties;
+import com.sivalabs.ft.features.domain.FeatureService;
+import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+class FeatureEventListenerTest extends AbstractIT {
+    private static final Logger log = LoggerFactory.getLogger(FeatureEventListenerTest.class);
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Autowired
+    private ApplicationProperties properties;
+
+    @MockitoSpyBean
+    private FeatureService featureService;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void shouldConsumeFeatureCreatedEvent() {
+        // Given
+        FeatureCreatedEvent event = new FeatureCreatedEvent(
+                1L,
+                "TEST-1",
+                "Test Feature",
+                "Test Description",
+                FeatureStatus.NEW,
+                "REL-1",
+                "user1",
+                "admin",
+                Instant.now());
+
+        // When
+        kafkaTemplate.send(properties.events().newFeatures(), event);
+
+        // Then
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(featureService, times(1)).handleFeatureEvent(captor.capture());
+
+            Object capturedEvent = captor.getValue();
+            assertThat(capturedEvent).isInstanceOf(FeatureCreatedEvent.class);
+            FeatureCreatedEvent received = (FeatureCreatedEvent) capturedEvent;
+            assertThat(received.code()).isEqualTo("TEST-1");
+            assertThat(received.title()).isEqualTo("Test Feature");
+            assertThat(received.status()).isEqualTo(FeatureStatus.NEW);
+        });
+    }
+
+    @Test
+    void shouldConsumeFeatureUpdatedEvent() {
+        // Given
+        FeatureUpdatedEvent event = new FeatureUpdatedEvent(
+                2L,
+                "TEST-2",
+                "Updated Feature",
+                "Updated Description",
+                FeatureStatus.IN_PROGRESS,
+                "REL-1",
+                "user2",
+                "admin",
+                Instant.now().minusSeconds(3600),
+                "admin",
+                Instant.now());
+
+        // When
+        kafkaTemplate.send(properties.events().updatedFeatures(), event);
+
+        // Then
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(featureService, times(1)).handleFeatureEvent(captor.capture());
+
+            Object capturedEvent = captor.getValue();
+            assertThat(capturedEvent).isInstanceOf(FeatureUpdatedEvent.class);
+            FeatureUpdatedEvent received = (FeatureUpdatedEvent) capturedEvent;
+            assertThat(received.code()).isEqualTo("TEST-2");
+            assertThat(received.title()).isEqualTo("Updated Feature");
+            assertThat(received.status()).isEqualTo(FeatureStatus.IN_PROGRESS);
+            assertThat(received.updatedBy()).isEqualTo("admin");
+        });
+    }
+
+    @Test
+    void shouldConsumeFeatureDeletedEvent() {
+        // Given
+        FeatureDeletedEvent event = new FeatureDeletedEvent(
+                3L,
+                "TEST-3",
+                "Deleted Feature",
+                "Deleted Description",
+                FeatureStatus.RELEASED,
+                "REL-1",
+                "user3",
+                "admin",
+                Instant.now().minusSeconds(7200),
+                "admin",
+                Instant.now().minusSeconds(3600),
+                "superadmin",
+                Instant.now());
+
+        // When
+        kafkaTemplate.send(properties.events().deletedFeatures(), event);
+
+        // Then
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(featureService, times(1)).handleFeatureEvent(captor.capture());
+
+            Object capturedEvent = captor.getValue();
+            assertThat(capturedEvent).isInstanceOf(FeatureDeletedEvent.class);
+            FeatureDeletedEvent received = (FeatureDeletedEvent) capturedEvent;
+            assertThat(received.code()).isEqualTo("TEST-3");
+            assertThat(received.title()).isEqualTo("Deleted Feature");
+            assertThat(received.deletedBy()).isEqualTo("superadmin");
+        });
+    }
+
+    @Test
+    void shouldConsumeEventsFromMultipleTopics() {
+        // Given
+        FeatureCreatedEvent createdEvent = new FeatureCreatedEvent(
+                10L, "TEST-10", "Created", "Desc", FeatureStatus.NEW, null, "user1", "admin", Instant.now());
+
+        FeatureUpdatedEvent updatedEvent = new FeatureUpdatedEvent(
+                11L,
+                "TEST-11",
+                "Updated",
+                "Desc",
+                FeatureStatus.IN_PROGRESS,
+                null,
+                "user2",
+                "admin",
+                Instant.now().minusSeconds(100),
+                "admin",
+                Instant.now());
+
+        FeatureDeletedEvent deletedEvent = new FeatureDeletedEvent(
+                12L,
+                "TEST-12",
+                "Deleted",
+                "Desc",
+                FeatureStatus.RELEASED,
+                null,
+                "user3",
+                "admin",
+                Instant.now().minusSeconds(200),
+                "admin",
+                Instant.now().minusSeconds(100),
+                "admin",
+                Instant.now());
+
+        // When
+        kafkaTemplate.send(properties.events().newFeatures(), createdEvent);
+        kafkaTemplate.send(properties.events().updatedFeatures(), updatedEvent);
+        kafkaTemplate.send(properties.events().deletedFeatures(), deletedEvent);
+
+        // Then
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(featureService, times(3)).handleFeatureEvent(captor.capture());
+
+            List<Object> capturedEvents = captor.getAllValues();
+            assertThat(capturedEvents).hasSize(3);
+            assertThat(capturedEvents)
+                    .hasAtLeastOneElementOfType(FeatureCreatedEvent.class)
+                    .hasAtLeastOneElementOfType(FeatureUpdatedEvent.class)
+                    .hasAtLeastOneElementOfType(FeatureDeletedEvent.class);
+        });
+    }
+
+    @Test
+    void shouldProcessEventsInCorrectOrder() {
+        // Given
+        int eventCount = 11;
+        List<FeatureCreatedEvent> events = new ArrayList<>();
+        for (int i = 0; i < eventCount; i++) {
+            events.add(new FeatureCreatedEvent(
+                    (long) (2000 + i),
+                    "ORDER-" + i,
+                    "Feature " + i,
+                    "Order test",
+                    FeatureStatus.NEW,
+                    null,
+                    "user",
+                    "admin",
+                    Instant.now()));
+        }
+
+        // When
+        events.forEach(event -> kafkaTemplate.send(properties.events().newFeatures(), event));
+
+        // Then
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(featureService, times(eventCount)).handleFeatureEvent(captor.capture());
+
+            List<String> receivedCodes = captor.getAllValues().stream()
+                    .filter(e -> e instanceof FeatureCreatedEvent)
+                    .map(e -> ((FeatureCreatedEvent) e).code())
+                    .toList();
+
+            // Verify all expected codes are present (order within batch is guaranteed, but batches may vary)
+            for (int i = 0; i < eventCount; i++) {
+                assertThat(receivedCodes).contains("ORDER-" + i);
+            }
+        });
+    }
+
+    @Test
+    void shouldHandleHighVolumeOfEvents() {
+        // Given
+        int eventCount = 666;
+        List<FeatureCreatedEvent> events = new ArrayList<>();
+
+        for (int i = 0; i < eventCount; i++) {
+            events.add(new FeatureCreatedEvent(
+                    (long) (10000 + i),
+                    "PERF-" + i,
+                    "Performance Test Feature " + i,
+                    "Testing high volume processing",
+                    FeatureStatus.NEW,
+                    i % 10 == 0 ? "REL-PERF-" + (i / 10) : null,
+                    "user" + (i % 20),
+                    "admin",
+                    Instant.now()));
+        }
+
+        // Capture metrics before sending events
+        double recordsConsumedBefore = getKafkaConsumerRecordsConsumedTotal();
+        double listenerInvocationsBefore = getSpringKafkaListenerCount();
+
+        // When
+        long startTime = System.currentTimeMillis();
+        events.forEach(event -> kafkaTemplate.send(properties.events().newFeatures(), event));
+        log.info("Sent {} events", eventCount);
+
+        // Then
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(featureService, times(eventCount)).handleFeatureEvent(any());
+        });
+
+        long processingTime = System.currentTimeMillis() - startTime;
+        log.info("Processed {} events in {} ms", eventCount, processingTime);
+        log.info("Throughput: {} events/second", (eventCount * 1000.0) / processingTime);
+
+        // Verify batch consumption via metrics
+        double recordsConsumedAfter = getKafkaConsumerRecordsConsumedTotal();
+        double listenerInvocationsAfter = getSpringKafkaListenerCount();
+
+        double recordsConsumed = recordsConsumedAfter - recordsConsumedBefore;
+        double listenerInvocations = listenerInvocationsAfter - listenerInvocationsBefore;
+
+        log.info("Metrics verification:");
+        log.info("  Records consumed: {}", recordsConsumed);
+        log.info("  Listener invocations: {}", listenerInvocations);
+        log.info("  Average batch size: {}", recordsConsumed / listenerInvocations);
+
+        // Assert batch consumption: listener invocations should be less than records consumed
+        assertThat(recordsConsumed).isGreaterThanOrEqualTo(eventCount);
+        assertThat(listenerInvocations)
+                .isLessThan(recordsConsumed)
+                .withFailMessage(
+                        "Expected batch consumption (listener invocations < records consumed), but got %s invocations for %s records",
+                        listenerInvocations, recordsConsumed);
+    }
+
+    private double getKafkaConsumerRecordsConsumedTotal() {
+        String url =
+                "http://localhost:" + port + "/actuator/metrics/kafka.consumer.fetch.manager.records.consumed.total";
+        ResponseEntity<MetricResponse> response =
+                restTemplate.exchange(url, HttpMethod.GET, null, new ParameterizedTypeReference<MetricResponse>() {});
+
+        return response.getBody().measurements().stream()
+                .filter(m -> "COUNT".equals(m.statistic()))
+                .findFirst()
+                .map(Measurement::value)
+                .orElse(0.0);
+    }
+
+    private double getSpringKafkaListenerCount() {
+        String url = "http://localhost:" + port + "/actuator/metrics/spring.kafka.listener";
+        ResponseEntity<MetricResponse> response =
+                restTemplate.exchange(url, HttpMethod.GET, null, new ParameterizedTypeReference<MetricResponse>() {});
+
+        return response.getBody().measurements().stream()
+                .filter(m -> "COUNT".equals(m.statistic()))
+                .findFirst()
+                .map(Measurement::value)
+                .orElse(0.0);
+    }
+    // DTOs for actuator metrics response
+
+    private record MetricResponse(String name, List<Measurement> measurements) {}
+
+    private record Measurement(String statistic, double value) {}
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
Issue https://github.com/dpaia/feature-service/issues/62

### Task Description:
Aggregate feature-related events in memory or in a message queue and process them in batches using a scheduled or trigger-based listener. Measure and optimize batch processing latency for high event volumes. Test batch handling logic under simulated load and document scalability best practices.

### Acceptance Criteria:

* Batch event processing logic exists, triggered by schedule or batch size.
* Processing latency and throughput are measured and optimized.
* Tests simulate high event volume and confirm correct batch handling.
* Documentation covers design and tuning for performance.

### Implementation details:

* Add a Kafka listener that consumes all existing feature events.
* Add a method in `FeatureService` called `handleFeatureEvent` accepting a single parameter, that simply logs the received event object.
* Listener should invoke this service method for each event received, providing the event body as parameter.
* Add comprehensive end-to-end tests for event consumption, sending messages to the topics on the Kafka instance that is already running inside the test context and verifying they have been successfully consumed.

### Tests:
FAIL_TO_PASS: com.sivalabs.ft.features.domain.events.FeatureEventListenerTest
PASS_TO_PASS: com.sivalabs.ft.features.FeatureServiceApplicationTests,com.sivalabs.ft.features.api.controllers.CommentControllerTests,com.sivalabs.ft.features.api.controllers.FeatureControllerTests,com.sivalabs.ft.features.api.controllers.ReleaseControllerTests,com.sivalabs.ft.features.api.controllers.ProductControllerTests,com.sivalabs.ft.features.api.controllers.FavoriteFeatureControllerTests,com.sivalabs.ft.features.domain.ProductServiceTest,com.sivalabs.ft.features.domain.ProductRepositoryTest