### PR TITLE
Implement Feature Developer: Create Developer entity

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.domain.DeveloperEntityTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/domain/DeveloperRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/DeveloperRepository.java
@@ -1,0 +1,6 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Developer;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface DeveloperRepository extends ListCrudRepository<Developer, Long> {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Developer.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Developer.java
@@ -1,0 +1,45 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "developers")
+public class Developer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "developers_id_gen")
+    @SequenceGenerator(name = "developers_id_gen", sequenceName = "developer_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 255) @NotNull @Column(name = "name", nullable = false)
+    private String name;
+
+    @Size(max = 255) @Column(name = "email_address", unique = true)
+    private String emailAddress;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+}

--- a/src/main/resources/db/migration/V5__create_developers_table.sql
+++ b/src/main/resources/db/migration/V5__create_developers_table.sql
@@ -1,0 +1,10 @@
+-- Create developers table with sequence
+create sequence developer_id_seq start with 100 increment by 50;
+
+create table developers
+(
+    id            bigint       not null default nextval('developer_id_seq'),
+    name          varchar(255) not null,
+    email_address varchar(255) unique,
+    primary key (id)
+);

--- a/src/test/java/com/sivalabs/ft/features/domain/DeveloperEntityTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/DeveloperEntityTest.java
@@ -1,0 +1,37 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.domain.entities.Developer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DeveloperEntityTest extends AbstractIT {
+
+    @Autowired
+    private DeveloperRepository developerRepository;
+
+    @Test
+    void shouldSaveAndRetrieveDeveloper() {
+        // Given
+        Developer developer = new Developer();
+        developer.setName("Test Developer");
+        developer.setEmailAddress("test@example.com");
+
+        // When
+        Developer savedDeveloper = developerRepository.save(developer);
+
+        // Then
+        assertThat(savedDeveloper.getId()).isNotNull();
+        assertThat(savedDeveloper.getName()).isEqualTo("Test Developer");
+        assertThat(savedDeveloper.getEmailAddress()).isEqualTo("test@example.com");
+
+        // Verify retrieval
+        Developer retrievedDeveloper =
+                developerRepository.findById(savedDeveloper.getId()).orElse(null);
+        assertThat(retrievedDeveloper).isNotNull();
+        assertThat(retrievedDeveloper.getName()).isEqualTo("Test Developer");
+        assertThat(retrievedDeveloper.getEmailAddress()).isEqualTo("test@example.com");
+    }
+}


### PR DESCRIPTION
Create a new Developer entity in the domain.entities package. That entity should include the next fields with getters and setters:
- `id` of typeLong, field with sequence generation strategy.
- `name` of type String
- `emailAddress` of type String.
 
Implement a Developer repository named `DeveloperRepository` for this entity in the features.domain package. Repository should be inherited from the `CrudRepository`.

Additionally, write a database migration script to create the developers table with a sequence for the id field, ensuring that it includes the appropriate columns and constraints.