### PR TITLE
nes-019: suggest @AllArgsConstructor when @NoArgsConstructor present

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "priorities")
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class Priority {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
```json
{
  "description": "Suggest @AllArgsConstructor annotation for a Lombok JPA entity that already has @NoArgsConstructor. Since no-arg constructor is already covered, the model should predict adding @AllArgsConstructor.",
  "notes": "Caret is on an empty line after the last field inside the class body. The presence of @NoArgsConstructor signals that the no-arg constructor is handled, so the natural next step is @AllArgsConstructor. Great example of model understanding Lombok semantics and contextual awareness.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java",
    "caret": 542,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java",
        "diff": "--- /dev/null\n+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java\n@@ -0,0 +1,24 @@\n+package com.sivalabs.ft.features.domain.entities;\n+\n+import jakarta.persistence.Entity;\n+import jakarta.persistence.GeneratedValue;\n+import jakarta.persistence.GenerationType;\n+import jakarta.persistence.Id;\n+import jakarta.persistence.Table;\n+import lombok.Data;\n+import lombok.NoArgsConstructor;\n+\n+@Entity\n+@Table(name = \"priorities\")\n+@Data\n+@NoArgsConstructor\n+public class Priority {\n+    @Id\n+    @GeneratedValue(strategy = GenerationType.IDENTITY)\n+    private Long id;\n+\n+    private String name;\n+    private int level;\n+    private String description;\n+\n+}"
      }
    ]
  }
}
```