### PR TITLE
nes-013: add maven-compiler-plugin with annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.6.3</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
```json
{
  "description": "Add entire maven-compiler-plugin with annotationProcessorPaths for mapstruct-processor when no compiler plugin exists",
  "notes": "When no maven-compiler-plugin is present in the pom at all, NES should suggest adding the full plugin configuration with annotationProcessorPaths containing the mapstruct-processor. This is the recommended approach for annotation processor configuration since Maven 3.5.",
  "context": {
    "filepath": "pom.xml",
    "caret": 3543,
    "history": [
      {
        "filepath": "pom.xml",
        "diff": "@@ -84,6 +84,11 @@\n             <version>${springdoc.version}</version>\n         </dependency>\n+        <dependency>\n+            <groupId>org.mapstruct</groupId>\n+            <artifactId>mapstruct</artifactId>\n+            <version>1.6.3</version>\n+        </dependency>\n \n         <dependency>\n"
      }
    ]
  }
}
```