### PR TITLE
nes-018: complete @Mapping for toEntity after entity field rename

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
@@ -10,6 +10,6 @@ public interface MilestoneMapper {
     @Mapping(target = "completedFeatures", source = "resolvedFeatures")
     MilestoneDto toDto(Milestone milestone);
 
-    @Mapping
+    @Mapping(target = "resolvedFeatures", source = "completedFeatures")
     Milestone toEntity(MilestoneDto dto);
 }


### PR DESCRIPTION
```json
{
  "description": "Complete @Mapping annotation for toEntity method after entity field was renamed from completedFeatures to resolvedFeatures. User has already typed @Mapping above toEntity. The toDto method already has the correct @Mapping.",
  "notes": "The toDto method already has @Mapping(target = \"completedFeatures\", source = \"resolvedFeatures\"). The caret is right after @Mapping text above toEntity. The model should complete it as @Mapping(target = \"resolvedFeatures\", source = \"completedFeatures\") — note the reversed target/source since toEntity maps from DTO to entity.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java",
    "caret": 427,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java",
        "diff": "--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java\n+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java\n@@ -25,7 +25,7 @@\n \n-    private int completedFeatures;\n+    private int resolvedFeatures;\n     private int totalFeatures;\n \n@@ -41,7 +41,7 @@\n \n-    public int getCompletedFeatures() {\n-        return completedFeatures;\n+    public int getResolvedFeatures() {\n+        return resolvedFeatures;\n     }"
      },
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java",
        "diff": "--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java\n+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java\n@@ -5,6 +5,7 @@\n import org.mapstruct.Mapper;\n+import org.mapstruct.Mapping;\n \n@@ -9,6 +10,7 @@\n public interface MilestoneMapper {\n     @Mapping(target = \"completedFeatures\", source = \"resolvedFeatures\")\n     MilestoneDto toDto(Milestone milestone);\n \n+    @Mapping\n     Milestone toEntity(MilestoneDto dto);"
      }
    ]
  }
}
```