### PR TITLE
fix: updating release with request body missing status fails with 500 #290

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
@@ -7,6 +7,7 @@ import com.sivalabs.ft.features.domain.Commands.CreateReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateReleaseCommand;
 import com.sivalabs.ft.features.domain.ReleaseService;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -128,6 +129,9 @@ class ReleaseController {
                 @ApiResponse(responseCode = "403", description = "Forbidden"),
             })
     void updateRelease(@PathVariable String code, @RequestBody UpdateReleasePayload payload) {
+        if (payload == null || payload.status() == null) {
+            throw new BadRequestException("Status is required");
+        }
         var username = SecurityUtils.getCurrentUsername();
         var cmd = new UpdateReleaseCommand(
                 code,

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseControllerTests.java
@@ -178,6 +178,35 @@ class ReleaseControllerTests extends AbstractIT {
 
     @Test
     @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenUpdatingReleaseWithoutStatus() {
+        var payload =
+                """
+            {
+                "description": "Updated description"
+            }
+            """;
+
+        var result = mvc.put()
+                .uri("/api/releases/{code}", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenUpdatingReleaseWithEmptyBody() {
+        var result = mvc.put()
+                .uri("/api/releases/{code}", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
     void shouldDeleteRelease() {
         var result = mvc.delete().uri("/api/releases/{code}", "RIDER-2024.2.6").exchange();
         assertThat(result).hasStatusOk();


### PR DESCRIPTION
Bugfix for #290

FAIL_TO_PASS: ReleaseControllerTests#shouldReturn400WhenUpdatingReleaseWithoutStatus