### PR TITLE
nes-034: empty prediction, enforcer rules already complete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@
                                 <requireJavaVersion>
                                     <version>1.8</version>
                                 </requireJavaVersion>
+<empty>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
```json
{
  "description": "After both requireMavenVersion and requireJavaVersion are present, no further suggestion expected",
  "notes": "Negative test case. Enforcer plugin already has both rules. Model should not repeat them. Reported issue: NES was suggesting the same requireMavenVersion + requireJavaVersion block again after it was already accepted.",
  "context": {
    "filepath": "pom.xml",
    "caret": 7404,
    "history": [
      {
        "filepath": "pom.xml",
        "diff": "--- a/pom.xml\n+++ b/pom.xml\n@@ -175,6 +175,26 @@\n     <build>\n         <plugins>\n+            <plugin>\n+                <groupId>org.apache.maven.plugins</groupId>\n+                <artifactId>maven-enforcer-plugin</artifactId>\n+                <executions>\n+                    <execution>\n+                        <id>enforce-maven</id>\n+                        <goals>\n+                            <goal>enforce</goal>\n+                        </goals>\n+                        <phase>initialize</phase>\n+                        <configuration>\n+                            <rules>\n+                                <requireMavenVersion>\n+                                    <version>3.2.5</version>\n+                                </requireMavenVersion>\n+                            </rules>\n+                        </configuration>\n+                    </execution>\n+                </executions>\n+            </plugin>\n             <plugin>\n                 <groupId>org.apache.maven.plugins</groupId>\n                 <artifactId>maven-compiler-plugin</artifactId>"
      },
      {
        "filepath": "pom.xml",
        "diff": "--- a/pom.xml\n+++ b/pom.xml\n@@ -189,6 +189,9 @@\n                                 <requireMavenVersion>\n                                     <version>3.2.5</version>\n                                 </requireMavenVersion>\n+                                <requireJavaVersion>\n+                                    <version>1.8</version>\n+                                </requireJavaVersion>\n                             </rules>\n                         </configuration>\n                     </execution>"
      }
    ]
  }
}
```