### PR TITLE
nes-010: suggest toDto method with actual DTO fields

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
@@ -6,5 +6,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MilestoneMapper {
-
+    public MilestoneDto toDto(Milestone milestone) {
+        return MilestoneDto.builder()
+                .id(milestone.getId())
+                .code(milestone.getCode())
+                .releaseCode(milestone.getReleaseCode())
+                .targetDate(milestone.getTargetDate())
+                .completedFeatures(milestone.getCompletedFeatures())
+                .totalFeatures(milestone.getTotalFeatures())
+                .build();
+    }
 }


### PR DESCRIPTION
```json
{
  "description": "Suggest toDto builder method in manual mapper using actual MilestoneDto fields instead of hallucinated generic ones",
  "notes": "NES should read the actual DTO class fields (code, releaseCode, targetDate, completedFeatures, totalFeatures) from the builder and use them in the mapping method. Instead, it tends to hallucinate generic fields like name and description that do not exist on the DTO, producing code that won't compile.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java",
    "caret": 261,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneDto.java",
        "diff": "@@ -0,0 +1,21 @@\n+package com.sivalabs.ft.features.domain.dtos;\n+\n+import java.time.LocalDate;\n+import lombok.AllArgsConstructor;\n+import lombok.Builder;\n+import lombok.Data;\n+import lombok.NoArgsConstructor;\n+\n+@Data\n+@Builder\n+@NoArgsConstructor\n+@AllArgsConstructor\n+public class MilestoneDto {\n+    private Long id;\n+    private String code;\n+    private String releaseCode;\n+    private LocalDate targetDate;\n+    private int completedFeatures;\n+    private int totalFeatures;\n+}\n"
      },
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java",
        "diff": "@@ -0,0 +1,10 @@\n+package com.sivalabs.ft.features.domain.mappers;\n+\n+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;\n+import com.sivalabs.ft.features.domain.entities.Milestone;\n+import org.springframework.stereotype.Component;\n+\n+@Component\n+public class MilestoneMapper {\n+\n+}\n"
      }
    ]
  }
}
```