### PR TITLE
Task/#140 email notifications with read tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -1,9 +1,15 @@
 package com.sivalabs.ft.features;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "ft")
-public record ApplicationProperties(EventsProperties events) {
+@Validated
+public record ApplicationProperties(
+        EventsProperties events,
+        @NotBlank(message = "ft.public-base-url property is required") String publicBaseUrl,
+        @NotBlank(message = "ft.mail-from property is required") String mailFrom) {
 
     public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationTrackingController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationTrackingController.java
@@ -1,0 +1,71 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.domain.NotificationRepository;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Public endpoint for tracking email opens via tracking pixel.
+ * This endpoint is accessible without authentication.
+ */
+@RestController
+class NotificationTrackingController {
+    private static final Logger log = LoggerFactory.getLogger(NotificationTrackingController.class);
+
+    // 1x1 transparent GIF (base64 encoded)
+    private static final byte[] TRANSPARENT_GIF =
+            Base64.getDecoder().decode("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+
+    private final NotificationRepository notificationRepository;
+
+    NotificationTrackingController(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    @GetMapping("/notifications/{id}/read")
+    @Transactional
+    public ResponseEntity<byte[]> trackRead(@PathVariable String id) {
+        UUID notificationId;
+        try {
+            notificationId = UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid notification ID format");
+        }
+
+        Notification notification = notificationRepository
+                .findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        // Idempotent: only update if not already read
+        if (!Boolean.TRUE.equals(notification.getRead())) {
+            notification.setRead(true);
+            notification.setReadAt(Instant.now());
+            notificationRepository.save(notification);
+            log.info("Notification {} marked as read via tracking pixel", notificationId);
+        } else {
+            log.debug("Notification {} already read, skipping update", notificationId);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_GIF);
+        headers.setCacheControl("no-cache, no-store, must-revalidate");
+        headers.setPragma("no-cache");
+        headers.setExpires(0);
+
+        return new ResponseEntity<>(TRANSPARENT_GIF, headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
@@ -26,6 +26,9 @@ class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/v3/api-docs.*")
                         .permitAll()
+                        // Email tracking endpoint - must be publicly accessible for email clients
+                        .requestMatchers(HttpMethod.GET, "/notifications/*/read")
+                        .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/products/**")
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/releases/**")

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationEmailService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationEmailService.java
@@ -1,0 +1,152 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.ApplicationProperties;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import jakarta.mail.internet.MimeMessage;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.HtmlUtils;
+
+/**
+ * Service for sending email notifications.
+ * Handles email rendering, error handling, and logging.
+ * Email delivery failures are logged but do not throw exceptions.
+ */
+@Service
+public class NotificationEmailService {
+    private static final Logger log = LoggerFactory.getLogger(NotificationEmailService.class);
+
+    private final JavaMailSender mailSender;
+    private final ApplicationProperties applicationProperties;
+    private final NotificationRepository notificationRepository;
+
+    public NotificationEmailService(
+            JavaMailSender mailSender,
+            ApplicationProperties applicationProperties,
+            NotificationRepository notificationRepository) {
+        this.mailSender = mailSender;
+        this.applicationProperties = applicationProperties;
+        this.notificationRepository = notificationRepository;
+    }
+
+    /**
+     * Send email notification for a saved notification.
+     * On error: logs recipient, eventType, timestamp, and error details, and updates delivery_status to FAILED.
+     * Does NOT throw exception to avoid affecting notification creation.
+     * Uses REQUIRES_NEW to create a new transaction (notification entity is detached after original commit).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendNotificationEmail(Notification notification) {
+        if (notification.getRecipientEmail() == null
+                || notification.getRecipientEmail().isBlank()) {
+            log.debug("Skipping email send for notification {} - no recipient email", notification.getId());
+            return;
+        }
+
+        try {
+            String subject = buildSubject(notification);
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(notification.getRecipientEmail());
+            helper.setSubject(subject);
+            helper.setText(buildHtmlContent(notification, subject), true);
+            helper.setFrom(applicationProperties.mailFrom());
+
+            mailSender.send(message);
+            log.info(
+                    "Email sent successfully to {} for notification {}",
+                    notification.getRecipientEmail(),
+                    notification.getId());
+
+        } catch (Exception e) {
+            logEmailFailure(notification, e);
+            updateDeliveryStatusToFailed(notification);
+        }
+    }
+
+    private void updateDeliveryStatusToFailed(Notification notification) {
+        try {
+            notificationRepository.updateDeliveryStatus(notification.getId(), DeliveryStatus.FAILED);
+            log.debug("Updated delivery_status to FAILED for notification {}", notification.getId());
+        } catch (Exception e) {
+            log.warn("Failed to update delivery_status for notification {}", notification.getId(), e);
+        }
+    }
+
+    private String buildSubject(Notification notification) {
+        return switch (notification.getEventType()) {
+            case FEATURE_CREATED -> "New Feature Created";
+            case FEATURE_UPDATED -> "Feature Updated";
+            case FEATURE_DELETED -> "Feature Deleted";
+            case RELEASE_CREATED -> "New Release Created";
+            case RELEASE_UPDATED -> "Release Updated";
+            case RELEASE_DELETED -> "Release Deleted";
+        };
+    }
+
+    private String buildHtmlContent(Notification notification, String subject) {
+        String trackingPixelUrl = buildTrackingPixelUrl(notification);
+        String linkHtml = notification.getLink() != null
+                ? "<p><a href=\"" + HtmlUtils.htmlEscape(notification.getLink()) + "\">View Details</a></p>"
+                : "";
+
+        String eventDetails = notification.getEventDetails() != null
+                ? HtmlUtils.htmlEscape(notification.getEventDetails())
+                : "No details available";
+
+        return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset="UTF-8">
+                </head>
+                <body>
+                    <h2>%s</h2>
+                    <p>%s</p>
+                    %s
+                    <hr>
+                    <p style="color: #666; font-size: 12px;">
+                        Recipient: %s<br>
+                        Event triggered at: %s
+                    </p>
+                    <img src="%s" width="1" height="1" alt="" style="display:none;">
+                </body>
+                </html>
+                """
+                .formatted(
+                        subject,
+                        eventDetails,
+                        linkHtml,
+                        HtmlUtils.htmlEscape(notification.getRecipientUserId()),
+                        HtmlUtils.htmlEscape(String.valueOf(notification.getCreatedAt())),
+                        HtmlUtils.htmlEscape(trackingPixelUrl));
+    }
+
+    private String buildTrackingPixelUrl(Notification notification) {
+        String baseUrl = applicationProperties.publicBaseUrl();
+        // Remove trailing slash if present
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return baseUrl + "/notifications/" + notification.getId() + "/read";
+    }
+
+    private void logEmailFailure(Notification notification, Exception e) {
+        log.error(
+                "Email delivery failed - recipient: {}, eventType: {}, timestamp: {}, error: {}",
+                notification.getRecipientEmail(),
+                notification.getEventType(),
+                Instant.now(),
+                e.getMessage(),
+                e);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.sivalabs.ft.features.domain;
 
 import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
 import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -9,7 +10,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 
-interface NotificationRepository extends ListCrudRepository<Notification, UUID> {
+public interface NotificationRepository extends ListCrudRepository<Notification, UUID> {
 
     /**
      * Find all notifications for a specific user with pagination, ordered by creation date (newest first)
@@ -32,4 +33,11 @@ interface NotificationRepository extends ListCrudRepository<Notification, UUID> 
     @Query(
             "UPDATE Notification n SET n.read = false, n.readAt = null WHERE n.id = :id AND n.recipientUserId = :recipientUserId")
     int markAsUnread(UUID id, String recipientUserId);
+
+    /**
+     * Update delivery status (used for FAILED status when email sending fails)
+     */
+    @Modifying
+    @Query("UPDATE Notification n SET n.deliveryStatus = :deliveryStatus WHERE n.id = :id")
+    int updateDeliveryStatus(UUID id, DeliveryStatus deliveryStatus);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/UserRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/UserRepository.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.User;
+import java.util.Optional;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface UserRepository extends ListCrudRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/NotificationDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/NotificationDto.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record NotificationDto(
         UUID id,
         String recipientUserId,
+        String recipientEmail,
         NotificationEventType eventType,
         String eventDetails,
         String link,
@@ -23,7 +24,16 @@ public record NotificationDto(
      */
     public NotificationDto markAsRead(Instant readAt) {
         return new NotificationDto(
-                id, recipientUserId, eventType, eventDetails, link, createdAt, true, readAt, deliveryStatus);
+                id,
+                recipientUserId,
+                recipientEmail,
+                eventType,
+                eventDetails,
+                link,
+                createdAt,
+                true,
+                readAt,
+                deliveryStatus);
     }
 
     /**
@@ -31,13 +41,23 @@ public record NotificationDto(
      */
     public NotificationDto markAsUnread() {
         return new NotificationDto(
-                id, recipientUserId, eventType, eventDetails, link, createdAt, false, null, deliveryStatus);
+                id,
+                recipientUserId,
+                recipientEmail,
+                eventType,
+                eventDetails,
+                link,
+                createdAt,
+                false,
+                null,
+                deliveryStatus);
     }
 
     /**
      * Create a copy with updated delivery status
      */
     public NotificationDto withDeliveryStatus(DeliveryStatus status) {
-        return new NotificationDto(id, recipientUserId, eventType, eventDetails, link, createdAt, read, readAt, status);
+        return new NotificationDto(
+                id, recipientUserId, recipientEmail, eventType, eventDetails, link, createdAt, read, readAt, status);
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Notification.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Notification.java
@@ -20,6 +20,9 @@ public class Notification {
     @Size(max = 255) @NotNull @Column(name = "recipient_user_id", nullable = false)
     private String recipientUserId;
 
+    @Size(max = 255) @Column(name = "recipient_email")
+    private String recipientEmail;
+
     @NotNull @Column(name = "event_type", nullable = false, length = 50)
     @Enumerated(EnumType.STRING)
     private NotificationEventType eventType;
@@ -60,6 +63,14 @@ public class Notification {
 
     public void setRecipientUserId(String recipientUserId) {
         this.recipientUserId = recipientUserId;
+    }
+
+    public String getRecipientEmail() {
+        return recipientEmail;
+    }
+
+    public void setRecipientEmail(String recipientEmail) {
+        this.recipientEmail = recipientEmail;
     }
 
     public NotificationEventType getEventType() {

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,0 +1,51 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Size(max = 255) @NotNull @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Size(max = 255) @NotNull @Column(name = "email", nullable = false)
+    private String email;
+
+    public User() {}
+
+    public User(String username, String email) {
+        this.username = username;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ ft.openapi.contact.email=support@sivalabs.in
 ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
+ft.public-base-url=http://localhost:8081
+ft.mail-from=noreply@feature-service.com
 
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}
@@ -26,6 +28,14 @@ spring.jpa.show-sql=true
 OAUTH2_SERVER_URL=http://localhost:9191
 REALM_URL=${OAUTH2_SERVER_URL}/realms/feature-tracker
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${REALM_URL}
+
+######## Mail Configuration  #########
+spring.mail.host=${MAIL_HOST:localhost}
+spring.mail.port=${MAIL_PORT:1025}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
 
 ######## Kafka Configuration  #########
 KAFKA_BROKER=localhost:9092

--- a/src/main/resources/db/migration/V9__add_email_notifications_support.sql
+++ b/src/main/resources/db/migration/V9__add_email_notifications_support.sql
@@ -1,0 +1,39 @@
+-- Create users table for storing user information
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL
+);
+
+-- Add index for username lookups
+CREATE INDEX idx_users_username ON users(username);
+
+-- Insert sample users (populated by support team)
+INSERT INTO users (username, email) VALUES
+    ('admin', 'admin@company.com'),
+    ('siva', 'siva@company.com'),
+    ('bob', 'bob@company.com'),
+    ('alice', 'alice@company.com'),
+    ('testuser', 'testuser@company.com'),
+    ('creator', 'creator@company.com'),
+    ('assignee', 'assignee@company.com'),
+    ('recipient', 'recipient@company.com'),
+    ('user1', 'user1@company.com'),
+    ('user2', 'user2@company.com'),
+    ('marcobehler', 'marcobehler@company.com'),
+    ('daniiltsarev', 'daniiltsarev@company.com'),
+    ('antonarhipov', 'antonarhipov@company.com'),
+    ('andreybelyaev', 'andreybelyaev@company.com'),
+    ('developer', 'developer@company.com'),
+    ('releaseManager', 'releaseManager@company.com'),
+    ('productOwner', 'productOwner@company.com'),
+    ('userA', 'userA@company.com'),
+    ('userB', 'userB@company.com'),
+    ('userC', 'userC@company.com');
+
+-- Add recipient_email column to notifications table for email delivery
+ALTER TABLE notifications ADD COLUMN recipient_email VARCHAR(255);
+
+COMMENT ON COLUMN notifications.recipient_email IS 'Email address of the notification recipient for email delivery';
+
+

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/EmailNotificationIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/EmailNotificationIntegrationTest.java
@@ -1,0 +1,543 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Integration tests for email notification system.
+ * Tests email sending, delivery failure handling, and read tracking via pixel.
+ */
+@Sql("/test-data.sql")
+@Import(MockJavaMailSenderConfig.class)
+@ExtendWith(OutputCaptureExtension.class)
+class EmailNotificationIntegrationTest extends AbstractIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM notifications");
+        reset(javaMailSender);
+        // Return new MimeMessage for each call so we can inspect content
+        when(javaMailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+    }
+
+    // ========== Test 1: Email is sent after notification creation ==========
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldSendEmailWhenNotificationIsCreated() throws Exception {
+        // Given - alice creates a feature assigned to bob
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Email Test Feature", "Test email notification", null, "bob");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Then - Verify notification was created with recipient_email
+        String recipientEmail = jdbcTemplate.queryForObject(
+                "SELECT recipient_email FROM notifications WHERE recipient_user_id = ?", String.class, "bob");
+        assertThat(recipientEmail).isEqualTo("bob@company.com");
+
+        // Get notification ID from database
+        UUID notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ?", UUID.class, "bob");
+
+        // Verify email was sent (with timeout for async implementations)
+        ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(javaMailSender, timeout(2000).times(1)).send(messageCaptor.capture());
+
+        // Verify email body contains tracking pixel link
+        MimeMessage sentMessage = messageCaptor.getValue();
+        String emailContent = extractEmailContent(sentMessage);
+        assertThat(emailContent)
+                .as("Email should contain tracking pixel link with notification ID")
+                .contains("/notifications/" + notificationId + "/read");
+    }
+
+    private String extractEmailContent(MimeMessage message) throws Exception {
+        Object content = message.getContent();
+        if (content instanceof String) {
+            return (String) content;
+        } else if (content instanceof MimeMultipart multipart) {
+            return extractFromMultipart(multipart);
+        }
+        // Fallback: try to get raw content via DataHandler
+        if (message.getDataHandler() != null) {
+            try (java.io.InputStream is = message.getDataHandler().getInputStream()) {
+                return new String(is.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            }
+        }
+        return "";
+    }
+
+    private String extractFromMultipart(MimeMultipart multipart) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < multipart.getCount(); i++) {
+            BodyPart part = multipart.getBodyPart(i);
+            Object partContent = part.getContent();
+            if (partContent instanceof String) {
+                sb.append(partContent);
+            } else if (partContent instanceof MimeMultipart nested) {
+                sb.append(extractFromMultipart(nested));
+            }
+        }
+        return sb.toString();
+    }
+
+    // ========== Test 2: Tracking endpoint marks notification as read ==========
+
+    @Test
+    void shouldMarkNotificationAsReadWhenTrackingPixelIsLoaded() throws Exception {
+        // Given - Create an unread notification directly in database
+        UUID notificationId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO notifications (id, recipient_user_id, recipient_email, event_type, event_details, created_at, read, delivery_status)
+                VALUES (?, 'testuser', 'testuser@example.com', 'FEATURE_CREATED', '{}', NOW(), false, 'PENDING')
+                """,
+                notificationId);
+
+        // When - Load tracking pixel
+        var result = mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+
+        // Then - Should return 200 OK with GIF image
+        assertThat(result).hasStatus(HttpStatus.OK);
+        assertThat(result.getResponse().getContentType()).isEqualTo("image/gif");
+
+        // Verify notification is marked as read in database
+        Boolean isRead = jdbcTemplate.queryForObject(
+                "SELECT read FROM notifications WHERE id = ?", Boolean.class, notificationId);
+        assertThat(isRead).isTrue();
+
+        // Verify read_at is populated
+        java.sql.Timestamp readAt = jdbcTemplate.queryForObject(
+                "SELECT read_at FROM notifications WHERE id = ?", java.sql.Timestamp.class, notificationId);
+        assertThat(readAt).isNotNull();
+    }
+
+    // ========== Test 3: Tracking endpoint is accessible without authentication ==========
+
+    @Test
+    void shouldAllowTrackingEndpointWithoutAuthentication() throws Exception {
+        // Given - Create notification (no @WithMockOAuth2User = unauthenticated request)
+        UUID notificationId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO notifications (id, recipient_user_id, recipient_email, event_type, event_details, created_at, read, delivery_status)
+                VALUES (?, 'testuser', 'testuser@example.com', 'FEATURE_CREATED', '{}', NOW(), false, 'PENDING')
+                """,
+                notificationId);
+
+        // When - Access tracking endpoint without authentication
+        var result = mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+
+        // Then - Should return 200 OK (not 401 Unauthorized)
+        assertThat(result).hasStatus(HttpStatus.OK);
+        assertThat(result.getResponse().getContentType()).isEqualTo("image/gif");
+    }
+
+    // ========== Test 4: Email failure does not affect notification creation ==========
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldCreateNotificationEvenWhenEmailSendingFails(CapturedOutput output) throws Exception {
+        // Given - Configure mail sender to throw exception
+        doThrow(new MailSendException("SMTP server unavailable"))
+                .when(javaMailSender)
+                .send(any(MimeMessage.class));
+
+        CreateFeaturePayload payload = new CreateFeaturePayload(
+                "intellij", "Email Failure Test", "Test notification despite email failure", null, "bob");
+
+        // When - Create feature (email sending will fail)
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Then - Feature should still be created
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Notification should be saved in database
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "bob");
+        assertThat(count).isEqualTo(1);
+
+        // Verify email send was attempted (will fail due to mock configuration)
+        verify(javaMailSender, timeout(2000).times(1)).send(any(MimeMessage.class));
+
+        // Verify delivery_status is updated to FAILED after failed send
+        String deliveryStatus = jdbcTemplate.queryForObject(
+                "SELECT delivery_status FROM notifications WHERE recipient_user_id = ?", String.class, "bob");
+        assertThat(deliveryStatus)
+                .as("delivery_status should be FAILED after email send failure")
+                .isEqualTo("FAILED");
+
+        // Verify error is logged with recipient email and event type (per Task Description requirements)
+        String logs = output.getOut();
+        assertThat(logs).as("Log should contain recipient email").contains("bob@company.com");
+        assertThat(logs).as("Log should contain event type").contains("FEATURE_CREATED");
+    }
+
+    // ========== Test 5: Tracking endpoint returns 404 for non-existent notification ==========
+
+    @Test
+    void shouldReturn404ForNonExistentNotificationId() throws Exception {
+        // Given - Random UUID that doesn't exist
+        UUID nonExistentId = UUID.randomUUID();
+
+        // When - Try to load tracking pixel for non-existent notification
+        var result = mvc.get().uri("/notifications/{id}/read", nonExistentId).exchange();
+
+        // Then - Should return 404 Not Found
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    // ========== Test 6: Tracking endpoint returns 400 for invalid UUID format ==========
+
+    @Test
+    void shouldReturn400ForInvalidUuidFormat() throws Exception {
+        // When - Try to load tracking pixel with invalid UUID
+        var result =
+                mvc.get().uri("/notifications/{id}/read", "not-a-valid-uuid").exchange();
+
+        // Then - Should return 400 Bad Request
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+
+        // Response should not expose internal details (stack traces)
+        String responseBody = result.getResponse().getContentAsString();
+        assertThat(responseBody).doesNotContain("IllegalArgumentException");
+        assertThat(responseBody).doesNotContain("java.util.UUID");
+        assertThat(responseBody).doesNotContain("Exception");
+    }
+
+    // ========== Test 7: Tracking endpoint is idempotent ==========
+
+    @Test
+    void shouldBeIdempotentWhenCalledMultipleTimes() throws Exception {
+        // Given - Create an unread notification
+        UUID notificationId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO notifications (id, recipient_user_id, recipient_email, event_type, event_details, created_at, read, delivery_status)
+                VALUES (?, 'testuser', 'testuser@example.com', 'FEATURE_CREATED', '{}', NOW(), false, 'PENDING')
+                """,
+                notificationId);
+
+        // When - Call tracking endpoint first time
+        var firstResult =
+                mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+
+        assertThat(firstResult).hasStatus(HttpStatus.OK);
+
+        // Get the read_at timestamp after first call
+        java.sql.Timestamp firstReadAt = jdbcTemplate.queryForObject(
+                "SELECT read_at FROM notifications WHERE id = ?", java.sql.Timestamp.class, notificationId);
+
+        // When - Call tracking endpoint second time
+        var secondResult =
+                mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+
+        // Then - Should still return 200 OK
+        assertThat(secondResult).hasStatus(HttpStatus.OK);
+
+        // read_at should NOT be updated (idempotent)
+        java.sql.Timestamp secondReadAt = jdbcTemplate.queryForObject(
+                "SELECT read_at FROM notifications WHERE id = ?", java.sql.Timestamp.class, notificationId);
+
+        assertThat(secondReadAt).isEqualTo(firstReadAt);
+    }
+
+    // ========== Test 8: Notification contains recipient_email in database ==========
+
+    @Test
+    @WithMockOAuth2User(username = "creator")
+    void shouldStoreRecipientEmailInNotification() throws Exception {
+        // Given
+        CreateFeaturePayload payload = new CreateFeaturePayload(
+                "intellij", "Recipient Email Test", "Test recipient email storage", null, "recipient");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Then - Verify recipient_email column is populated
+        String recipientEmail = jdbcTemplate.queryForObject(
+                "SELECT recipient_email FROM notifications WHERE recipient_user_id = ?", String.class, "recipient");
+
+        assertThat(recipientEmail)
+                .as("recipient_email should match email from users table")
+                .isEqualTo("recipient@company.com");
+    }
+
+    // ========== Test 9: Tracking endpoint returns valid GIF image ==========
+
+    @Test
+    void shouldReturnValidGifImage() throws Exception {
+        // Given - Create notification
+        UUID notificationId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO notifications (id, recipient_user_id, recipient_email, event_type, event_details, created_at, read, delivery_status)
+                VALUES (?, 'testuser', 'testuser@example.com', 'FEATURE_CREATED', '{}', NOW(), false, 'PENDING')
+                """,
+                notificationId);
+
+        // When - Load tracking pixel
+        var result = mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+
+        // Then - Should return valid GIF
+        assertThat(result).hasStatus(HttpStatus.OK);
+        assertThat(result.getResponse().getContentType()).isEqualTo("image/gif");
+
+        // Verify response body is not empty (actual GIF content)
+        byte[] content = result.getResponse().getContentAsByteArray();
+        assertThat(content).isNotEmpty();
+    }
+
+    // ========== Test 10: XSS prevention - HTML should be escaped in email content ==========
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldEscapeHtmlInEmailContent() throws Exception {
+        // Given - Create feature with potentially malicious HTML content
+        String maliciousTitle = "<script>alert('XSS')</script>Malicious Feature";
+        String maliciousDescription = "<img src=x onerror=alert('XSS')>Description";
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", maliciousTitle, maliciousDescription, null, "bob");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Then - Capture email and verify HTML is escaped (with timeout for async)
+        ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(javaMailSender, timeout(2000).times(1)).send(messageCaptor.capture());
+
+        MimeMessage sentMessage = messageCaptor.getValue();
+        String emailContent = extractEmailContent(sentMessage);
+
+        // Verify malicious tags are escaped (not present as raw HTML)
+        assertThat(emailContent).doesNotContain("<script>");
+        assertThat(emailContent).doesNotContain("onerror=");
+        assertThat(emailContent).doesNotContain("<img src=x");
+    }
+
+    // ========== Test 11: Email should include all required fields ==========
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldIncludeAllRequiredFieldsInEmail() throws Exception {
+        // Given
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Complete Email Test", "Full email validation", null, "bob");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Capture email (with timeout for async implementations)
+        ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(javaMailSender, timeout(2000).times(1)).send(messageCaptor.capture());
+
+        MimeMessage sentMessage = messageCaptor.getValue();
+        String emailContent = extractEmailContent(sentMessage);
+
+        // Verify required fields are present (per Task Description)
+        // Note: Tracking pixel is verified in shouldSendEmailWhenNotificationIsCreated
+        // 1. Link to affected entity
+        assertThat(emailContent).as("Email should contain link to feature").contains("/features/");
+        // 2. Event summary (feature title or code should be present)
+        assertThat(emailContent)
+                .as("Email should contain event summary with feature info")
+                .satisfiesAnyOf(
+                        content -> assertThat(content).contains("Complete Email Test"),
+                        content -> assertThat(content).contains("IDEA-"));
+        // 3. Actor (who triggered the event)
+        assertThat(emailContent)
+                .as("Email should contain actor who triggered the event")
+                .contains("alice");
+    }
+
+    // ========== Test 12: No email sent when user not found in users table ==========
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldNotSendEmailWhenUserNotFoundInUsersTable() throws Exception {
+        // Given - Create feature assigned to user that does NOT exist in users table
+        CreateFeaturePayload payload = new CreateFeaturePayload(
+                "intellij", "Feature for Unknown User", "Test unknown user handling", null, "nonexistent_user");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Then - Feature should be created successfully
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // No email should be sent for user not in users table
+        // Use after() to wait and verify no email was sent (for async implementations)
+        verify(javaMailSender, after(1000).never()).send(any(MimeMessage.class));
+    }
+
+    // ========== Test 13: Batch notifications send multiple emails for release status change ==========
+
+    @Test
+    @WithMockOAuth2User(username = "admin")
+    void shouldSendMultipleEmailsForBatchNotifications() throws Exception {
+        // Given - Create release and multiple features assigned to different users
+
+        // Create release
+        mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                        "{\"productCode\":\"intellij\",\"code\":\"BATCH-TEST-REL\",\"description\":\"Batch Test Release\"}")
+                .exchange();
+
+        String releaseCode = "IDEA-BATCH-TEST-REL";
+
+        // Create features assigned to different users (user1, user2)
+        mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateFeaturePayload("intellij", "Feature 1", "Desc 1", releaseCode, "user1")))
+                .exchange();
+
+        mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateFeaturePayload("intellij", "Feature 2", "Desc 2", releaseCode, "user2")))
+                .exchange();
+
+        // Wait for feature creation emails to complete before resetting mock
+        verify(javaMailSender, timeout(2000).times(2)).send(any(MimeMessage.class));
+
+        // Now safe to reset - feature creation emails are done
+        jdbcTemplate.execute("DELETE FROM notifications");
+        reset(javaMailSender);
+        when(javaMailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+
+        // Transition release: DRAFT → PLANNED → IN_PROGRESS → RELEASED
+        mvc.put()
+                .uri("/api/releases/{code}", releaseCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"description\":\"Planned\",\"status\":\"PLANNED\"}")
+                .exchange();
+
+        mvc.put()
+                .uri("/api/releases/{code}", releaseCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"description\":\"In Progress\",\"status\":\"IN_PROGRESS\"}")
+                .exchange();
+
+        // When - Update to RELEASED status (triggers batch notifications)
+        var result = mvc.put()
+                .uri("/api/releases/{code}", releaseCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"description\":\"Released\",\"status\":\"RELEASED\"}")
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.OK);
+
+        // Then - Verify multiple notifications created (for user1 and user2, not admin who made the update)
+        Integer totalNotifications = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
+        assertThat(totalNotifications)
+                .as("Should create notifications for both feature assignees")
+                .isEqualTo(2);
+
+        // Verify emails were sent for batch notifications (with timeout for async)
+        verify(javaMailSender, timeout(2000).times(totalNotifications)).send(any(MimeMessage.class));
+    }
+
+    // ========== Test 14: Tracking pixel returns Cache-Control header ==========
+
+    @Test
+    void shouldReturnCacheControlHeaderForTrackingPixel() throws Exception {
+        // Given - Create notification
+        UUID notificationId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO notifications (id, recipient_user_id, recipient_email, event_type, event_details, created_at, read, delivery_status)
+                VALUES (?, 'testuser', 'testuser@example.com', 'FEATURE_CREATED', '{}', NOW(), false, 'PENDING')
+                """,
+                notificationId);
+
+        // When - Load tracking pixel
+        var result = mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+
+        // Then - Cache-Control must prevent caching (required for tracking to work correctly)
+        String cacheControl = result.getResponse().getHeader("Cache-Control");
+        assertThat(cacheControl)
+                .as("Cache-Control header must be present to prevent pixel caching")
+                .isNotNull()
+                .satisfiesAnyOf(s -> assertThat(s.toLowerCase()).contains("no-cache"), s -> assertThat(s.toLowerCase())
+                        .contains("no-store"));
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseCascadeNotificationIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseCascadeNotificationIntegrationTest.java
@@ -8,6 +8,7 @@ import com.sivalabs.ft.features.MockOAuth2UserContextFactory;
 import com.sivalabs.ft.features.WithMockOAuth2User;
 import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
 import com.sivalabs.ft.features.api.models.CreateReleasePayload;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -29,6 +31,7 @@ import org.springframework.test.context.jdbc.Sql;
  * Tests that notifications are created when release status changes to significant states
  */
 @Sql("/test-data.sql")
+@Import(MockJavaMailSenderConfig.class)
 class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
 
     @Autowired

--- a/src/test/java/com/sivalabs/ft/features/testsupport/MockJavaMailSenderConfig.java
+++ b/src/test/java/com/sivalabs/ft/features/testsupport/MockJavaMailSenderConfig.java
@@ -1,0 +1,26 @@
+package com.sivalabs.ft.features.testsupport;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+
+/**
+ * Test configuration that provides a mock JavaMailSender.
+ * Import this config in tests that trigger email sending to avoid real SMTP connections.
+ */
+@TestConfiguration
+public class MockJavaMailSenderConfig {
+    @Bean
+    @Primary
+    public JavaMailSender mockJavaMailSender() {
+        JavaMailSender mailSender = mock(JavaMailSender.class);
+        when(mailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+        return mailSender;
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -3,6 +3,31 @@ delete from comments;
 delete from features;
 delete from releases;
 delete from products;
+delete from users;
+
+-- Insert test users
+insert into users (username, email) values
+('admin', 'admin@company.com'),
+('siva', 'siva@company.com'),
+('alice', 'alice@company.com'),
+('bob', 'bob@company.com'),
+('testuser', 'testuser@company.com'),
+('creator', 'creator@company.com'),
+('assignee', 'assignee@company.com'),
+('recipient', 'recipient@company.com'),
+('user1', 'user1@company.com'),
+('user2', 'user2@company.com'),
+('otheruser', 'otheruser@company.com'),
+('marcobehler', 'marcobehler@company.com'),
+('daniiltsarev', 'daniiltsarev@company.com'),
+('antonarhipov', 'antonarhipov@company.com'),
+('andreybelyaev', 'andreybelyaev@company.com'),
+('developer', 'developer@company.com'),
+('releaseManager', 'releaseManager@company.com'),
+('productOwner', 'productOwner@company.com'),
+('userA', 'userA@company.com'),
+('userB', 'userB@company.com'),
+('userC', 'userC@company.com');
 
 insert into products (id, code, prefix, name, description, image_url, disabled, created_by, created_at) values
 (1, 'intellij', 'IDEA', 'IntelliJ IDEA', 'JetBrains IDE for Java', 'https://resources.jetbrains.com/storage/products/company/brand/logos/IntelliJ_IDEA.png', false, 'admin', '2024-03-01 00:00:00'),


### PR DESCRIPTION
# Implement User Notification System: Email Notifications (with Read Tracking) #140

## Task Description

### Objective
Implement email notifications for feature/release events, including read tracking.

### Requirements

#### Email Delivery

Send emails when in-app notifications are created.

Email recipients must match the recipients of the corresponding in-app Notification.

Email content must include:
- Event summary
- Actor (who triggered the event)
- Links to affected entities

#### Database Schema

A `users` table must be created with columns: `id`, `username`, `email`. This table is the source of email addresses for notifications.

The `notifications` table must include a column named `recipient_email`.

The email must be sent to the address stored in `recipient_email`, which is retrieved from the `users` table by `username`.

#### Delivery Logging

Log email delivery failures with:
- Recipient email
- Event type
- Timestamp
- Error details

Email delivery failure must not prevent notification creation.

#### Email Read Tracking

- Embed a tracking pixel in each email (unique link with notification ID)
- When email is opened, the system calls `GET /notifications/{id}/read`
- Update the notification's status in DB

#### Configuration

The application must be configured with a public base URL via a property named `publicBaseUrl` defined in `application.properties`.

---

### Public API

#### GET /notifications/{id}/read

**Authentication:** None required (must be publicly accessible for email clients)

**Path Parameters:**
- `id` (UUID) — notification ID

**Response:**

| HTTP Status | Condition | Body |
|-------------|-----------|------|
| 200 OK | Notification exists | 1x1 transparent GIF image (Content-Type: `image/gif`) |
| 400 Bad Request | Invalid UUID format | Error message (must not expose stack traces or internal details) |
| 404 Not Found | Notification does not exist | Error message |

**Behavior:**
- Marks notification as read and records the timestamp
- Idempotent: subsequent calls return 200 OK but do not update the timestamp

---

### Test Coverage

- Unit/integration tests for email service
- Tests for read tracking (pixel invocation)
- Security tests to ensure tracking cannot be spoofed:
  - Non-existent notification ID must return 404
  - Invalid UUID format must return 400 without exposing internals
  - Multiple calls must be idempotent

---

### Acceptance Criteria

- Emails are sent when in-app notifications are created
- Delivery failures are logged
- Notifications are marked as read when the tracking pixel is triggered
- Tracking endpoint is secure against spoofing attempts
