### PR TITLE
nes-011: add mapstruct-processor inside annotationProcessorPaths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.6.3</version>
+                        </path>
                         <!-- other annotation processors -->
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
```json
{
  "description": "Add mapstruct-processor path entry inside existing annotationProcessorPaths block after adding mapstruct dependency",
  "notes": "When annotationProcessorPaths already exists in maven-compiler-plugin, NES should suggest adding the mapstruct-processor path entry inside it. This is the recommended way to configure annotation processors since Maven 3.5.",
  "context": {
    "filepath": "pom.xml",
    "caret": 3543,
    "history": [
      {
        "filepath": "pom.xml",
        "diff": "@@ -84,6 +84,11 @@\n             <version>${springdoc.version}</version>\n         </dependency>\n+        <dependency>\n+            <groupId>org.mapstruct</groupId>\n+            <artifactId>mapstruct</artifactId>\n+            <version>1.6.3</version>\n+        </dependency>\n \n         <dependency>\n"
      }
    ]
  }
}
```