### PR TITLE
nes-005: suggest @Id field for Lombok User entity

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,10 +1,15 @@
 package com.sivalabs.ft.features.domain.entities;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.Data;
 
 @Entity
 @Data
 public class User {
-
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 }


### PR DESCRIPTION
```json
{
  "description": "Suggest @Id field with @GeneratedValue as the first field in an empty Lombok JPA entity",
  "notes": "An @Entity class with @Data and an empty body is a strong signal that the developer is starting to define fields. The most common first field in a JPA entity is the primary key @Id field. NES should suggest @Id @GeneratedValue private Long id; when the caret is inside an empty entity body.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
    "caret": 142,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
        "diff": "@@ -0,0 +1,10 @@\n+package com.sivalabs.ft.features.domain.entities;\n+\n+import jakarta.persistence.Entity;\n+import lombok.Data;\n+\n+@Entity\n+@Data\n+public class User {\n+\n+}\n"
      }
    ]
  }
}
```