### PR TITLE
nes-035: add requireActiveProfiles for dev profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,9 @@
                                 <requireJavaVersion>
                                     <version>1.8</version>
                                 </requireJavaVersion>
+                                <requireActiveProfiles>
+                                    <activeProfiles>dev</activeProfiles>
+                                </requireActiveProfiles>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
```json
{
  "description": "With dev profile defined in pom.xml, suggest adding requireActiveProfiles rule for dev after requireJavaVersion",
  "notes": "Project has a dev profile with activeByDefault=true. After adding requireMavenVersion and requireJavaVersion, the model should suggest requireActiveProfiles with dev to enforce the profile is active. Unlike case 034 (no profiles, expect empty), here the profile context makes the suggestion valid.",
  "context": {
    "filepath": "pom.xml",
    "caret": 7404,
    "history": [
      {
        "filepath": "pom.xml",
        "diff": "--- a/pom.xml\n+++ b/pom.xml\n@@ -189,6 +189,9 @@\n                                 <requireMavenVersion>\n                                     <version>3.2.5</version>\n                                 </requireMavenVersion>\n+                                <requireJavaVersion>\n+                                    <version>1.8</version>\n+                                </requireJavaVersion>\n                             </rules>\n                         </configuration>\n                     </execution>"
      }
    ]
  }
}
```