### PR TITLE
nes-015: suggest @Mapping for toDto after entity field rename

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
@@ -3,10 +3,11 @@ package com.sivalabs.ft.features.domain.mappers;
 import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
 import com.sivalabs.ft.features.domain.entities.Milestone;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface MilestoneMapper {
-
+    @Mapping(target = "completedFeatures", source = "resolvedFeatures")
     MilestoneDto toDto(Milestone milestone);
 
     Milestone toEntity(MilestoneDto dto);


### PR DESCRIPTION
```json
{
  "description": "Suggest @Mapping annotation for toDto method after entity field was renamed from completedFeatures to resolvedFeatures. The DTO still uses completedFeatures, so a @Mapping is needed to map between the differently-named fields.",
  "notes": "The caret is on an empty line above toDto method. The model should suggest adding @Mapping(target = \"completedFeatures\", source = \"resolvedFeatures\") with the import.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java",
    "caret": 267,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java",
        "diff": "--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java\n+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java\n@@ -25,7 +25,7 @@\n \n-    private int completedFeatures;\n+    private int resolvedFeatures;\n     private int totalFeatures;\n \n@@ -41,7 +41,7 @@\n \n-    public int getCompletedFeatures() {\n-        return completedFeatures;\n+    public int getResolvedFeatures() {\n+        return resolvedFeatures;\n     }"
      }
    ]
  }
}
```