### PR TITLE
nes-008: rename comentId to commentId in method

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/api/controllers/CommentController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/CommentController.java
@@ -64,10 +64,10 @@ class CommentController {
                 @ApiResponse(responseCode = "204", description = "Comment removed successfully"),
                 @ApiResponse(responseCode = "400", description = "Comment not found")
             })
-    ResponseEntity<Void> removeComment(@PathVariable Long comentId) {
+    ResponseEntity<Void> removeComment(@PathVariable Long commentId) {
         String username = SecurityUtils.getCurrentUsername();
-        commentService.removeComment(comentId, username);
-        log.info("Comment with id: {} is removed", comentId);
+        commentService.removeComment(commentId, username);
+        log.info("Comment with id: {} is removed", commentId);
         return ResponseEntity.noContent().build();
     }
 


### PR DESCRIPTION
```json
{
  "description": "Rename @PathVariable parameter comentId to commentId to match the fixed /{commentId} path",
  "notes": "After fixing a typo in @DeleteMapping path from /{comentId} to /{commentId}, the @PathVariable parameter and all its usages in the method body should be renamed to match. Path variable and @PathVariable parameter must match - this is a common source of runtime errors from mismatched names.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/api/controllers/CommentController.java",
    "caret": 2955,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/api/controllers/CommentController.java",
        "diff": "@@ -59,7 +59,7 @@\n-    @DeleteMapping(\"/{comentId}\")\n+    @DeleteMapping(\"/{commentId}\")\n     @Operation(\n             summary = \"Remove a comment\",\n             description = \"Remove a comment by its id\",\n"
      }
    ]
  }
}
```