### PR TITLE
Admin Event Monitoring and Reprocessing (#145)

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -1,12 +1,16 @@
 package com.sivalabs.ft.features;
 
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "ft")
-public record ApplicationProperties(EventsProperties events, UsageTrackingProperties usageTracking) {
+public record ApplicationProperties(
+        EventsProperties events, UsageTrackingProperties usageTracking, ReprocessProperties reprocess) {
 
     public record EventsProperties(
             String newFeatures, String updatedFeatures, String deletedFeatures, String featureUsage) {}
 
     public record UsageTrackingProperties(boolean enabled, boolean captureIp, boolean captureUserAgent) {}
+
+    public record ReprocessProperties(Duration persistenceTimeout, Duration pollInterval) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -7,12 +7,14 @@ import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -22,6 +24,7 @@ class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     ProblemDetail handle(Exception e) {
         log.error("Unhandled exception", e);
+
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(INTERNAL_SERVER_ERROR, e.getMessage());
         problemDetail.setTitle("Internal Server Error");
         problemDetail.setProperty("timestamp", Instant.now());
@@ -67,8 +70,23 @@ class GlobalExceptionHandler {
         if (e.getBindingResult().hasFieldErrors()) {
             message = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
         }
+
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, message);
         problemDetail.setTitle("Validation Error");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    ProblemDetail handle(MethodArgumentTypeMismatchException e) {
+        log.warn("Method argument type mismatch", e);
+        String message = "Invalid request parameter";
+        if (e.getRequiredType() != null && e.getRequiredType().isEnum()) {
+            message = "Invalid " + e.getName() + " value";
+        }
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, message);
+        problemDetail.setTitle("Bad Request");
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;
     }
@@ -76,8 +94,19 @@ class GlobalExceptionHandler {
     @ExceptionHandler(AuthorizationDeniedException.class)
     ProblemDetail handle(AuthorizationDeniedException e) {
         log.warn("Access denied", e);
+
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(FORBIDDEN, "Access denied");
         problemDetail.setTitle("Forbidden");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    ProblemDetail handle(DataIntegrityViolationException e) {
+        log.error("Database constraint violation", e);
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, "Database constraint violation");
+        problemDetail.setTitle("Database Error");
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;
     }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/AdminController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/AdminController.java
@@ -1,0 +1,138 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.domain.ErrorLoggingService;
+import com.sivalabs.ft.features.domain.HealthMetricsService;
+import com.sivalabs.ft.features.domain.ReprocessService;
+import com.sivalabs.ft.features.domain.dtos.ErrorLogDto;
+import com.sivalabs.ft.features.domain.dtos.HealthMetricsDto;
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Instant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin")
+@Tag(name = "Admin API")
+@PreAuthorize("hasRole('ADMIN')")
+class AdminController {
+
+    private final ErrorLoggingService errorLoggingService;
+    private final HealthMetricsService healthMetricsService;
+    private final ReprocessService reprocessService;
+
+    AdminController(
+            ErrorLoggingService errorLoggingService,
+            HealthMetricsService healthMetricsService,
+            ReprocessService reprocessService) {
+        this.errorLoggingService = errorLoggingService;
+        this.healthMetricsService = healthMetricsService;
+        this.reprocessService = reprocessService;
+    }
+
+    @GetMapping("/health")
+    @Operation(
+            summary = "Get system health metrics",
+            description = "Get system health metrics for specified time period (default: last 7 days)",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = HealthMetricsDto.class))),
+                @ApiResponse(responseCode = "403", description = "Forbidden - Admin role required")
+            })
+    ResponseEntity<HealthMetricsDto> getSystemHealth(
+            @RequestParam(required = false) Instant startDate, @RequestParam(required = false) Instant endDate) {
+        if (hasPartialDateRange(startDate, endDate)) {
+            return ResponseEntity.badRequest().build();
+        }
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            return ResponseEntity.badRequest().build();
+        }
+        HealthMetricsDto metrics = healthMetricsService.getSystemHealth(startDate, endDate);
+        return ResponseEntity.ok(metrics);
+    }
+
+    @GetMapping("/errors")
+    @Operation(
+            summary = "Get error logs with pagination and filtering",
+            description = "Get paginated list of error logs with optional filtering by error type and date range",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Successful response"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - Admin role required")
+            })
+    ResponseEntity<Page<ErrorLogDto>> getErrors(
+            @PageableDefault(size = 20, sort = "timestamp", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) ErrorType errorType,
+            @RequestParam(required = false) Instant startDate,
+            @RequestParam(required = false) Instant endDate) {
+        if (hasPartialDateRange(startDate, endDate)) {
+            return ResponseEntity.badRequest().build();
+        }
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            return ResponseEntity.badRequest().build();
+        }
+        Page<ErrorLogDto> errors = errorLoggingService.getErrors(pageable, errorType, startDate, endDate);
+        return ResponseEntity.ok(errors);
+    }
+
+    @GetMapping("/errors/{id}")
+    @Operation(
+            summary = "Get error log by ID",
+            description = "Get detailed error log information by ID",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ErrorLogDto.class))),
+                @ApiResponse(responseCode = "404", description = "Error log not found"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - Admin role required")
+            })
+    ResponseEntity<ErrorLogDto> getErrorById(@PathVariable Long id) {
+        return errorLoggingService
+                .getErrorById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/errors/{id}/reprocess")
+    @Operation(
+            summary = "Reprocess failed error log",
+            description = "Attempt to reprocess a failed event. Always returns 200 OK with ErrorLogDto. "
+                    + "Success: original record updated to resolved=true. "
+                    + "Failure: new error log record created with resolved=false",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Reprocessing attempted (check resolved field for result)",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ErrorLogDto.class))),
+                @ApiResponse(responseCode = "404", description = "Error log not found"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - Admin role required")
+            })
+    ResponseEntity<ErrorLogDto> reprocessError(@PathVariable Long id) {
+        ErrorLogDto result = reprocessService.reprocessSingleError(id);
+        return ResponseEntity.ok(result);
+    }
+
+    private boolean hasPartialDateRange(Instant startDate, Instant endDate) {
+        return (startDate == null) != (endDate == null);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/ErrorLogRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ErrorLogRepository.java
@@ -1,0 +1,26 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.ErrorLog;
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.time.Instant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ErrorLogRepository extends JpaRepository<ErrorLog, Long> {
+
+    Page<ErrorLog> findByErrorType(ErrorType errorType, Pageable pageable);
+
+    Page<ErrorLog> findByTimestampBetween(Instant start, Instant end, Pageable pageable);
+
+    Page<ErrorLog> findByErrorTypeAndTimestampBetween(
+            ErrorType errorType, Instant start, Instant end, Pageable pageable);
+
+    long countByTimestampBetween(Instant start, Instant end);
+
+    @Query("SELECT COUNT(e) FROM ErrorLog e WHERE e.errorType = :errorType AND e.timestamp BETWEEN :start AND :end")
+    long countByErrorTypeAndTimestampBetween(
+            @Param("errorType") ErrorType errorType, @Param("start") Instant start, @Param("end") Instant end);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/ErrorLoggingService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ErrorLoggingService.java
@@ -1,0 +1,85 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.ErrorLogDto;
+import com.sivalabs.ft.features.domain.entities.ErrorLog;
+import com.sivalabs.ft.features.domain.mappers.ErrorLogMapper;
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ErrorLoggingService {
+    private static final Logger log = LoggerFactory.getLogger(ErrorLoggingService.class);
+    private final ErrorLogRepository errorLogRepository;
+    private final ErrorLogMapper errorLogMapper;
+
+    public ErrorLoggingService(ErrorLogRepository errorLogRepository, ErrorLogMapper errorLogMapper) {
+        this.errorLogRepository = errorLogRepository;
+        this.errorLogMapper = errorLogMapper;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void logError(ErrorType errorType, String message, Exception exception, String eventPayload, String userId) {
+        try {
+            ErrorLog errorLog = new ErrorLog();
+            errorLog.setTimestamp(Instant.now());
+            errorLog.setErrorType(errorType);
+            errorLog.setErrorMessage(message);
+            errorLog.setEventPayload(eventPayload);
+            errorLog.setUserId(userId);
+
+            if (exception != null) {
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                exception.printStackTrace(pw);
+                errorLog.setStackTrace(sw.toString());
+            }
+
+            errorLogRepository.save(errorLog);
+            log.debug("Logged error: type={}, message={}", errorType, message);
+        } catch (Exception e) {
+            log.error("Failed to log error to database", e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ErrorLogDto> getErrors(Pageable pageable, ErrorType errorType, Instant startDate, Instant endDate) {
+        Page<ErrorLog> errorLogs;
+
+        if (errorType != null && startDate != null && endDate != null) {
+            errorLogs = errorLogRepository.findByErrorTypeAndTimestampBetween(errorType, startDate, endDate, pageable);
+        } else if (errorType != null) {
+            errorLogs = errorLogRepository.findByErrorType(errorType, pageable);
+        } else if (startDate != null && endDate != null) {
+            errorLogs = errorLogRepository.findByTimestampBetween(startDate, endDate, pageable);
+        } else {
+            errorLogs = errorLogRepository.findAll(pageable);
+        }
+
+        return errorLogs.map(errorLogMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ErrorLogDto> getErrorById(Long id) {
+        return errorLogRepository.findById(id).map(errorLogMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ErrorLog> getErrorEntityById(Long id) {
+        return errorLogRepository.findById(id);
+    }
+
+    @Transactional
+    public ErrorLog saveErrorLog(ErrorLog errorLog) {
+        return errorLogRepository.save(errorLog);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageEventConsumer.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageEventConsumer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sivalabs.ft.features.domain.entities.FeatureUsage;
 import com.sivalabs.ft.features.domain.events.FeatureUsageEvent;
+import com.sivalabs.ft.features.domain.models.ErrorType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -12,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class FeatureUsageEventConsumer {
@@ -20,10 +20,15 @@ public class FeatureUsageEventConsumer {
 
     private final FeatureUsageRepository featureUsageRepository;
     private final ObjectMapper objectMapper;
+    private final ErrorLoggingService errorLoggingService;
 
-    public FeatureUsageEventConsumer(FeatureUsageRepository featureUsageRepository, ObjectMapper objectMapper) {
+    public FeatureUsageEventConsumer(
+            FeatureUsageRepository featureUsageRepository,
+            ObjectMapper objectMapper,
+            ErrorLoggingService errorLoggingService) {
         this.featureUsageRepository = featureUsageRepository;
         this.objectMapper = objectMapper;
+        this.errorLoggingService = errorLoggingService;
     }
 
     @KafkaListener(
@@ -32,7 +37,6 @@ public class FeatureUsageEventConsumer {
             batch = "true",
             autoStartup = "${spring.kafka.listener.auto-startup:true}",
             containerFactory = "batchKafkaListenerContainerFactory")
-    @Transactional
     public void consume(List<FeatureUsageEvent> events) {
         log.debug("Received batch of {} FeatureUsage events from Kafka", events.size());
 
@@ -42,6 +46,7 @@ public class FeatureUsageEventConsumer {
         // is committed, causing a unique constraint violation on INSERT.
         Set<String> seenEventIds = new HashSet<>();
         List<FeatureUsage> toSave = new ArrayList<>();
+        List<FeatureUsageEvent> toSaveEvents = new ArrayList<>();
 
         for (FeatureUsageEvent event : events) {
             try {
@@ -58,14 +63,35 @@ public class FeatureUsageEventConsumer {
 
                 FeatureUsage featureUsage = toEntity(event);
                 toSave.add(featureUsage);
+                toSaveEvents.add(event);
             } catch (Exception e) {
                 log.error("Failed to process FeatureUsage event eventId={}", event.eventId(), e);
+                errorLoggingService.logError(
+                        ErrorType.PROCESSING_ERROR,
+                        "Failed to process FeatureUsage Kafka event",
+                        e,
+                        toPayload(event),
+                        event.userId());
             }
         }
 
         if (!toSave.isEmpty()) {
-            featureUsageRepository.saveAll(toSave);
-            log.debug("Saved {} FeatureUsage records from Kafka batch", toSave.size());
+            try {
+                // Force DB constraints check inside this try/catch so database failures
+                // are captured and logged into error_log.
+                featureUsageRepository.saveAllAndFlush(toSave);
+                log.debug("Saved {} FeatureUsage records from Kafka batch", toSave.size());
+            } catch (Exception e) {
+                log.error("Failed to persist FeatureUsage Kafka batch", e);
+                for (FeatureUsageEvent event : toSaveEvents) {
+                    errorLoggingService.logError(
+                            ErrorType.DATABASE_ERROR,
+                            "Failed to persist FeatureUsage Kafka event",
+                            e,
+                            toPayload(event),
+                            event.userId());
+                }
+            }
         }
     }
 
@@ -89,5 +115,13 @@ public class FeatureUsageEventConsumer {
         featureUsage.setTimestamp(event.timestamp());
         featureUsage.setContext(contextJson);
         return featureUsage;
+    }
+
+    private String toPayload(FeatureUsageEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            return "eventId=" + event.eventId();
+        }
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageRepository.java
@@ -270,4 +270,10 @@ public interface FeatureUsageRepository extends JpaRepository<FeatureUsage, Long
             @Param("actionType") ActionType actionType,
             @Param("startDate") Instant startDate,
             @Param("endDate") Instant endDate);
+
+    // Methods for health metrics
+    long countByTimestampBetween(Instant start, Instant end);
+
+    @Query("SELECT MAX(fu.timestamp) FROM FeatureUsage fu WHERE fu.timestamp BETWEEN :start AND :end")
+    Instant findLatestTimestampBetween(@Param("start") Instant start, @Param("end") Instant end);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageService.java
@@ -1,13 +1,17 @@
 package com.sivalabs.ft.features.domain;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sivalabs.ft.features.domain.dtos.*;
 import com.sivalabs.ft.features.domain.entities.FeatureUsage;
 import com.sivalabs.ft.features.domain.events.EventPublisher;
 import com.sivalabs.ft.features.domain.mappers.FeatureUsageMapper;
 import com.sivalabs.ft.features.domain.models.ActionType;
+import com.sivalabs.ft.features.domain.models.ErrorType;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -21,21 +25,29 @@ import org.springframework.stereotype.Service;
 @Service
 public class FeatureUsageService {
     private static final Logger log = LoggerFactory.getLogger(FeatureUsageService.class);
+    private static final Duration DEFAULT_REPROCESS_PERSISTENCE_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_REPROCESS_POLL_INTERVAL = Duration.ofMillis(100);
 
     private final FeatureUsageRepository featureUsageRepository;
     private final com.sivalabs.ft.features.ApplicationProperties applicationProperties;
     private final FeatureUsageMapper featureUsageMapper;
     private final EventPublisher eventPublisher;
+    private final ErrorLoggingService errorLoggingService;
+    private final ObjectMapper objectMapper;
 
     public FeatureUsageService(
             FeatureUsageRepository featureUsageRepository,
             com.sivalabs.ft.features.ApplicationProperties applicationProperties,
             FeatureUsageMapper featureUsageMapper,
-            EventPublisher eventPublisher) {
+            EventPublisher eventPublisher,
+            ErrorLoggingService errorLoggingService,
+            ObjectMapper objectMapper) {
         this.featureUsageRepository = featureUsageRepository;
         this.applicationProperties = applicationProperties;
         this.featureUsageMapper = featureUsageMapper;
         this.eventPublisher = eventPublisher;
+        this.errorLoggingService = errorLoggingService;
+        this.objectMapper = objectMapper;
     }
 
     public void logUsage(
@@ -51,25 +63,8 @@ public class FeatureUsageService {
             return;
         }
         try {
-            // Enrich context with anonymized device fingerprint for anonymous users
-            Map<String, Object> enrichedContext = contextData != null ? new HashMap<>(contextData) : new HashMap<>();
-
-            if (ipAddress != null && userAgent != null) {
-                // Create device fingerprint: hash(device:ip)
-                String deviceFingerprint = createDeviceFingerprint(ipAddress, userAgent);
-                enrichedContext.put("deviceFingerprint", deviceFingerprint);
-
-                // Extract location from IP (placeholder - would use GeoIP service in production)
-                String location = extractLocation(ipAddress);
-                if (location != null) {
-                    enrichedContext.put("location", location);
-                }
-            }
-
-            Map<String, Object> contextToPublish = enrichedContext.isEmpty() ? null : enrichedContext;
-
-            eventPublisher.publishFeatureUsageEvent(
-                    userId, featureCode, productCode, releaseCode, actionType, contextToPublish, ipAddress, userAgent);
+            publishUsageEvent(
+                    userId, featureCode, productCode, releaseCode, actionType, contextData, ipAddress, userAgent);
 
             log.debug(
                     "Published usage event to Kafka: user={}, feature={}, product={}, release={}, action={}",
@@ -80,6 +75,20 @@ public class FeatureUsageService {
                     actionType);
         } catch (Exception e) {
             log.error("Failed to publish usage event", e);
+            errorLoggingService.logError(
+                    ErrorType.PROCESSING_ERROR,
+                    "Failed to publish usage event",
+                    e,
+                    buildPayload(
+                            userId,
+                            featureCode,
+                            productCode,
+                            releaseCode,
+                            actionType,
+                            contextData,
+                            ipAddress,
+                            userAgent),
+                    userId);
             // Don't throw exception to avoid breaking the main flow
         }
     }
@@ -91,6 +100,124 @@ public class FeatureUsageService {
     public void logUsage(
             String userId, String featureCode, String productCode, String releaseCode, ActionType actionType) {
         logUsage(userId, featureCode, productCode, releaseCode, actionType, null, null, null);
+    }
+
+    /**
+     * Reprocessing path: succeeds only after Kafka event is actually persisted in feature_usage.
+     * Throws on publish failures or on persistence timeout.
+     */
+    public void logUsageForReprocessing(
+            String userId,
+            String featureCode,
+            String productCode,
+            String releaseCode,
+            ActionType actionType,
+            Map<String, Object> contextData,
+            String ipAddress,
+            String userAgent) {
+        if (!applicationProperties.usageTracking().enabled()) {
+            throw new IllegalStateException("Usage tracking is disabled");
+        }
+        String eventId = publishUsageEvent(
+                userId, featureCode, productCode, releaseCode, actionType, contextData, ipAddress, userAgent);
+        waitForPersistence(eventId);
+    }
+
+    private String buildPayload(
+            String userId,
+            String featureCode,
+            String productCode,
+            String releaseCode,
+            ActionType actionType,
+            Map<String, Object> contextData,
+            String ipAddress,
+            String userAgent) {
+        try {
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("userId", userId);
+            payload.put("featureCode", featureCode);
+            payload.put("productCode", productCode);
+            payload.put("releaseCode", releaseCode);
+            payload.put("actionType", actionType);
+            payload.put("context", contextData);
+            payload.put("ipAddress", ipAddress);
+            payload.put("userAgent", userAgent);
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.debug("Failed to serialize usage payload", e);
+            return "featureCode=" + featureCode + ", productCode=" + productCode + ", actionType=" + actionType;
+        }
+    }
+
+    private String publishUsageEvent(
+            String userId,
+            String featureCode,
+            String productCode,
+            String releaseCode,
+            ActionType actionType,
+            Map<String, Object> contextData,
+            String ipAddress,
+            String userAgent) {
+        // Enrich context with anonymized device fingerprint for anonymous users
+        Map<String, Object> enrichedContext = contextData != null ? new HashMap<>(contextData) : new HashMap<>();
+
+        if (ipAddress != null && userAgent != null) {
+            // Create device fingerprint: hash(device:ip)
+            String deviceFingerprint = createDeviceFingerprint(ipAddress, userAgent);
+            enrichedContext.put("deviceFingerprint", deviceFingerprint);
+
+            // Extract location from IP (placeholder - would use GeoIP service in production)
+            String location = extractLocation(ipAddress);
+            if (location != null) {
+                enrichedContext.put("location", location);
+            }
+        }
+
+        Map<String, Object> contextToPublish = enrichedContext.isEmpty() ? null : enrichedContext;
+        return eventPublisher.publishFeatureUsageEventWithEventId(
+                userId, featureCode, productCode, releaseCode, actionType, contextToPublish, ipAddress, userAgent);
+    }
+
+    private void waitForPersistence(String eventId) {
+        Duration timeout = getReprocessPersistenceTimeout();
+        Duration pollInterval = getReprocessPollInterval();
+        long pollIntervalMs = Math.max(1, pollInterval.toMillis());
+
+        Instant deadline = Instant.now().plus(timeout);
+        while (Instant.now().isBefore(deadline)) {
+            if (featureUsageRepository.existsByEventId(eventId)) {
+                return;
+            }
+            try {
+                Thread.sleep(pollIntervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting for reprocessed event persistence", e);
+            }
+        }
+        throw new IllegalStateException("Timed out waiting for reprocessed event persistence. eventId=" + eventId);
+    }
+
+    private Duration getReprocessPersistenceTimeout() {
+        var reprocessConfig = applicationProperties.reprocess();
+        if (reprocessConfig == null
+                || reprocessConfig.persistenceTimeout() == null
+                || reprocessConfig.persistenceTimeout().isNegative()
+                || reprocessConfig.persistenceTimeout().isZero()) {
+            return DEFAULT_REPROCESS_PERSISTENCE_TIMEOUT;
+        }
+        return reprocessConfig.persistenceTimeout();
+    }
+
+    private Duration getReprocessPollInterval() {
+        var reprocessConfig = applicationProperties.reprocess();
+        if (reprocessConfig == null
+                || reprocessConfig.pollInterval() == null
+                || reprocessConfig.pollInterval().isNegative()
+                || reprocessConfig.pollInterval().isZero()) {
+            return DEFAULT_REPROCESS_POLL_INTERVAL;
+        }
+        return reprocessConfig.pollInterval();
     }
 
     /**

--- a/src/main/java/com/sivalabs/ft/features/domain/HealthMetricsService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/HealthMetricsService.java
@@ -1,0 +1,58 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.HealthMetricsDto;
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class HealthMetricsService {
+    private final FeatureUsageRepository featureUsageRepository;
+    private final ErrorLogRepository errorLogRepository;
+
+    public HealthMetricsService(FeatureUsageRepository featureUsageRepository, ErrorLogRepository errorLogRepository) {
+        this.featureUsageRepository = featureUsageRepository;
+        this.errorLogRepository = errorLogRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public HealthMetricsDto getSystemHealth(Instant startDate, Instant endDate) {
+        // Default to last 7 days if no dates provided
+        if (startDate == null || endDate == null) {
+            endDate = Instant.now();
+            startDate = endDate.minus(7, ChronoUnit.DAYS);
+        }
+
+        // Get successful events from feature_usage
+        long successfulEvents = featureUsageRepository.countByTimestampBetween(startDate, endDate);
+
+        // Get failed events from error_log
+        long failedEvents = errorLogRepository.countByTimestampBetween(startDate, endDate);
+
+        // Total events = successful + failed (error_log contains events that did NOT make it to feature_usage)
+        long totalEvents = successfulEvents + failedEvents;
+
+        // Calculate rates
+        double successRate = totalEvents > 0 ? (successfulEvents * 100.0 / totalEvents) : 100.0;
+        double errorRate = totalEvents > 0 ? (failedEvents * 100.0 / totalEvents) : 0.0;
+
+        // Keep timestamp consistent with the same selected analysis period.
+        Instant lastEventTimestamp = featureUsageRepository.findLatestTimestampBetween(startDate, endDate);
+
+        // Get errors by type
+        Map<ErrorType, Long> errorsByType = new HashMap<>();
+        for (ErrorType errorType : ErrorType.values()) {
+            long count = errorLogRepository.countByErrorTypeAndTimestampBetween(errorType, startDate, endDate);
+            if (count > 0) {
+                errorsByType.put(errorType, count);
+            }
+        }
+
+        return new HealthMetricsDto(
+                totalEvents, failedEvents, successRate, errorRate, lastEventTimestamp, errorsByType);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/ReprocessService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReprocessService.java
@@ -1,0 +1,119 @@
+package com.sivalabs.ft.features.domain;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.api.models.CreateUsageEventPayload;
+import com.sivalabs.ft.features.domain.dtos.ErrorLogDto;
+import com.sivalabs.ft.features.domain.entities.ErrorLog;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import com.sivalabs.ft.features.domain.mappers.ErrorLogMapper;
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReprocessService {
+    private static final Logger log = LoggerFactory.getLogger(ReprocessService.class);
+    private final ErrorLoggingService errorLoggingService;
+    private final FeatureUsageService featureUsageService;
+    private final ErrorLogMapper errorLogMapper;
+    private final ObjectMapper objectMapper;
+
+    public ReprocessService(
+            ErrorLoggingService errorLoggingService,
+            FeatureUsageService featureUsageService,
+            ErrorLogMapper errorLogMapper,
+            ObjectMapper objectMapper) {
+        this.errorLoggingService = errorLoggingService;
+        this.featureUsageService = featureUsageService;
+        this.errorLogMapper = errorLogMapper;
+        this.objectMapper = objectMapper;
+    }
+
+    public ErrorLogDto reprocessSingleError(Long errorLogId) {
+        // Fetch original error log record (404 if not found)
+        ErrorLog originalErrorLog = errorLoggingService
+                .getErrorEntityById(errorLogId)
+                .orElseThrow(() -> new ResourceNotFoundException("Error log not found with id: " + errorLogId));
+
+        String eventPayload = originalErrorLog.getEventPayload();
+        if (eventPayload == null || eventPayload.isBlank()) {
+            // Create new error log for missing payload
+            ErrorLog newErrorLog =
+                    createReprocessingError(originalErrorLog, "Cannot reprocess: event payload is missing", null);
+            return errorLogMapper.toDto(newErrorLog);
+        }
+
+        try {
+            // Parse and validate FeatureUsage payload
+            CreateUsageEventPayload payload = parseFeatureUsagePayload(eventPayload);
+
+            // Try to reprocess via FeatureUsageService
+            String userId = originalErrorLog.getUserId() != null ? originalErrorLog.getUserId() : "anonymous";
+            featureUsageService.logUsageForReprocessing(
+                    userId,
+                    payload.featureCode(),
+                    payload.productCode(),
+                    payload.releaseCode(),
+                    payload.actionType(),
+                    payload.context(),
+                    null,
+                    null);
+
+            // Success: update original record to resolved=true
+            originalErrorLog.setResolved(true);
+            ErrorLog updatedErrorLog = errorLoggingService.saveErrorLog(originalErrorLog);
+            log.info("Successfully reprocessed error log id: {}", errorLogId);
+            return errorLogMapper.toDto(updatedErrorLog);
+
+        } catch (Exception e) {
+            // Failure: create new error log entry
+            log.warn("Failed to reprocess error log id: {}", errorLogId, e);
+            ErrorLog newErrorLog = createReprocessingError(originalErrorLog, e.getMessage(), e);
+            return errorLogMapper.toDto(newErrorLog);
+        }
+    }
+
+    private ErrorLog createReprocessingError(ErrorLog originalErrorLog, String errorMessage, Exception exception) {
+        ErrorLog newErrorLog = new ErrorLog();
+        newErrorLog.setTimestamp(Instant.now());
+        newErrorLog.setErrorType(ErrorType.PROCESSING_ERROR);
+        newErrorLog.setErrorMessage(
+                "Reprocessing failed for error log id " + originalErrorLog.getId() + ": " + errorMessage);
+        newErrorLog.setEventPayload(originalErrorLog.getEventPayload());
+        newErrorLog.setUserId(originalErrorLog.getUserId());
+        newErrorLog.setResolved(false);
+
+        if (exception != null) {
+            java.io.StringWriter sw = new java.io.StringWriter();
+            java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+            exception.printStackTrace(pw);
+            newErrorLog.setStackTrace(sw.toString());
+        }
+
+        return errorLoggingService.saveErrorLog(newErrorLog);
+    }
+
+    private CreateUsageEventPayload parseFeatureUsagePayload(String eventPayload) throws Exception {
+        var root = objectMapper.readTree(eventPayload);
+        if (root == null || !root.isObject()) {
+            throw new IllegalArgumentException("eventPayload must be a single FeatureUsage JSON object");
+        }
+
+        CreateUsageEventPayload payload = objectMapper.treeToValue(root, CreateUsageEventPayload.class);
+        if (payload.actionType() == null) {
+            throw new IllegalArgumentException(
+                    "eventPayload is not a valid FeatureUsage event: actionType is required");
+        }
+        if (isBlank(payload.featureCode()) && isBlank(payload.productCode()) && isBlank(payload.releaseCode())) {
+            throw new IllegalArgumentException(
+                    "eventPayload is not a valid FeatureUsage event: at least one of featureCode/productCode/releaseCode is required");
+        }
+        return payload;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/ErrorLogDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/ErrorLogDto.java
@@ -1,0 +1,14 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.time.Instant;
+
+public record ErrorLogDto(
+        Long id,
+        Instant timestamp,
+        ErrorType errorType,
+        String errorMessage,
+        String stackTrace,
+        String eventPayload,
+        String userId,
+        Boolean resolved) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/HealthMetricsDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/HealthMetricsDto.java
@@ -1,0 +1,13 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.time.Instant;
+import java.util.Map;
+
+public record HealthMetricsDto(
+        Long totalEvents,
+        Long failedEvents,
+        Double successRate,
+        Double errorRate,
+        Instant lastEventTimestamp,
+        Map<ErrorType, Long> errorsByType) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/ErrorLog.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/ErrorLog.java
@@ -1,0 +1,128 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "error_log")
+public class ErrorLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @NotNull @Column(name = "timestamp", nullable = false)
+    private Instant timestamp;
+
+    @NotNull @Column(name = "error_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private ErrorType errorType;
+
+    @NotNull @Column(name = "error_message", nullable = false, columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(name = "stack_trace", columnDefinition = "TEXT")
+    private String stackTrace;
+
+    @Column(name = "event_payload", columnDefinition = "TEXT")
+    private String eventPayload;
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @NotNull @ColumnDefault("false")
+    @Column(name = "resolved", nullable = false)
+    private Boolean resolved = false;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+        if (timestamp == null) {
+            timestamp = Instant.now();
+        }
+        if (resolved == null) {
+            resolved = false;
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    public void setErrorType(ErrorType errorType) {
+        this.errorType = errorType;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(String stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    public String getEventPayload() {
+        return eventPayload;
+    }
+
+    public void setEventPayload(String eventPayload) {
+        this.eventPayload = eventPayload;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public Boolean getResolved() {
+        return resolved;
+    }
+
+    public void setResolved(Boolean resolved) {
+        this.resolved = resolved;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
@@ -76,8 +76,22 @@ public class EventPublisher {
             Map<String, Object> context,
             String ipAddress,
             String userAgent) {
+        publishFeatureUsageEventWithEventId(
+                userId, featureCode, productCode, releaseCode, actionType, context, ipAddress, userAgent);
+    }
+
+    public String publishFeatureUsageEventWithEventId(
+            String userId,
+            String featureCode,
+            String productCode,
+            String releaseCode,
+            ActionType actionType,
+            Map<String, Object> context,
+            String ipAddress,
+            String userAgent) {
+        String eventId = UUID.randomUUID().toString();
         FeatureUsageEvent event = new FeatureUsageEvent(
-                UUID.randomUUID().toString(),
+                eventId,
                 userId,
                 featureCode,
                 productCode,
@@ -88,5 +102,6 @@ public class EventPublisher {
                 ipAddress,
                 userAgent);
         kafkaTemplate.send(properties.events().featureUsage(), event);
+        return eventId;
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/ErrorLogMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/ErrorLogMapper.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.ErrorLogDto;
+import com.sivalabs.ft.features.domain.entities.ErrorLog;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ErrorLogMapper {
+    ErrorLogDto toDto(ErrorLog errorLog);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/ErrorType.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/ErrorType.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum ErrorType {
+    DATABASE_ERROR,
+    PROCESSING_ERROR,
+    UNKNOWN_ERROR
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,8 @@ ft.events.feature-usage=feature_usage_events
 ft.usage-tracking.enabled=true
 ft.usage-tracking.capture-ip=true
 ft.usage-tracking.capture-user-agent=true
+ft.reprocess.persistence-timeout=10s
+ft.reprocess.poll-interval=100ms
 
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}

--- a/src/main/resources/db/migration/V7__create_error_log_table.sql
+++ b/src/main/resources/db/migration/V7__create_error_log_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE error_log (
+    id BIGSERIAL PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL,
+    error_type VARCHAR(50) NOT NULL,
+    error_message TEXT NOT NULL,
+    stack_trace TEXT,
+    event_payload TEXT,
+    user_id VARCHAR(255),
+    resolved BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Single index for date range queries
+CREATE INDEX idx_error_log_timestamp ON error_log(timestamp);
+CREATE INDEX idx_error_log_error_type ON error_log(error_type);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/AdminControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/AdminControllerTests.java
@@ -1,0 +1,859 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.domain.ErrorLogRepository;
+import com.sivalabs.ft.features.domain.FeatureUsageRepository;
+import com.sivalabs.ft.features.domain.entities.ErrorLog;
+import com.sivalabs.ft.features.domain.models.ActionType;
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+/**
+ * Integration tests for AdminController endpoints.
+ * Uses JPA ErrorLogRepository for test data setup (standard persistence pattern).
+ * All assertions performed via API endpoints (true end-to-end).
+ */
+class AdminControllerTests extends AbstractIT {
+
+    @Autowired
+    private ErrorLogRepository errorLogRepository;
+
+    @Autowired
+    private FeatureUsageRepository featureUsageRepository;
+
+    // Helper method using JPA repository (standard persistence pattern)
+    private void insertErrorLog(
+            String errorType, String errorMessage, String stackTrace, String eventPayload, String userId) {
+        ErrorLog errorLog = new ErrorLog();
+        errorLog.setTimestamp(Instant.now());
+        errorLog.setErrorType(ErrorType.valueOf(errorType));
+        errorLog.setErrorMessage(errorMessage);
+        errorLog.setStackTrace(stackTrace);
+        errorLog.setEventPayload(eventPayload);
+        errorLog.setUserId(userId);
+        errorLog.setResolved(false);
+        errorLogRepository.save(errorLog);
+    }
+
+    private Long getLatestErrorLogId() {
+        return errorLogRepository.findAll().stream()
+                .max((e1, e2) -> e1.getCreatedAt().compareTo(e2.getCreatedAt()))
+                .map(ErrorLog::getId)
+                .orElseThrow();
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Clean up error logs before each test (test-data.sql already deletes them)
+        errorLogRepository.deleteAll();
+        featureUsageRepository.deleteAll();
+    }
+
+    private static Stream<Arguments> unauthorizedAdminRequests() {
+        return Stream.of(
+                Arguments.of("GET", "/api/admin/health"),
+                Arguments.of("GET", "/api/admin/errors"),
+                Arguments.of("GET", "/api/admin/errors/1"),
+                Arguments.of("POST", "/api/admin/errors/1/reprocess"));
+    }
+
+    private static Stream<Arguments> adminEndpoints() {
+        return Stream.of(
+                Arguments.of("GET", "/api/admin/health"),
+                Arguments.of("GET", "/api/admin/errors"),
+                Arguments.of("GET", "/api/admin/errors/1"),
+                Arguments.of("POST", "/api/admin/errors/1/reprocess"));
+    }
+
+    private static Stream<Arguments> adminAuthorizedRequests() {
+        return Stream.of(
+                Arguments.of("GET", "/api/admin/health", HttpStatus.OK),
+                Arguments.of("GET", "/api/admin/errors", HttpStatus.OK),
+                Arguments.of("GET", "/api/admin/errors/1", HttpStatus.NOT_FOUND),
+                Arguments.of("POST", "/api/admin/errors/1/reprocess", HttpStatus.NOT_FOUND));
+    }
+
+    private MvcTestResult exchange(String method, String uri) {
+        return switch (method) {
+            case "GET" -> mvc.get().uri(uri).exchange();
+            case "POST" -> mvc.post().uri(uri).exchange();
+            default -> throw new IllegalArgumentException("Unsupported method: " + method);
+        };
+    }
+
+    // ========== Authorization Tests ==========
+
+    @ParameterizedTest
+    @MethodSource("unauthorizedAdminRequests")
+    void shouldReturn401ForAnonymousUserAccessingAdminEndpointsParameterized(String method, String uri) {
+        var result = exchange(method, uri);
+        assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @ParameterizedTest
+    @MethodSource("adminEndpoints")
+    @WithMockOAuth2User(
+            username = "user",
+            roles = {"USER"})
+    void shouldReturn403ForUserRoleAccessingAdminEndpoints(String method, String uri) {
+        var result = exchange(method, uri);
+        assertThat(result).hasStatus(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest
+    @MethodSource("adminEndpoints")
+    @WithMockOAuth2User(
+            username = "manager",
+            roles = {"PRODUCT_MANAGER"})
+    void shouldReturn403ForProductManagerAccessingAdminEndpoints(String method, String uri) {
+        var result = exchange(method, uri);
+        assertThat(result).hasStatus(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest
+    @MethodSource("adminAuthorizedRequests")
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldAllowAdminAccessToAdminEndpoints(String method, String uri, HttpStatus expectedStatus) {
+        var result = exchange(method, uri);
+        assertThat(result).hasStatus(expectedStatus);
+    }
+
+    // ========== Error Logging Tests ==========
+
+    @Test
+    void shouldNotLogUnauthorizedUsageCapture() {
+        var payload =
+                """
+            {
+                "actionType": "FEATURE_VIEWED",
+                "featureCode": "IDEA-1",
+                "productCode": "intellij"
+            }
+            """;
+
+        var result = mvc.post()
+                .uri("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+
+        var errors = errorLogRepository.findAll();
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnUnknownErrorTypeFromAdminErrorsEndpoint() {
+        insertErrorLog("UNKNOWN_ERROR", "Unhandled failure", null, "{\"actionType\":\"FEATURE_VIEWED\"}", "user1");
+
+        var result = mvc.get().uri("/api/admin/errors?errorType=UNKNOWN_ERROR").exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content.size()")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content[0].errorType")
+                .asString()
+                .isEqualTo("UNKNOWN_ERROR");
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "user",
+            roles = {"USER"})
+    void shouldNotLogValidationErrorForUsageCapture() {
+        var payload =
+                """
+            {
+                "featureCode": "IDEA-1",
+                "productCode": "intellij"
+            }
+            """;
+
+        var result = mvc.post()
+                .uri("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+
+        // In the reprocessable-only contract, capture-level validation errors are not written to error_log.
+        var errors = errorLogRepository.findAll();
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldNotPersistCapturePayloadForInvalidUsageRequest() {
+        // Invalid actionType should fail usage capture validation but not create error_log entries.
+        var payload =
+                """
+            {
+                "actionType": "INVALID_ACTION",
+                "featureCode": "IDEA-1",
+                "productCode": "intellij"
+            }
+            """;
+
+        var result = mvc.post()
+                .uri("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+
+        var errors = errorLogRepository.findAll();
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldLogDatabaseErrorWithPayloadCaptureForUsageProcessing() {
+        String longFeatureCode = "F".repeat(120);
+        String payload =
+                """
+            {
+                "actionType": "FEATURE_VIEWED",
+                "featureCode": "%s",
+                "productCode": "intellij"
+            }
+            """
+                        .formatted(longFeatureCode);
+
+        var result = mvc.post()
+                .uri("/api/usage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.ACCEPTED);
+
+        await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            var errors = errorLogRepository.findAll();
+            assertThat(errors).anySatisfy(error -> {
+                assertThat(error.getErrorType()).isEqualTo(ErrorType.DATABASE_ERROR);
+                assertThat(error.getEventPayload()).contains(longFeatureCode);
+            });
+        });
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "user",
+            roles = {"USER"})
+    void shouldNotLogNonUsageEndpointErrors() {
+        var result = mvc.get().uri("/api/admin/health").exchange();
+        assertThat(result).hasStatus(HttpStatus.FORBIDDEN);
+
+        var errors = errorLogRepository.findAll();
+        assertThat(errors).isEmpty();
+    }
+
+    // ========== Error Management Tests ==========
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldGetErrorsWithPagination() {
+        // Create multiple error logs
+        for (int i = 0; i < 25; i++) {
+            insertErrorLog("PROCESSING_ERROR", "Error " + i, null, "payload" + i, "user" + i);
+        }
+
+        var result = mvc.get().uri("/api/admin/errors?page=0&size=10").exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content.size()")
+                .asNumber()
+                .isEqualTo(10);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.totalElements")
+                .asNumber()
+                .isEqualTo(25);
+        assertThat(result).bodyJson().extractingPath("$.totalPages").asNumber().isEqualTo(3);
+        assertThat(result).bodyJson().extractingPath("$.number").asNumber().isEqualTo(0);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldFilterErrorsByErrorType() {
+        insertErrorLog("UNKNOWN_ERROR", "Unknown", null, null, "user1");
+        insertErrorLog("DATABASE_ERROR", "Database", null, null, "user2");
+        insertErrorLog("PROCESSING_ERROR", "Processing", null, null, "user3");
+
+        var result =
+                mvc.get().uri("/api/admin/errors?errorType=PROCESSING_ERROR").exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content.size()")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content[0].errorType")
+                .asString()
+                .isEqualTo("PROCESSING_ERROR");
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldFilterByCombinedErrorTypeAndDateRange() {
+        // Test combined filtering by errorType + dateRange
+        Instant endDate = Instant.now().plus(1, ChronoUnit.HOURS);
+        Instant startDate = Instant.now().minus(2, ChronoUnit.DAYS);
+
+        // Create errors of different types
+        insertErrorLog("UNKNOWN_ERROR", "Unknown 1", null, null, "user1");
+        insertErrorLog("PROCESSING_ERROR", "Validation 2", null, null, "user2");
+        insertErrorLog("DATABASE_ERROR", "Database error", null, null, "user3");
+        insertErrorLog("PROCESSING_ERROR", "Processing error", null, null, "user4");
+
+        // Filter by PROCESSING_ERROR type within date range
+        var result = mvc.get()
+                .uri("/api/admin/errors?errorType=PROCESSING_ERROR&startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content.size()")
+                .asNumber()
+                .isEqualTo(2);
+
+        // Verify all returned errors are PROCESSING_ERROR type
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content[0].errorType")
+                .asString()
+                .isEqualTo("PROCESSING_ERROR");
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content[1].errorType")
+                .asString()
+                .isEqualTo("PROCESSING_ERROR");
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldFilterErrorsByDateRange() {
+        Instant endDate = Instant.now().plus(1, ChronoUnit.HOURS);
+        Instant startDate = Instant.now().minus(2, ChronoUnit.DAYS);
+
+        // Create errors with current timestamps
+        insertErrorLog("PROCESSING_ERROR", "Recent error", null, null, "user1");
+
+        var result = mvc.get()
+                .uri("/api/admin/errors?startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        // Should return exactly 1 error that we just created (БД очищена в @BeforeEach)
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content.size()")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content[0].errorMessage")
+                .asString()
+                .isEqualTo("Recent error");
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400ForInvalidDateRangeOnErrorsEndpoint() {
+        Instant startDate = Instant.now();
+        Instant endDate = Instant.now().minus(1, ChronoUnit.DAYS);
+        var result = mvc.get()
+                .uri("/api/admin/errors?startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400WhenOnlyStartDateProvidedOnErrorsEndpoint() {
+        Instant startDate = Instant.now().minus(1, ChronoUnit.DAYS);
+        var result =
+                mvc.get().uri("/api/admin/errors?startDate={start}", startDate).exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400WhenOnlyEndDateProvidedOnErrorsEndpoint() {
+        Instant endDate = Instant.now();
+        var result = mvc.get().uri("/api/admin/errors?endDate={end}", endDate).exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400ForInvalidErrorTypeOnErrorsFilter() {
+        var result =
+                mvc.get().uri("/api/admin/errors?errorType=INVALID_ERROR_TYPE").exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldVerifyResolvedFieldDefaultsToFalse() {
+        // Test that resolved field defaults to false for new error logs
+        insertErrorLog("PROCESSING_ERROR", "Test error", null, null, "user1");
+
+        // Verify via API (no direct DB access)
+        var result = mvc.get().uri("/api/admin/errors").exchange();
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.totalElements")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content[0].resolved")
+                .asBoolean()
+                .isFalse();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldGetErrorById() {
+        insertErrorLog("PROCESSING_ERROR", "Test error", null, "payload", "testuser");
+
+        // Get error ID via SQL from requirements (table: error_log, fields from requirements)
+        Long errorId = getLatestErrorLogId();
+
+        var result = mvc.get().uri("/api/admin/errors/{id}", errorId).exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().satisfies(id -> {
+            assertThat(id.longValue()).isEqualTo(errorId);
+        });
+        assertThat(result).bodyJson().extractingPath("$.errorType").asString().isEqualTo("PROCESSING_ERROR");
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorMessage")
+                .asString()
+                .isEqualTo("Test error");
+        assertThat(result).bodyJson().extractingPath("$.userId").asString().isEqualTo("testuser");
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isFalse();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnFullErrorLogDtoDetailsById() {
+        String stackTrace = "java.lang.RuntimeException: boom";
+        String payload = "{\"actionType\":\"FEATURE_VIEWED\",\"featureCode\":\"IDEA-1\"}";
+        insertErrorLog("PROCESSING_ERROR", "Processing failed", stackTrace, payload, "full-details-user");
+        Long errorId = getLatestErrorLogId();
+
+        var result = mvc.get().uri("/api/admin/errors/{id}", errorId).exchange();
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().isEqualTo(errorId.intValue());
+        assertThat(result).bodyJson().extractingPath("$.timestamp").asString().isNotBlank();
+        assertThat(result).bodyJson().extractingPath("$.errorType").asString().isEqualTo("PROCESSING_ERROR");
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorMessage")
+                .asString()
+                .isEqualTo("Processing failed");
+        assertThat(result).bodyJson().extractingPath("$.stackTrace").asString().contains("RuntimeException");
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.eventPayload")
+                .asString()
+                .contains("FEATURE_VIEWED");
+        assertThat(result).bodyJson().extractingPath("$.userId").asString().isEqualTo("full-details-user");
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isFalse();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn404WhenErrorNotFound() {
+        var result = mvc.get().uri("/api/admin/errors/99999").exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldSortErrorsByTimestampDesc() throws InterruptedException {
+        insertErrorLog("PROCESSING_ERROR", "First", null, null, "user1");
+        Thread.sleep(100); // Ensure different timestamps
+        insertErrorLog("PROCESSING_ERROR", "Second", null, null, "user2");
+
+        var result = mvc.get().uri("/api/admin/errors").exchange();
+
+        assertThat(result).hasStatusOk();
+        // Most recent should be first (Second)
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content[0].errorMessage")
+                .asString()
+                .isEqualTo("Second");
+    }
+
+    // ========== Reprocessing Tests ==========
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldSuccessfullyReprocessValidError() {
+        // Reprocessing is supported only for eventPayload that is a valid single FeatureUsage JSON object.
+        // Create a valid usage event payload (raw JSON, no internal models)
+        String eventPayload =
+                """
+            {
+                "actionType": "FEATURE_VIEWED",
+                "featureCode": "IDEA-1",
+                "productCode": "intellij"
+            }
+            """;
+
+        // Create an error log with valid payload
+        insertErrorLog("PROCESSING_ERROR", "Test error", null, eventPayload, "testuser");
+
+        // Get ID via SQL
+        Long errorId = getLatestErrorLogId();
+
+        var result = mvc.post().uri("/api/admin/errors/{id}/reprocess", errorId).exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().satisfies(id -> {
+            assertThat(id.longValue()).isEqualTo(errorId);
+        });
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isTrue();
+    }
+
+    // Note: Failed reprocessing scenario is covered by shouldHandleReprocessingErrorWithMissingPayload test
+    // which validates that missing payload creates a new error log entry with resolved=false
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn404WhenReprocessingNonexistentError() {
+        var result = mvc.post().uri("/api/admin/errors/99999/reprocess").exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldHandleReprocessingErrorWithMissingPayload() {
+        // Create error log without event payload
+        insertErrorLog("PROCESSING_ERROR", "Test error", null, null, "testuser");
+
+        // Get ID via SQL
+        Long errorId = getLatestErrorLogId();
+
+        var result = mvc.post().uri("/api/admin/errors/{id}/reprocess", errorId).exchange();
+
+        assertThat(result).hasStatusOk();
+        // Failed reprocessing creates new error log (from requirements)
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isFalse();
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().satisfies(id -> {
+            assertThat(id.longValue()).isNotEqualTo(errorId); // New record created
+        });
+        assertThat(result).bodyJson().extractingPath("$.errorType").asString().isEqualTo("PROCESSING_ERROR");
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldCreateNewErrorLogWhenReprocessingInvalidJsonPayload() {
+        // Reprocessing is supported only for eventPayload that is a valid single FeatureUsage JSON object.
+        String invalidPayload = "{\"actionType\":\"FEATURE_VIEWED\",";
+        insertErrorLog("PROCESSING_ERROR", "Original error", null, invalidPayload, "bad-json-user");
+        Long originalId = getLatestErrorLogId();
+
+        var result =
+                mvc.post().uri("/api/admin/errors/{id}/reprocess", originalId).exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isFalse();
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().satisfies(id -> {
+            assertThat(id.longValue()).isNotEqualTo(originalId);
+        });
+
+        var original = errorLogRepository.findById(originalId).orElseThrow();
+        assertThat(original.getResolved()).isFalse();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldCreateNewErrorLogWhenReprocessingPayloadWithInvalidActionType() {
+        String invalidActionPayload =
+                """
+            {
+                "actionType": "INVALID_ACTION",
+                "featureCode": "IDEA-1",
+                "productCode": "intellij"
+            }
+            """;
+        insertErrorLog("PROCESSING_ERROR", "Original error", null, invalidActionPayload, "bad-action-user");
+        Long originalId = getLatestErrorLogId();
+
+        var result =
+                mvc.post().uri("/api/admin/errors/{id}/reprocess", originalId).exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isFalse();
+        assertThat(result).bodyJson().extractingPath("$.errorType").asString().isEqualTo("PROCESSING_ERROR");
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().satisfies(id -> {
+            assertThat(id.longValue()).isNotEqualTo(originalId);
+        });
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldCreateNewErrorLogWhenReprocessingArrayPayload() {
+        // Reprocessing is supported only for eventPayload that is a valid single FeatureUsage JSON object.
+        String arrayPayload =
+                """
+            [
+                {
+                    "actionType": "FEATURE_VIEWED",
+                    "featureCode": "IDEA-1",
+                    "productCode": "intellij"
+                }
+            ]
+            """;
+        insertErrorLog("PROCESSING_ERROR", "Original error", null, arrayPayload, "array-user");
+        Long originalId = getLatestErrorLogId();
+
+        var result =
+                mvc.post().uri("/api/admin/errors/{id}/reprocess", originalId).exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isFalse();
+        assertThat(result).bodyJson().extractingPath("$.errorType").asString().isEqualTo("PROCESSING_ERROR");
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().satisfies(id -> {
+            assertThat(id.longValue()).isNotEqualTo(originalId);
+        });
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldCreateNewErrorLogWhenReprocessingPayloadWithoutTargetCodes() {
+        // actionType alone is not enough for meaningful feature-usage reprocessing.
+        // At least one target dimension (featureCode/productCode/releaseCode) is required.
+        String payloadWithoutTargetCodes =
+                """
+            {
+                "actionType": "FEATURE_VIEWED"
+            }
+            """;
+        insertErrorLog("PROCESSING_ERROR", "Original error", null, payloadWithoutTargetCodes, "no-codes-user");
+        Long originalId = getLatestErrorLogId();
+
+        var result =
+                mvc.post().uri("/api/admin/errors/{id}/reprocess", originalId).exchange();
+
+        // Reprocessing failure must keep the original unresolved and create a new PROCESSING_ERROR entry.
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isFalse();
+        assertThat(result).bodyJson().extractingPath("$.errorType").asString().isEqualTo("PROCESSING_ERROR");
+        assertThat(result).bodyJson().extractingPath("$.id").asNumber().satisfies(id -> {
+            assertThat(id.longValue()).isNotEqualTo(originalId);
+        });
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldAllowMultipleReprocessingAttempts() {
+        // Create valid payload (raw JSON)
+        String eventPayload =
+                """
+            {
+                "actionType": "FEATURE_CREATED",
+                "featureCode": "IDEA-2",
+                "productCode": "intellij"
+            }
+            """;
+
+        insertErrorLog("PROCESSING_ERROR", "Test error", null, eventPayload, "testuser");
+
+        // Get ID via SQL
+        Long errorId = getLatestErrorLogId();
+        long initialUsageCount = featureUsageRepository.count();
+
+        // First reprocessing attempt
+        var result1 =
+                mvc.post().uri("/api/admin/errors/{id}/reprocess", errorId).exchange();
+        assertThat(result1).hasStatusOk();
+        assertThat(result1).bodyJson().extractingPath("$.id").asNumber().isEqualTo(errorId.intValue());
+        assertThat(result1).bodyJson().extractingPath("$.resolved").asBoolean().isTrue();
+
+        // Second reprocessing attempt (should work even if already resolved)
+        var result2 =
+                mvc.post().uri("/api/admin/errors/{id}/reprocess", errorId).exchange();
+        assertThat(result2).hasStatusOk();
+        assertThat(result2).bodyJson().extractingPath("$.id").asNumber().isEqualTo(errorId.intValue());
+        assertThat(result2).bodyJson().extractingPath("$.resolved").asBoolean().isTrue();
+
+        await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            long finalUsageCount = featureUsageRepository.count();
+            assertThat(finalUsageCount).isEqualTo(initialUsageCount + 2);
+        });
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldCreateCompleteAuditTrailForReprocessing() {
+        // Create valid payload (raw JSON)
+        String eventPayload =
+                """
+            {
+                "actionType": "FEATURE_VIEWED",
+                "featureCode": "IDEA-1",
+                "productCode": "intellij"
+            }
+            """;
+
+        insertErrorLog("PROCESSING_ERROR", "Original error", null, eventPayload, "testuser");
+
+        // Get ID via SQL
+        Long originalErrorId = getLatestErrorLogId();
+        long errorsBeforeReprocess = errorLogRepository.count();
+
+        // Reprocess
+        var reprocessResult = mvc.post()
+                .uri("/api/admin/errors/{id}/reprocess", originalErrorId)
+                .exchange();
+        assertThat(reprocessResult).hasStatusOk();
+        assertThat(reprocessResult).bodyJson().extractingPath("$.id").asNumber().isEqualTo(originalErrorId.intValue());
+        assertThat(reprocessResult)
+                .bodyJson()
+                .extractingPath("$.resolved")
+                .asBoolean()
+                .isTrue();
+        assertThat(errorLogRepository.count()).isEqualTo(errorsBeforeReprocess);
+
+        // Verify audit trail via API (not direct DB access)
+        var result = mvc.get().uri("/api/admin/errors/{id}", originalErrorId).exchange();
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isTrue();
+        assertThat(result).bodyJson().extractingPath("$.timestamp").isNotNull();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldActuallyReprocessEventAndCreateFeatureUsageRecord() {
+        // 1. Create error log with valid usage event payload
+        String eventPayload =
+                """
+            {
+                "userId": "testuser",
+                "featureCode": "IDEA-1",
+                "productCode": "intellij",
+                "actionType": "FEATURE_VIEWED"
+            }
+            """;
+
+        insertErrorLog("PROCESSING_ERROR", "Failed to process usage event", null, eventPayload, "testuser");
+        Long errorId = getLatestErrorLogId();
+
+        // 2. Count initial feature_usage records
+        long initialUsageCount = featureUsageRepository.count();
+
+        // 3. Reprocess the error
+        var result = mvc.post().uri("/api/admin/errors/{id}/reprocess", errorId).exchange();
+
+        // 4. Verify reprocessing was marked as successful
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.resolved").asBoolean().isTrue();
+
+        // 5. **KEY ASSERTION:** Verify new feature_usage record was actually created
+        await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            long finalUsageCount = featureUsageRepository.count();
+            assertThat(finalUsageCount).isEqualTo(initialUsageCount + 1);
+        });
+
+        // 6. Verify the created record has correct data
+        var usageRecords = featureUsageRepository.findAll();
+        var newRecord = usageRecords.get(usageRecords.size() - 1);
+        assertThat(newRecord.getUserId()).isEqualTo("testuser");
+        assertThat(newRecord.getFeatureCode()).isEqualTo("IDEA-1");
+        assertThat(newRecord.getProductCode()).isEqualTo("intellij");
+        assertThat(newRecord.getActionType()).isEqualTo(ActionType.FEATURE_VIEWED);
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/AdminHealthMetricsTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/AdminHealthMetricsTests.java
@@ -1,0 +1,352 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.domain.ErrorLogRepository;
+import com.sivalabs.ft.features.domain.FeatureUsageRepository;
+import com.sivalabs.ft.features.domain.entities.ErrorLog;
+import com.sivalabs.ft.features.domain.entities.FeatureUsage;
+import com.sivalabs.ft.features.domain.models.ActionType;
+import com.sivalabs.ft.features.domain.models.ErrorType;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class AdminHealthMetricsTests extends AbstractIT {
+
+    @Autowired
+    private ErrorLogRepository errorLogRepository;
+
+    @Autowired
+    private FeatureUsageRepository featureUsageRepository;
+
+    private void insertErrorLog(
+            String errorType, String errorMessage, String stackTrace, String eventPayload, String userId) {
+        insertErrorLog(errorType, errorMessage, stackTrace, eventPayload, userId, Instant.now());
+    }
+
+    private void insertErrorLog(
+            String errorType,
+            String errorMessage,
+            String stackTrace,
+            String eventPayload,
+            String userId,
+            Instant timestamp) {
+        ErrorLog errorLog = new ErrorLog();
+        errorLog.setTimestamp(timestamp);
+        errorLog.setErrorType(ErrorType.valueOf(errorType));
+        errorLog.setErrorMessage(errorMessage);
+        errorLog.setStackTrace(stackTrace);
+        errorLog.setEventPayload(eventPayload);
+        errorLog.setUserId(userId);
+        errorLog.setResolved(false);
+        errorLogRepository.save(errorLog);
+    }
+
+    private void insertFeatureUsage(String userId, ActionType actionType, Instant timestamp) {
+        FeatureUsage featureUsage = new FeatureUsage();
+        featureUsage.setUserId(userId);
+        featureUsage.setActionType(actionType);
+        featureUsage.setTimestamp(timestamp);
+        featureUsage.setFeatureCode("TEST-FEATURE");
+        featureUsage.setProductCode("test-product");
+        featureUsageRepository.save(featureUsage);
+    }
+
+    @BeforeEach
+    void setUp() {
+        errorLogRepository.deleteAll();
+        featureUsageRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnExpectedHealthMetricsPayload() {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant olderUsage = now.minus(2, ChronoUnit.HOURS);
+        Instant newerUsage = now.minus(1, ChronoUnit.HOURS);
+        insertFeatureUsage("user-a", ActionType.FEATURE_VIEWED, olderUsage);
+        insertFeatureUsage("user-b", ActionType.FEATURE_VIEWED, newerUsage);
+
+        insertErrorLog("PROCESSING_ERROR", "Error 1", null, null, "user1");
+        insertErrorLog("DATABASE_ERROR", "Error 2", null, null, "user2");
+
+        long successfulEvents = 2;
+        long failedEvents = 2;
+        long totalEvents = successfulEvents + failedEvents;
+        double expectedSuccessRate = (successfulEvents * 100.0) / totalEvents;
+        double expectedErrorRate = (failedEvents * 100.0) / totalEvents;
+
+        var result = mvc.get().uri("/api/admin/health").exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.totalEvents").asNumber().satisfies(count -> {
+            assertThat(count.longValue()).isEqualTo(totalEvents);
+        });
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.failedEvents")
+                .asNumber()
+                .satisfies(count -> {
+                    assertThat(count.longValue()).isEqualTo(failedEvents);
+                });
+        assertThat(result).bodyJson().extractingPath("$.successRate").asNumber().satisfies(rate -> {
+            assertThat(rate.doubleValue()).isCloseTo(expectedSuccessRate, org.assertj.core.data.Offset.offset(0.001));
+        });
+        assertThat(result).bodyJson().extractingPath("$.errorRate").asNumber().satisfies(rate -> {
+            assertThat(rate.doubleValue()).isCloseTo(expectedErrorRate, org.assertj.core.data.Offset.offset(0.001));
+        });
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.lastEventTimestamp")
+                .asString()
+                .startsWith(newerUsage.toString().substring(0, 19));
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.PROCESSING_ERROR")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.DATABASE_ERROR")
+                .asNumber()
+                .isEqualTo(1);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldCalculateSuccessRateCorrectly() {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        insertFeatureUsage("u1", ActionType.FEATURE_VIEWED, now.minus(4, ChronoUnit.HOURS));
+        insertFeatureUsage("u2", ActionType.FEATURE_VIEWED, now.minus(3, ChronoUnit.HOURS));
+        insertFeatureUsage("u3", ActionType.FEATURE_VIEWED, now.minus(2, ChronoUnit.HOURS));
+        Instant latestUsage = now.minus(1, ChronoUnit.HOURS);
+        insertFeatureUsage("u4", ActionType.FEATURE_VIEWED, latestUsage);
+
+        insertErrorLog("PROCESSING_ERROR", "Error 1", null, null, "user1");
+
+        long successfulEvents = 4;
+        long failedEvents = 1;
+        long totalEvents = successfulEvents + failedEvents;
+        double expectedErrorRate = (failedEvents * 100.0) / totalEvents;
+        double expectedSuccessRate = (successfulEvents * 100.0) / totalEvents;
+
+        var result = mvc.get().uri("/api/admin/health").exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result).bodyJson().extractingPath("$.totalEvents").asNumber().satisfies(count -> {
+            assertThat(count.longValue()).isEqualTo(totalEvents);
+        });
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.failedEvents")
+                .asNumber()
+                .satisfies(count -> {
+                    assertThat(count.longValue()).isEqualTo(failedEvents);
+                });
+        assertThat(result).bodyJson().extractingPath("$.successRate").asNumber().satisfies(rate -> {
+            assertThat(rate.doubleValue()).isCloseTo(expectedSuccessRate, org.assertj.core.data.Offset.offset(0.001));
+        });
+        assertThat(result).bodyJson().extractingPath("$.errorRate").asNumber().satisfies(rate -> {
+            assertThat(rate.doubleValue()).isCloseTo(expectedErrorRate, org.assertj.core.data.Offset.offset(0.001));
+        });
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.lastEventTimestamp")
+                .asString()
+                .startsWith(latestUsage.toString().substring(0, 19));
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400ForInvalidDateRangeOnHealthEndpoint() {
+        Instant startDate = Instant.now();
+        Instant endDate = Instant.now().minus(1, ChronoUnit.DAYS);
+
+        var result = mvc.get()
+                .uri("/api/admin/health?startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400WhenOnlyStartDateProvidedOnHealthEndpoint() {
+        Instant startDate = Instant.now().minus(1, ChronoUnit.DAYS);
+        var result =
+                mvc.get().uri("/api/admin/health?startDate={start}", startDate).exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400WhenOnlyEndDateProvidedOnHealthEndpoint() {
+        Instant endDate = Instant.now();
+        var result = mvc.get().uri("/api/admin/health?endDate={end}", endDate).exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnHealthMetricsWithCustomDateRange() {
+        Instant now = Instant.now();
+        insertErrorLog("PROCESSING_ERROR", "Recent error", null, null, "user1", now.minus(1, ChronoUnit.HOURS));
+        insertErrorLog("DATABASE_ERROR", "Old error", null, null, "user2", now.minus(10, ChronoUnit.DAYS));
+
+        Instant startDate = now.minus(1, ChronoUnit.DAYS);
+        Instant endDate = now.plus(1, ChronoUnit.HOURS);
+
+        var result = mvc.get()
+                .uri("/api/admin/health?startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.failedEvents")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.PROCESSING_ERROR")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result).bodyJson().extractingPath("$.errorsByType").asMap().doesNotContainKey("DATABASE_ERROR");
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldGroupErrorsByType() {
+        insertErrorLog("PROCESSING_ERROR", "Validation 1", null, null, "user1");
+        insertErrorLog("PROCESSING_ERROR", "Validation 2", null, null, "user1");
+        insertErrorLog("DATABASE_ERROR", "DB Error", null, null, "user2");
+        insertErrorLog("UNKNOWN_ERROR", "Unknown", null, null, "user3");
+
+        var result = mvc.get().uri("/api/admin/health").exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.failedEvents")
+                .asNumber()
+                .isEqualTo(4);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.PROCESSING_ERROR")
+                .asNumber()
+                .isEqualTo(2);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.DATABASE_ERROR")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.UNKNOWN_ERROR")
+                .asNumber()
+                .isEqualTo(1);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnAllSupportedErrorTypesInHealthMetrics() {
+        insertErrorLog("PROCESSING_ERROR", "Validation", null, null, "user1");
+        insertErrorLog("DATABASE_ERROR", "Database", null, null, "user2");
+        insertErrorLog("PROCESSING_ERROR", "Processing", null, null, "user3");
+        insertErrorLog("UNKNOWN_ERROR", "Unknown", null, null, "user4");
+
+        var result = mvc.get().uri("/api/admin/health").exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.failedEvents")
+                .asNumber()
+                .isEqualTo(4);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.PROCESSING_ERROR")
+                .asNumber()
+                .isEqualTo(2);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.UNKNOWN_ERROR")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.errorsByType.DATABASE_ERROR")
+                .asNumber()
+                .isEqualTo(1);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnMostRecentLastEventTimestamp() {
+        Instant older = Instant.now().minus(2, ChronoUnit.DAYS);
+        Instant newer = Instant.now().minus(1, ChronoUnit.HOURS);
+        insertFeatureUsage("u1", ActionType.FEATURE_VIEWED, older);
+        insertFeatureUsage("u2", ActionType.FEATURE_VIEWED, newer);
+
+        var result = mvc.get().uri("/api/admin/health").exchange();
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.lastEventTimestamp")
+                .asString()
+                .startsWith(newer.toString().substring(0, 19));
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldCalculateLastEventTimestampWithinRequestedPeriod() {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant outsidePeriod = now.minus(10, ChronoUnit.DAYS);
+        Instant insidePeriodOlder = now.minus(2, ChronoUnit.DAYS);
+        Instant insidePeriodNewer = now.minus(1, ChronoUnit.HOURS);
+
+        insertFeatureUsage("u-outside", ActionType.FEATURE_VIEWED, outsidePeriod);
+        insertFeatureUsage("u-inside-1", ActionType.FEATURE_VIEWED, insidePeriodOlder);
+        insertFeatureUsage("u-inside-2", ActionType.FEATURE_VIEWED, insidePeriodNewer);
+
+        Instant startDate = now.minus(3, ChronoUnit.DAYS);
+        Instant endDate = now;
+
+        var result = mvc.get()
+                .uri("/api/admin/health?startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.lastEventTimestamp")
+                .asString()
+                .startsWith(insidePeriodNewer.toString().substring(0, 19));
+    }
+}


### PR DESCRIPTION
Prerequisites: Subtask #144  must be completed before starting this task

#Admin Event Monitoring and Reprocessing

Issue #145

## Objective
Provide admin tools for monitoring system health, reviewing errors, and manually reprocessing failed events.

---

## Requirements

### Error Logging and Tracking
- Log failures in processing usage events (Kafka publish/consume/persistence and reprocessing paths).
- Authorization failures (401/403) are not logged to `error_log`.
- Track error types for processing pipeline: database errors, processing exceptions, unknown errors.
- Store error context: `timestamp`, `errorType`, `errorMessage`, `stackTrace`, `eventPayload`.
- Support pagination and filtering of error logs.
- Audit trail with resolved tracking: successful reprocessing updates `resolved=true`, failures create new entries.

**Error Types:** `DATABASE_ERROR`, `PROCESSING_ERROR`, `UNKNOWN_ERROR`

**Data Model:** Create a JPA entity `ErrorLog` (mapped to table `error_log`) with fields:
- `id` (Long, auto-generated)
- `timestamp` (Instant, not null)
- `errorType` (ErrorType enum, not null)
- `errorMessage` (String/TEXT, not null)
- `stackTrace` (String/TEXT, nullable)
- `eventPayload` (String/TEXT, nullable)
- `userId` (String, nullable)
- `resolved` (Boolean, default false, not null)
- `createdAt` (Instant, default CURRENT_TIMESTAMP, not null)

`eventPayload` should contain original FeatureUsage event payload when available and may be `null` for non-reprocessable/legacy records.

#### Error Management API Endpoints
- `GET /api/admin/errors` with `page`, `size`, `errorType`, `startDate`, `endDate` Returns: `Page<ErrorLogDto>`
- `GET /api/admin/errors/{id}` Returns: `ErrorLogDto` (full details)

### Admin Dashboard Health Metrics
- Calculate system health indicators from usage data and error logs.
- Track: `totalEvents`, `failedEvents`, `successRate`, `errorRate`.
- Track `lastEventTimestamp` to verify system activity.

#### Health Monitoring API Endpoint
- `GET /api/admin/health` with optional `startDate`, `endDate`
- Default period: last 7 days if no params provided
- Custom period: explicit `startDate` + `endDate`
- Data source: `feature_usage` (total events) and `error_log` (failed events) within selected period
- Returns: `HealthMetricsDto`

### Manual Reprocessing for Single Failed Event
- Reprocess a single failed FeatureUsage event from `error_log` by ID.
- For existing records, returns `200 OK` with `ErrorLogDto` showing reprocessing result.
- Creates audit trail of reprocessing attempts.

#### Reprocessing API Endpoint
- `POST /api/admin/errors/{id}/reprocess`

**HTTP Contract**
- `200 OK` with `ErrorLogDto` for existing `errorLogId` (both success and failed reprocess attempts)
- `404 Not Found` only if original `errorLogId` does not exist

**Reprocessing Logic:**
1. Find `error_log` record by ID (`404` if not found)
2. Parse `eventPayload` as a single FeatureUsage JSON object and retry via `FeatureUsageService`
3. If success: update original record `resolved=true`, return updated record
4. If failure create new `error_log` entry with `PROCESSING_ERROR` (`resolved=false`), return new record

### Authorization
All `/api/admin/*` endpoints require ADMIN role (`403` for USER, PRODUCT_MANAGER).

### Error Handling
- `400 Bad Request`: invalid date range, missing required fields, invalid `errorType`
- `404 Not Found`: error log ID not found
- `403 Forbidden`: non-ADMIN access to admin endpoints

### DTO Structures
**Error Log DTO**
```json
{
  "id": 123,
  "timestamp": "2026-01-10T09:00:00Z",
  "errorType": "PROCESSING_ERROR",
  "errorMessage": "Failed to process usage event",
  "stackTrace": "...",
  "eventPayload": "{\"actionType\":\"FEATURE_VIEWED\",...}",
  "userId": "user123",
  "resolved": false
}
```

**Health Metrics DTO**
```json
{
  "totalEvents": 10000,
  "failedEvents": 25,
  "successRate": 99.75,
  "errorRate": 0.25,
  "lastEventTimestamp": "2026-01-10T09:30:00Z",
  "errorsByType": {
    "DATABASE_ERROR": 5,
    "PROCESSING_ERROR": 18,
    "UNKNOWN_ERROR": 2
  }
}
```

---

## Test Coverage

**Error Logging:**
- Processing errors logged with `PROCESSING_ERROR`
- Database exceptions logged with `DATABASE_ERROR`
- Unknown pipeline failures logged with `UNKNOWN_ERROR`
- For processing failures, `eventPayload` is stored when available

**Health Dashboard:**
- Success rate calculated correctly
- Error counts by type are accurate
- Last event timestamp reflects most recent activity

**Reprocessing:**
- Successful reprocess returns `200 OK` with `resolved=true`
- Failed reprocess returns `200 OK` with new `resolved=false` record
- Invalid error log IDs return `404`
- Safe repeated retries are allowed
- Audit trail: success updates original, failure creates new record

**Authorization:**
- ADMIN accesses all admin endpoints; others get `403`

---

## Acceptance Criteria

- Processing failures of FeatureUsage events are logged to `error_log` with supported error types.
- Admin health dashboard returns correct totals/rates and `errorsByType` breakdown.
- `POST /api/admin/errors/{id}/reprocess` supports single-event reprocessing with audit trail: successful reprocess sets original `resolved=true`; failed reprocess creates new `PROCESSING_ERROR` record.
- Reprocess endpoint returns `200 OK` for existing records and `404` only when `errorLogId` does not exist.
- Admin endpoints enforce role-based access (`ADMIN` only; `403` for other authenticated roles).
- Error logs support pagination and filtering by `errorType` and date range.

FAIL_TO_PASS: com.sivalabs.ft.features.api.controllers.AdminControllerTests, com.sivalabs.ft.features.api.controllers.AdminHealthMetricsTests