### PR TITLE
nes-027: propagate new field to POJO constructor

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/models/FeatureFilter.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/FeatureFilter.java
@@ -6,10 +6,11 @@ public class FeatureFilter {
     private FeatureStatus status;
     private String assignedTo;
 
-    public FeatureFilter(String productCode, String releaseCode, FeatureStatus status) {
+    public FeatureFilter(String productCode, String releaseCode, FeatureStatus status, String assignedTo) {
         this.productCode = productCode;
         this.releaseCode = releaseCode;
         this.status = status;
+        this.assignedTo = assignedTo;
     }
 
     public String getProductCode() {


### PR DESCRIPTION
```json
{
  "description": "After adding a new 'assignedTo' field to the FeatureFilter plain POJO, NES suggests updating the constructor to include the new field parameter and its initialization.",
  "notes": "Caret is at the constructor closing brace. The model should detect that 'assignedTo' field exists but is missing from the constructor, and suggest adding the parameter and 'this.assignedTo = assignedTo' assignment. Plain POJO variation of case 023 (JPA entity) — no framework annotations, pure Java class structure understanding. Demonstrates consistent initialization pattern recognition.",
  "context": {
    "filepath": "src/main/java/com/sivalabs/ft/features/domain/models/FeatureFilter.java",
    "caret": 407,
    "history": [
      {
        "filepath": "src/main/java/com/sivalabs/ft/features/domain/models/FeatureFilter.java",
        "diff": "--- a/src/main/java/com/sivalabs/ft/features/domain/models/FeatureFilter.java\n+++ b/src/main/java/com/sivalabs/ft/features/domain/models/FeatureFilter.java\n@@ -5,6 +5,7 @@\n     private String releaseCode;\n     private FeatureStatus status;\n+    private String assignedTo;\n \n     public FeatureFilter(String productCode, String releaseCode, FeatureStatus status) {"
      }
    ]
  }
}
```