### PR TITLE
nes-003: generate JPA Id field for User entity

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,10 +1,15 @@
 package com.sivalabs.ft.features.domain.entities;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "users")
 public class User {
-
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 }


### PR DESCRIPTION
```json
{
  "description": "Generate JPA @Id field with @GeneratedValue for empty User entity after @Entity and @Table annotations",
  "notes": "Primary key is the obvious first field for any JPA entity",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
    "caret": 174,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
        "diff": "@@ -0,0 +1,10 @@\n+package com.sivalabs.ft.features.domain.entities;\n+\n+import jakarta.persistence.Entity;\n+import jakarta.persistence.Table;\n+\n+@Entity\n+@Table(name = \"users\")\n+public class User {\n+\n+}\n"
      }
    ]
  }
}
```