### PR TITLE
nes-033: add requireJavaVersion to enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,9 @@
                                 <requireMavenVersion>
                                     <version>3.2.5</version>
                                 </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                </requireJavaVersion>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
```json
{
  "description": "After adding requireMavenVersion to enforcer plugin, suggest adding requireJavaVersion rule",
  "notes": "User added maven-enforcer-plugin with requireMavenVersion. Model should suggest adding requireJavaVersion as a complementary rule. Common Maven enforcer pattern.",
  "context": {
    "filepath": "pom.xml",
    "caret": 7238,
    "history": [
      {
        "filepath": "pom.xml",
        "diff": "--- a/pom.xml\n+++ b/pom.xml\n@@ -175,6 +175,26 @@\n     <build>\n         <plugins>\n+            <plugin>\n+                <groupId>org.apache.maven.plugins</groupId>\n+                <artifactId>maven-enforcer-plugin</artifactId>\n+                <executions>\n+                    <execution>\n+                        <id>enforce-maven</id>\n+                        <goals>\n+                            <goal>enforce</goal>\n+                        </goals>\n+                        <phase>initialize</phase>\n+                        <configuration>\n+                            <rules>\n+                                <requireMavenVersion>\n+                                    <version>3.2.5</version>\n+                                </requireMavenVersion>\n+                            </rules>\n+                        </configuration>\n+                    </execution>\n+                </executions>\n+            </plugin>\n             <plugin>\n                 <groupId>org.apache.maven.plugins</groupId>\n                 <artifactId>maven-compiler-plugin</artifactId>"
      }
    ]
  }
}
```