### PR TITLE
nes-016: complete @Mapping for toDto after entity field rename

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface MilestoneMapper {
-    @Mapping
+    @Mapping(target = "completedFeatures", source = "resolvedFeatures")
     MilestoneDto toDto(Milestone milestone);
 
     Milestone toEntity(MilestoneDto dto);


### PR DESCRIPTION
```json
{
  "description": "Complete @Mapping annotation for toDto method after entity field was renamed from completedFeatures to resolvedFeatures. User has already typed @Mapping above toDto and added the import.",
  "notes": "The caret is right after @Mapping text. The model should complete it as @Mapping(target = \"completedFeatures\", source = \"resolvedFeatures\").",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java",
    "caret": 309,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java",
        "diff": "--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java\n+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java\n@@ -25,7 +25,7 @@\n \n-    private int completedFeatures;\n+    private int resolvedFeatures;\n     private int totalFeatures;\n \n@@ -41,7 +41,7 @@\n \n-    public int getCompletedFeatures() {\n-        return completedFeatures;\n+    public int getResolvedFeatures() {\n+        return resolvedFeatures;\n     }"
      },
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java",
        "diff": "--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java\n+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java\n@@ -5,6 +5,7 @@\n import org.mapstruct.Mapper;\n+import org.mapstruct.Mapping;\n \n@@ -9,6 +10,7 @@\n public interface MilestoneMapper {\n+    @Mapping\n     MilestoneDto toDto(Milestone milestone);"
      }
    ]
  }
}
```