### PR TITLE
nes-012: add annotationProcessorPaths to existing plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,13 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.6.3</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
```json
{
  "description": "Add annotationProcessorPaths block with mapstruct-processor to existing maven-compiler-plugin configuration",
  "notes": "When maven-compiler-plugin configuration exists but has no annotationProcessorPaths, NES should suggest adding the entire annotationProcessorPaths block with the mapstruct-processor entry. The plugin config already has source/target settings.",
  "context": {
    "filepath": "pom.xml",
    "caret": 3543,
    "history": [
      {
        "filepath": "pom.xml",
        "diff": "@@ -84,6 +84,11 @@\n             <version>${springdoc.version}</version>\n         </dependency>\n+        <dependency>\n+            <groupId>org.mapstruct</groupId>\n+            <artifactId>mapstruct</artifactId>\n+            <version>1.6.3</version>\n+        </dependency>\n \n         <dependency>\n"
      }
    ]
  }
}
```