### PR TITLE
nes-006: add @Id annotation to existing id field

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,10 +1,12 @@
 package com.sivalabs.ft.features.domain.entities;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import lombok.Data;
 
 @Entity
 @Data
 public class User {
+    @Id
     private Long id;
 }


### PR DESCRIPTION
```json
{
  "description": "Add @Id annotation to existing private Long id field in a Lombok JPA entity",
  "notes": "When an @Entity class has a field named id without @Id annotation, the suggestion should add the @Id annotation to the existing field rather than add a new field or getter/setter method.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
    "caret": 146,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
        "diff": "@@ -0,0 +1,10 @@\n+package com.sivalabs.ft.features.domain.entities;\n+\n+import jakarta.persistence.Entity;\n+import lombok.Data;\n+\n+@Entity\n+@Data\n+public class User {\n+    private Long id;\n+}\n"
      }
    ]
  }
}
```