### PR TITLE
nes-004: add Lombok constructor annotations to User entity

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,10 +1,13 @@
 package com.sivalabs.ft.features.domain.entities;
 
 import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Data
-
+@NoArgsConstructor
+@AllArgsConstructor
 public class User {
 }


### PR DESCRIPTION
```json
{
  "description": "Add @NoArgsConstructor and @AllArgsConstructor annotations to JPA entity with @Data",
  "notes": "These annotations are idiomatic with @Data in JPA entities. JPA requires a no-arg constructor, and @AllArgsConstructor is commonly paired with @NoArgsConstructor for convenience. NES should suggest these stereotype annotations after @Data on an @Entity class.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
    "caret": 124,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
        "diff": "@@ -0,0 +1,10 @@\n+package com.sivalabs.ft.features.domain.entities;\n+\n+import jakarta.persistence.Entity;\n+import lombok.Data;\n+\n+@Entity\n+@Data\n+\n+public class User {\n+}\n"
      }
    ]
  }
}
```