### PR TITLE
fix: Handle changeType filter in feature/release history endpoints #264

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,43 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  spotless:
+    name: Code Style Spotless Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run spotless plugin check
+        run: ./mvnw --no-transfer-progress spotless:check
+
+  verify:
+    name: Maven Build & Test
+    needs: spotless
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run mvn verify
+        run: ./mvnw --no-transfer-progress verify

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/PlanningHistoryController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/PlanningHistoryController.java
@@ -42,21 +42,23 @@ class PlanningHistoryController {
     @Operation(summary = "Get planning history for a specific release")
     PagedResult<PlanningHistoryDto> getReleaseHistory(
             @PathVariable String code,
+            @RequestParam(required = false) ChangeType changeType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String sort) {
-        return PagedResult.from(
-                planningHistoryService.findHistory(EntityType.RELEASE, code, null, null, null, null, page, size, sort));
+        return PagedResult.from(planningHistoryService.findHistory(
+                EntityType.RELEASE, code, null, changeType, null, null, page, size, sort));
     }
 
     @GetMapping("/api/features/{code}/history")
     @Operation(summary = "Get planning history for a specific feature")
     PagedResult<PlanningHistoryDto> getFeatureHistory(
             @PathVariable String code,
+            @RequestParam(required = false) ChangeType changeType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String sort) {
-        return PagedResult.from(
-                planningHistoryService.findHistory(EntityType.FEATURE, code, null, null, null, null, page, size, sort));
+        return PagedResult.from(planningHistoryService.findHistory(
+                EntityType.FEATURE, code, null, changeType, null, null, page, size, sort));
     }
 }

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/PlanningHistoryControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/PlanningHistoryControllerTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sivalabs.ft.features.AbstractIT;
 import com.sivalabs.ft.features.WithMockOAuth2User;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -229,5 +230,77 @@ class PlanningHistoryControllerTests extends AbstractIT {
                 .asNumber()
                 .extracting(Number::intValue)
                 .satisfies(n -> assertThat(n).isGreaterThanOrEqualTo(1));
+    }
+
+    @Test
+    void shouldGetFeatureHistoryWithChangeTypeFilter() {
+        // Seed data: IDEA-1 has CREATED, STATUS_CHANGED, and ASSIGNED history entries
+        var result = mvc.get()
+                .uri("/api/features/{code}/history?changeType=STATUS_CHANGED", "IDEA-1")
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content")
+                .asList()
+                .isNotEmpty()
+                .allSatisfy(entry -> {
+                    var history = (Map<?, ?>) entry;
+                    assertThat(history.get("changeType")).isEqualTo("STATUS_CHANGED");
+                    assertThat(history.get("entityCode")).isEqualTo("IDEA-1");
+                });
+    }
+
+    @Test
+    void shouldReturnEmptyHistoryWhenChangeTypeDoesNotMatch() {
+        // Seed data: IDEA-1 has no DELETED history entries
+        var result = mvc.get()
+                .uri("/api/features/{code}/history?changeType=DELETED", "IDEA-1")
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.totalElements")
+                .asNumber()
+                .extracting(Number::intValue)
+                .satisfies(n -> assertThat(n).isEqualTo(0));
+    }
+
+    @Test
+    void shouldGetReleaseHistoryWithChangeTypeFilter() {
+        // Seed data: IDEA-2023.3.8 has CREATED and STATUS_CHANGED history entries
+        var result = mvc.get()
+                .uri("/api/releases/{code}/history?changeType=STATUS_CHANGED", "IDEA-2023.3.8")
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.content")
+                .asList()
+                .isNotEmpty()
+                .allSatisfy(entry -> {
+                    var history = (Map<?, ?>) entry;
+                    assertThat(history.get("changeType")).isEqualTo("STATUS_CHANGED");
+                    assertThat(history.get("entityCode")).isEqualTo("IDEA-2023.3.8");
+                });
+    }
+
+    @Test
+    void shouldReturnEmptyReleaseHistoryWhenChangeTypeDoesNotMatch() {
+        // Seed data: IDEA-2023.3.8 has no DELETED history entries
+        var result = mvc.get()
+                .uri("/api/releases/{code}/history?changeType=DELETED", "IDEA-2023.3.8")
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result)
+                .bodyJson()
+                .extractingPath("$.totalElements")
+                .asNumber()
+                .extracting(Number::intValue)
+                .satisfies(n -> assertThat(n).isEqualTo(0));
     }
 }


### PR DESCRIPTION
Bug fix for #264


FAIL_TO_PASS: PlanningHistoryControllerTests#shouldGetFeatureHistoryWithChangeTypeFilter