### PR TITLE
fix: reject inverted date range in GET releases-by-date-range endpoint #233

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -37,6 +38,15 @@ class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException.class)
     ProblemDetail handle(BadRequestException e) {
         log.error("Bad Request", e);
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    ProblemDetail handle(MissingServletRequestParameterException e) {
+        log.error("Missing Request Parameter", e);
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
         problemDetail.setTitle("Bad Request");
         problemDetail.setProperty("timestamp", Instant.now());

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
@@ -57,6 +57,7 @@ public class ReleaseService {
             Instant endDate,
             int page,
             int size) {
+        validateDateRange(startDate, endDate);
         Pageable pageable = PageRequest.of(page, size);
         Specification<Release> spec = buildSpecification(productCode, status, owner, startDate, endDate);
         var pageResult = releaseRepository.findAll(spec, pageable);
@@ -110,9 +111,16 @@ public class ReleaseService {
 
     @Transactional(readOnly = true)
     public List<ReleaseDto> findReleasesByDateRange(Instant startDate, Instant endDate) {
+        validateDateRange(startDate, endDate);
         return releaseRepository.findByPlannedReleaseDateBetween(startDate, endDate).stream()
                 .map(releaseMapper::toDto)
                 .toList();
+    }
+
+    private void validateDateRange(Instant startDate, Instant endDate) {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw new BadRequestException("startDate cannot be after endDate");
+        }
     }
 
     @Transactional

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseControllerTests.java
@@ -505,4 +505,62 @@ class ReleaseControllerTests extends AbstractIT {
         var result = mvc.delete().uri("/api/releases/{code}", "GO-2024.2.3").exchange();
         assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
     }
+
+    @Test
+    void shouldRejectInvalidDateRange() {
+        var startDate = "2024-12-31T23:59:59Z";
+        var endDate = "2024-01-01T00:00:00Z";
+        var result = mvc.get()
+                .uri("/api/releases/by-date-range?startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+        assertThat(result).hasStatus4xxClientError();
+    }
+
+    @Test
+    void shouldRejectInvalidDateRangeOnMainEndpoint() {
+        var startDate = "2024-12-31T23:59:59Z";
+        var endDate = "2024-01-01T00:00:00Z";
+        var result = mvc.get()
+                .uri("/api/releases?startDate={start}&endDate={end}", startDate, endDate)
+                .exchange();
+        assertThat(result).hasStatus4xxClientError();
+    }
+
+    @Test
+    void shouldHandleSameStartAndEndDateRange() {
+        var date = "2024-01-01T00:00:00Z";
+        var result = mvc.get()
+                .uri("/api/releases/by-date-range?startDate={date}&endDate={date}", date, date)
+                .exchange();
+        assertThat(result).hasStatusOk();
+    }
+
+    @Test
+    void shouldRejectMissingStartDateInDateRange() {
+        var result = mvc.get()
+                .uri("/api/releases/by-date-range?endDate=2024-01-01T00:00:00Z")
+                .exchange();
+        assertThat(result).hasStatus4xxClientError();
+    }
+
+    @Test
+    void shouldRejectMissingEndDateInDateRange() {
+        var result = mvc.get()
+                .uri("/api/releases/by-date-range?startDate=2024-01-01T00:00:00Z")
+                .exchange();
+        assertThat(result).hasStatus4xxClientError();
+    }
+
+    @Test
+    void shouldAcceptOnlyStartDateOnMainEndpoint() {
+        var result =
+                mvc.get().uri("/api/releases?startDate=2024-01-01T00:00:00Z").exchange();
+        assertThat(result).hasStatusOk();
+    }
+
+    @Test
+    void shouldAcceptOnlyEndDateOnMainEndpoint() {
+        var result = mvc.get().uri("/api/releases?endDate=2024-01-01T00:00:00Z").exchange();
+        assertThat(result).hasStatusOk();
+    }
 }


### PR DESCRIPTION
Bugfix for issue #233