### PR TITLE
nes-020: suggest @NoArgsConstructor when absent on JPA entity

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java
@@ -6,10 +6,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "priorities")
 @Data
+@NoArgsConstructor
 public class Priority {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
```json
{
  "description": "Suggest @NoArgsConstructor annotation for a Lombok JPA entity that only has @Data. JPA requires a no-arg constructor, and without @NoArgsConstructor the entity would fail at runtime if any other constructor is added.",
  "notes": "Caret is on an empty line after the last field inside the class body. The absence of @NoArgsConstructor on a JPA @Entity with @Data signals that it should be added. Contrast with case 019 where @NoArgsConstructor is already present and @AllArgsConstructor is predicted instead.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java",
    "caret": 490,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java",
        "diff": "--- /dev/null\n+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Priority.java\n@@ -0,0 +1,22 @@\n+package com.sivalabs.ft.features.domain.entities;\n+\n+import jakarta.persistence.Entity;\n+import jakarta.persistence.GeneratedValue;\n+import jakarta.persistence.GenerationType;\n+import jakarta.persistence.Id;\n+import jakarta.persistence.Table;\n+import lombok.Data;\n+\n+@Entity\n+@Table(name = \"priorities\")\n+@Data\n+public class Priority {\n+    @Id\n+    @GeneratedValue(strategy = GenerationType.IDENTITY)\n+    private Long id;\n+\n+    private String name;\n+    private int level;\n+    private String description;\n+\n+}"
      }
    ]
  }
}
```