### PR TITLE
Release Planning and Roadmapping : Send Updates to Kafka #160

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -5,5 +5,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "ft")
 public record ApplicationProperties(EventsProperties events) {
 
-    public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
+    public record EventsProperties(
+            String newFeatures,
+            String updatedFeatures,
+            String deletedFeatures,
+            String updatedReleases,
+            String updatedMilestones) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -136,7 +136,7 @@ public class FeatureService {
         feature.setUpdatedBy(cmd.updatedBy());
         feature.setUpdatedAt(Instant.now());
         featureRepository.save(feature);
-        eventPublisher.publishFeatureUpdatedEvent(feature);
+        eventPublisher.publishFeatureUpdatedEvent(toEventDto(feature));
     }
 
     @Transactional
@@ -263,6 +263,7 @@ public class FeatureService {
         feature.setUpdatedAt(Instant.now());
 
         featureRepository.save(feature);
+        eventPublisher.publishFeatureUpdatedEvent(toEventDto(feature));
 
         log.info(
                 "Feature {} assigned to release {} by user {}", cmd.featureCode(), cmd.releaseCode(), cmd.assignedBy());
@@ -306,6 +307,7 @@ public class FeatureService {
         feature.setUpdatedAt(Instant.now());
 
         featureRepository.save(feature);
+        eventPublisher.publishFeatureUpdatedEvent(toEventDto(feature));
 
         log.info("Feature planning updated for feature {} by user {}", cmd.featureCode(), cmd.updatedBy());
     }
@@ -333,6 +335,7 @@ public class FeatureService {
         feature.setUpdatedAt(Instant.now());
 
         featureRepository.save(feature);
+        eventPublisher.publishFeatureUpdatedEvent(toEventDto(feature));
 
         log.info(
                 "Feature {} moved from {} to release {} by user {} with rationale: {}",
@@ -362,6 +365,7 @@ public class FeatureService {
         feature.setUpdatedAt(Instant.now());
 
         featureRepository.save(feature);
+        eventPublisher.publishFeatureUpdatedEvent(toEventDto(feature));
 
         log.info(
                 "Feature {} removed from release {} by user {} with rationale: {}",
@@ -369,5 +373,9 @@ public class FeatureService {
                 releaseCode,
                 cmd.removedBy(),
                 cmd.rationale());
+    }
+
+    private FeatureDto toEventDto(Feature feature) {
+        return featureMapper.toDto(feature).makeFavorite(false);
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/MilestoneRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/MilestoneRepository.java
@@ -27,7 +27,8 @@ interface MilestoneRepository extends ListCrudRepository<Milestone, Long> {
 
     List<Milestone> findByProductCodeAndStatusAndOwner(String productCode, MilestoneStatus status, String owner);
 
-    @Modifying
+    // Bulk delete bypasses the persistence context; clear/flush prevents stale Milestone refs.
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     void deleteByCode(String code);
 
     boolean existsByCode(String code);

--- a/src/main/java/com/sivalabs/ft/features/domain/MilestoneService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/MilestoneService.java
@@ -8,6 +8,8 @@ import com.sivalabs.ft.features.domain.dtos.MilestoneSummaryDto;
 import com.sivalabs.ft.features.domain.entities.Milestone;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.events.EventPublisher;
+import com.sivalabs.ft.features.domain.events.EventType;
 import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.MilestoneMapper;
@@ -27,16 +29,19 @@ public class MilestoneService {
     private final ProductRepository productRepository;
     private final ReleaseRepository releaseRepository;
     private final MilestoneMapper milestoneMapper;
+    private final EventPublisher eventPublisher;
 
     MilestoneService(
             MilestoneRepository milestoneRepository,
             ProductRepository productRepository,
             ReleaseRepository releaseRepository,
-            MilestoneMapper milestoneMapper) {
+            MilestoneMapper milestoneMapper,
+            EventPublisher eventPublisher) {
         this.milestoneRepository = milestoneRepository;
         this.productRepository = productRepository;
         this.releaseRepository = releaseRepository;
         this.milestoneMapper = milestoneMapper;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -45,30 +50,7 @@ public class MilestoneService {
         if (milestoneOptional.isEmpty()) {
             return Optional.empty();
         }
-        Milestone milestone = milestoneOptional.get();
-        MilestoneDto dto = milestoneMapper.toDto(milestone);
-        Integer progress = calculateProgress(new ArrayList<>(milestone.getReleases()));
-        List<MilestoneReleaseDto> releaseDtos =
-                milestoneMapper.toReleaseDtoList(new ArrayList<>(milestone.getReleases()));
-        dto = new MilestoneDto(
-                dto.id(),
-                dto.code(),
-                dto.name(),
-                dto.description(),
-                dto.targetDate(),
-                dto.actualDate(),
-                dto.status(),
-                dto.productCode(),
-                dto.owner(),
-                dto.notes(),
-                progress,
-                releaseDtos,
-                dto.createdBy(),
-                dto.createdAt(),
-                dto.updatedBy(),
-                dto.updatedAt());
-
-        return Optional.of(dto);
+        return Optional.of(buildMilestoneDto(milestoneOptional.get()));
     }
 
     @Transactional(readOnly = true)
@@ -139,6 +121,9 @@ public class MilestoneService {
         milestone.setCreatedAt(Instant.now());
 
         milestoneRepository.save(milestone);
+        MilestoneDto dto = buildMilestoneDto(
+                milestoneRepository.findByCodeWithReleases(milestone.getCode()).orElseThrow());
+        eventPublisher.publishMilestoneEvent(dto, EventType.CREATED);
         return milestone.getCode();
     }
 
@@ -160,15 +145,22 @@ public class MilestoneService {
         milestone.setUpdatedAt(Instant.now());
 
         milestoneRepository.save(milestone);
+        MilestoneDto dto = buildMilestoneDto(
+                milestoneRepository.findByCodeWithReleases(milestone.getCode()).orElseThrow());
+        eventPublisher.publishMilestoneEvent(dto, EventType.UPDATED);
     }
 
     @Transactional
     public void deleteMilestone(String code) {
-        if (!milestoneRepository.existsByCode(code)) {
+        Optional<Milestone> milestoneOptional = milestoneRepository.findByCodeWithReleases(code);
+        if (milestoneOptional.isEmpty()) {
             throw new ResourceNotFoundException("Milestone with code %s not found".formatted(code));
         }
+        Milestone milestone = milestoneOptional.get();
+        MilestoneDto dto = buildMilestoneDto(milestone);
         releaseRepository.unsetMilestone(code);
         milestoneRepository.deleteByCode(code);
+        eventPublisher.publishMilestoneEvent(dto, EventType.DELETED);
     }
 
     private Integer calculateProgress(List<Release> releases) {
@@ -181,5 +173,29 @@ public class MilestoneService {
                 .count();
 
         return (int) Math.round((completedCount * 100.0) / releases.size());
+    }
+
+    private MilestoneDto buildMilestoneDto(Milestone milestone) {
+        MilestoneDto dto = milestoneMapper.toDto(milestone);
+        Integer progress = calculateProgress(new ArrayList<>(milestone.getReleases()));
+        List<MilestoneReleaseDto> releaseDtos =
+                milestoneMapper.toReleaseDtoList(new ArrayList<>(milestone.getReleases()));
+        return new MilestoneDto(
+                dto.id(),
+                dto.code(),
+                dto.name(),
+                dto.description(),
+                dto.targetDate(),
+                dto.actualDate(),
+                dto.status(),
+                dto.productCode(),
+                dto.owner(),
+                dto.notes(),
+                progress,
+                releaseDtos,
+                dto.createdBy(),
+                dto.createdAt(),
+                dto.updatedBy(),
+                dto.updatedAt());
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
@@ -17,7 +17,8 @@ interface ReleaseRepository extends ListCrudRepository<Release, Long> {
 
     boolean existsByCode(String code);
 
-    @Modifying
+    // Bulk update bypasses the persistence context; clear/flush avoids stale Milestone refs in memory.
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Release r set r.milestone = null where r.milestone.code = :code")
     void unsetMilestone(String code);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
@@ -6,6 +6,8 @@ import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Milestone;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.events.EventPublisher;
+import com.sivalabs.ft.features.domain.events.EventType;
 import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.ReleaseMapper;
@@ -24,18 +26,21 @@ public class ReleaseService {
     private final FeatureRepository featureRepository;
     private final ReleaseMapper releaseMapper;
     private final MilestoneRepository milestoneRepository;
+    private final EventPublisher eventPublisher;
 
     ReleaseService(
             ReleaseRepository releaseRepository,
             ProductRepository productRepository,
             FeatureRepository featureRepository,
             ReleaseMapper releaseMapper,
-            MilestoneRepository milestoneRepository) {
+            MilestoneRepository milestoneRepository,
+            EventPublisher eventPublisher) {
         this.releaseRepository = releaseRepository;
         this.productRepository = productRepository;
         this.featureRepository = featureRepository;
         this.releaseMapper = releaseMapper;
         this.milestoneRepository = milestoneRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -70,6 +75,7 @@ public class ReleaseService {
         release.setCreatedBy(cmd.createdBy());
         release.setCreatedAt(Instant.now());
         releaseRepository.save(release);
+        eventPublisher.publishReleaseEvent(releaseMapper.toDto(release), EventType.CREATED);
         return code;
     }
 
@@ -96,6 +102,7 @@ public class ReleaseService {
         release.setUpdatedBy(cmd.updatedBy());
         release.setUpdatedAt(Instant.now());
         releaseRepository.save(release);
+        eventPublisher.publishReleaseEvent(releaseMapper.toDto(release), EventType.UPDATED);
     }
 
     @Transactional

--- a/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
@@ -1,8 +1,15 @@
 package com.sivalabs.ft.features.domain.events;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sivalabs.ft.features.ApplicationProperties;
+import com.sivalabs.ft.features.domain.dtos.FeatureDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Feature;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -10,10 +17,13 @@ import org.springframework.stereotype.Component;
 public class EventPublisher {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final ApplicationProperties properties;
+    private final ObjectMapper objectMapper;
 
-    public EventPublisher(KafkaTemplate<String, Object> kafkaTemplate, ApplicationProperties properties) {
+    public EventPublisher(
+            KafkaTemplate<String, Object> kafkaTemplate, ApplicationProperties properties, ObjectMapper objectMapper) {
         this.kafkaTemplate = kafkaTemplate;
         this.properties = properties;
+        this.objectMapper = objectMapper;
     }
 
     public void publishFeatureCreatedEvent(Feature feature) {
@@ -28,22 +38,13 @@ public class EventPublisher {
                 feature.getCreatedBy(),
                 feature.getCreatedAt());
         kafkaTemplate.send(properties.events().newFeatures(), event);
+        kafkaTemplate.flush();
     }
 
-    public void publishFeatureUpdatedEvent(Feature feature) {
-        FeatureUpdatedEvent event = new FeatureUpdatedEvent(
-                feature.getId(),
-                feature.getCode(),
-                feature.getTitle(),
-                feature.getDescription(),
-                feature.getStatus(),
-                feature.getRelease() == null ? null : feature.getRelease().getCode(),
-                feature.getAssignedTo(),
-                feature.getCreatedBy(),
-                feature.getCreatedAt(),
-                feature.getUpdatedBy(),
-                feature.getUpdatedAt());
-        kafkaTemplate.send(properties.events().updatedFeatures(), event);
+    public void publishFeatureUpdatedEvent(FeatureDto featureDto) {
+        Map<String, Object> payload = toPayload(featureDto, EventType.UPDATED);
+        kafkaTemplate.send(properties.events().updatedFeatures(), payload);
+        kafkaTemplate.flush();
     }
 
     public void publishFeatureDeletedEvent(Feature feature, String deletedBy, Instant deletedAt) {
@@ -62,5 +63,25 @@ public class EventPublisher {
                 deletedBy,
                 deletedAt);
         kafkaTemplate.send(properties.events().deletedFeatures(), event);
+        kafkaTemplate.flush();
+    }
+
+    public void publishReleaseEvent(ReleaseDto releaseDto, EventType eventType) {
+        Map<String, Object> payload = toPayload(releaseDto, eventType);
+        kafkaTemplate.send(properties.events().updatedReleases(), payload);
+        kafkaTemplate.flush();
+    }
+
+    public void publishMilestoneEvent(MilestoneDto milestoneDto, EventType eventType) {
+        Map<String, Object> payload = toPayload(milestoneDto, eventType);
+        kafkaTemplate.send(properties.events().updatedMilestones(), payload);
+        kafkaTemplate.flush();
+    }
+
+    private Map<String, Object> toPayload(Object dto, EventType eventType) {
+        Map<String, Object> payload =
+                objectMapper.convertValue(dto, new TypeReference<LinkedHashMap<String, Object>>() {});
+        payload.put("eventType", eventType.name());
+        return payload;
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/events/EventType.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/EventType.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.events;
+
+public enum EventType {
+    CREATED,
+    UPDATED,
+    DELETED
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ ft.openapi.contact.email=support@sivalabs.in
 ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
+ft.events.updated-releases=updated_releases
+ft.events.updated-milestones=updated_milestones
 
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}

--- a/src/test/java/com/sivalabs/ft/features/TestcontainersConfiguration.java
+++ b/src/test/java/com/sivalabs/ft/features/TestcontainersConfiguration.java
@@ -3,6 +3,8 @@ package com.sivalabs.ft.features;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -29,5 +31,10 @@ public class TestcontainersConfiguration {
     @ServiceConnection
     KafkaContainer kafkaContainer() {
         return kafka;
+    }
+
+    @DynamicPropertySource
+    static void registerKafkaProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
     }
 }

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/KafkaEventsIntegrationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/KafkaEventsIntegrationTests.java
@@ -1,0 +1,363 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.testcontainers.kafka.KafkaContainer;
+
+@WithMockOAuth2User(username = "event-user")
+class KafkaEventsIntegrationTests extends AbstractIT {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${ft.events.updated-releases}")
+    private String updatedReleasesTopic;
+
+    @Value("${ft.events.updated-features}")
+    private String updatedFeaturesTopic;
+
+    @Value("${ft.events.updated-milestones}")
+    private String updatedMilestonesTopic;
+
+    @Autowired
+    private KafkaContainer kafkaContainer;
+
+    @Test
+    void shouldPublishReleaseCreatedEvent() throws Exception {
+        var payload =
+                """
+            {
+                "productCode": "intellij",
+                "code": "2025.1.0",
+                "description": "Release 2025.1.0"
+            }
+            """;
+
+        var locationRef = new java.util.concurrent.atomic.AtomicReference<String>();
+        Map<String, Object> event = readEvent(updatedReleasesTopic, () -> {
+            var result = mvc.post()
+                    .uri("/api/releases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatus(HttpStatus.CREATED);
+            locationRef.set(result.getMvcResult().getResponse().getHeader("Location"));
+        });
+
+        assertEventMatchesGet(event, "CREATED", locationRef.get());
+    }
+
+    @Test
+    void shouldPublishReleaseUpdatedEvent() throws Exception {
+        var payload =
+                """
+            {
+                "description": "Updated release description",
+                "status": "RELEASED",
+                "releasedAt": "2024-03-30T00:00:00Z",
+                "milestoneCode": "Q1-2024"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedReleasesTopic, () -> {
+            var result = mvc.put()
+                    .uri("/api/releases/{code}", "IDEA-2023.3.8")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/releases/IDEA-2023.3.8");
+    }
+
+    @Test
+    void shouldPublishFeatureUpdatedEventOnUpdate() throws Exception {
+        var payload =
+                """
+            {
+                "title": "Updated Feature",
+                "description": "Updated description",
+                "assignedTo": "jane.doe",
+                "status": "IN_PROGRESS"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedFeaturesTopic, () -> {
+            var result = mvc.put()
+                    .uri("/api/features/{code}", "IDEA-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/features/IDEA-1");
+    }
+
+    @Test
+    void shouldPublishFeatureUpdatedEventOnAssign() throws Exception {
+        var payload =
+                """
+            {
+                "featureCode": "IDEA-3",
+                "plannedCompletionDate": "2024-05-01",
+                "featureOwner": "alice"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedFeaturesTopic, () -> {
+            var result = mvc.post()
+                    .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatus(HttpStatus.CREATED);
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/features/IDEA-3");
+    }
+
+    @Test
+    void shouldPublishFeatureUpdatedEventOnMove() throws Exception {
+        var payload =
+                """
+            {
+                "targetReleaseCode": "IDEA-2024.2.3",
+                "rationale": "Move for testing"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedFeaturesTopic, () -> {
+            var result = mvc.post()
+                    .uri("/api/releases/{targetReleaseCode}/features/{featureCode}/move", "IDEA-2024.2.3", "IDEA-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/features/IDEA-1");
+    }
+
+    @Test
+    void shouldPublishFeatureUpdatedEventOnRemove() throws Exception {
+        Map<String, Object> event = readEvent(updatedFeaturesTopic, () -> {
+            var result = mvc.delete()
+                    .uri("/api/releases/{releaseCode}/features/{featureCode}", "IDEA-2023.3.8", "IDEA-1")
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/features/IDEA-1");
+    }
+
+    @Test
+    void shouldPublishFeatureUpdatedEventOnPlanningUpdate() throws Exception {
+        var payload =
+                """
+            {
+                "planningStatus": "IN_PROGRESS",
+                "notes": "Starting implementation",
+                "featureOwner": "owner@example.com"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedFeaturesTopic, () -> {
+            var result = mvc.patch()
+                    .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/features/IDEA-1");
+    }
+
+    @Test
+    void shouldPublishMilestoneCreatedEvent() throws Exception {
+        var payload =
+                """
+            {
+                "productCode": "intellij",
+                "code": "M-NEW-1",
+                "name": "Milestone New",
+                "description": "New milestone",
+                "targetDate": "2024-12-31T00:00:00Z",
+                "status": "PLANNED",
+                "owner": "owner@example.com",
+                "notes": "Created for test"
+            }
+            """;
+
+        var locationRef = new java.util.concurrent.atomic.AtomicReference<String>();
+        Map<String, Object> event = readEvent(updatedMilestonesTopic, () -> {
+            var result = mvc.post()
+                    .uri("/api/milestones")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatus(HttpStatus.CREATED);
+            locationRef.set(result.getMvcResult().getResponse().getHeader("Location"));
+        });
+
+        assertEventMatchesGet(event, "CREATED", locationRef.get());
+    }
+
+    @Test
+    void shouldPublishMilestoneUpdatedEvent() throws Exception {
+        var payload =
+                """
+            {
+                "name": "Q2 2024 Release Updated",
+                "description": "Updated milestone",
+                "targetDate": "2024-06-30T23:59:59Z",
+                "actualDate": "2024-06-20T10:00:00Z",
+                "status": "COMPLETED",
+                "owner": "bob@example.com",
+                "notes": "Updated for test"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedMilestonesTopic, () -> {
+            var result = mvc.put()
+                    .uri("/api/milestones/{code}", "Q2-2024")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/milestones/Q2-2024");
+    }
+
+    @Test
+    void shouldPublishMilestoneDeletedEvent() throws Exception {
+        Map<String, Object> expected = getPayloadMap("/api/milestones/Q3-2024");
+
+        Map<String, Object> event = readEvent(updatedMilestonesTopic, () -> {
+            var result = mvc.delete().uri("/api/milestones/{code}", "Q3-2024").exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertThat(event.get("eventType")).isEqualTo("DELETED");
+        event.remove("eventType");
+        assertThat(normalizePayload(event)).isEqualTo(normalizePayload(expected));
+    }
+
+    private Map<String, Object> readEvent(String topic, Runnable action) throws Exception {
+        Consumer<String, String> consumer = createConsumer();
+        consumer.subscribe(List.of(topic));
+        waitForAssignment(consumer);
+        consumer.seekToEnd(consumer.assignment());
+        // seekToEnd is lazy; touching position forces the end offset before publishing.
+        consumer.assignment().forEach(consumer::position);
+        try {
+            action.run();
+            ConsumerRecord<String, String> record = pollForRecord(consumer, topic, Duration.ofSeconds(10));
+            return toMap(record.value());
+        } finally {
+            consumer.close();
+        }
+    }
+
+    private Consumer<String, String> createConsumer() {
+        String groupId = "test-" + UUID.randomUUID();
+        var props = new java.util.HashMap<String, Object>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<String, String>(props).createConsumer();
+    }
+
+    private void waitForAssignment(Consumer<String, String> consumer) {
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(5).toMillis();
+        while (consumer.assignment().isEmpty() && System.currentTimeMillis() < deadline) {
+            consumer.poll(Duration.ofMillis(100));
+        }
+    }
+
+    private ConsumerRecord<String, String> pollForRecord(
+            Consumer<String, String> consumer, String topic, Duration timeout) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(250));
+            for (ConsumerRecord<String, String> record : records.records(topic)) {
+                return record;
+            }
+        }
+        throw new IllegalStateException("No records found for topic");
+    }
+
+    private void assertEventMatchesGet(Map<String, Object> event, String expectedEventType, String getUri)
+            throws Exception {
+        assertThat(event.get("eventType")).isEqualTo(expectedEventType);
+        event.remove("eventType");
+        Map<String, Object> expected = getPayloadMap(getUri);
+        assertThat(normalizePayload(event)).isEqualTo(normalizePayload(expected));
+    }
+
+    private Map<String, Object> getPayloadMap(String uri) throws Exception {
+        var result = mvc.get().uri(uri).exchange();
+        assertThat(result).hasStatusOk();
+        String body = result.getMvcResult().getResponse().getContentAsString();
+        return toMap(body);
+    }
+
+    private Map<String, Object> toMap(String json) throws Exception {
+        return objectMapper.readValue(json, new TypeReference<>() {});
+    }
+
+    private Map<String, Object> normalizePayload(Map<String, Object> payload) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> normalized = (Map<String, Object>) normalizeValue(payload);
+        return normalized;
+    }
+
+    private Object normalizeValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            var result = new java.util.LinkedHashMap<String, Object>();
+            for (var entry : map.entrySet()) {
+                result.put(String.valueOf(entry.getKey()), normalizeValue(entry.getValue()));
+            }
+            return result;
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::normalizeValue).toList();
+        }
+        if (value instanceof String str) {
+            try {
+                Instant instant = Instant.parse(str);
+                return instant.truncatedTo(ChronoUnit.MILLIS).toString();
+            } catch (Exception ignored) {
+                return str;
+            }
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
# Release Planning and Roadmapping : Send Updates to Kafka #160

## Objective  
Send Kafka events for all changes related to release planning: releases, features, milestones.

## Events and payloads (combined rules)
1. Release creation / update should send a new event to Kafka: use the same event for both; publish to updated_releases. The payload must match GET /api/releases/{code} after the operation, plus eventType (CREATED or UPDATED).
2. Feature updated event (already exists): should be sent on feature update and when a feature is assigned to/removed from a release or moved between releases, and on update planning. Publish to updated_features. The payload must match GET /api/features/{code} after the operation, plus eventType=UPDATED.
3. Milestone creation / update and deletion should send new events. Publish all milestone events to updated_milestones. The payload must match GET /api/milestones/{code} after the operation, plus eventType (CREATED, UPDATED, DELETED). For deletion, the base payload matches the milestone state before deletion.

## Topic names  
Topic names must be explicitly defined, configurable via ft.events.*, with defaults in application.properties:
- ft.events.updated-releases=updated_releases
- ft.events.updated-features=updated_features
- ft.events.updated-milestones=updated_milestones

FAIL_TO_PASS: com.sivalabs.ft.features.api.controllers.KafkaEventsIntegrationTests