### PR TITLE
nes-007: suggest annotation between @Size and field

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,13 +1,16 @@
 package com.sivalabs.ft.features.domain.entities;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "users")
 public class User {
     @Size(max = 50)
-
+    @NotNull
+    @Column(name = "username", nullable = false, length = 50)
     private String username;
 }


### PR DESCRIPTION
```json
{
  "description": "Add @NotNull and @Column annotations between @Size and private String username field",
  "notes": "When the caret is between an annotation and its field declaration, the user likely wants to add more annotations to that field, not a new field. NES should suggest annotations like @NotNull or @Column rather than predicting a new field.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
    "caret": 236,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/User.java",
        "diff": "@@ -0,0 +1,13 @@\n+package com.sivalabs.ft.features.domain.entities;\n+\n+import jakarta.persistence.Entity;\n+import jakarta.persistence.Table;\n+import jakarta.validation.constraints.Size;\n+\n+@Entity\n+@Table(name = \"users\")\n+public class User {\n+    @Size(max = 50)\n+\n+    private String username;\n+}\n"
      }
    ]
  }
}
```