### PR TITLE
nes-014: extract hardcoded mapstruct version into property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <java.version>24</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <springdoc.version>2.8.9</springdoc.version>
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
         <palantir-java-format.version>2.74.0</palantir-java-format.version>
         <dockerImageName>sivaprasadreddy/ft-feature-service</dockerImageName>
@@ -86,7 +87,7 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>1.6.3</version>
+            <version>${org.mapstruct.version}</version>
         </dependency>
 
         <dependency>
@@ -182,7 +183,7 @@
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
-                            <version>1.6.3</version>
+                            <version>${org.mapstruct.version}</version>
                         </path>
                         <!-- other annotation processors -->
                     </annotationProcessorPaths>


### PR DESCRIPTION
```json
{
  "description": "Extract hardcoded mapstruct version 1.6.3 into a Maven property and reference it in dependency and annotation processor path",
  "notes": "Hardcoded version duplication across dependency and annotationProcessorPaths is a maintenance smell. NES should suggest extracting the version into a <properties> block and replacing all hardcoded occurrences with the property reference. This is idiomatic Maven configuration.",
  "context": {
    "filepath": "pom.xml",
    "caret": 3521,
    "history": [
      {
        "filepath": "pom.xml",
        "diff": "@@ -84,6 +84,11 @@\n             <version>${springdoc.version}</version>\n         </dependency>\n+        <dependency>\n+            <groupId>org.mapstruct</groupId>\n+            <artifactId>mapstruct</artifactId>\n+            <version>1.6.3</version>\n+        </dependency>\n \n         <dependency>\n"
      }
    ]
  }
}
```