### PR TITLE
Set up login form user authentication using database storage with Spring Data JPA

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.security.SecurityConfigTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
@@ -3,20 +3,26 @@ package com.sivalabs.ft.features.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 class SecurityConfig {
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationProvider authenticationProvider)
+            throws Exception {
         http.authorizeHttpRequests(c -> c.requestMatchers(
                                 "/favicon.ico",
                                 "/actuator/**",
@@ -36,10 +42,23 @@ class SecurityConfig {
                         .permitAll()
                         .anyRequest()
                         .authenticated())
-                .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(form -> form.loginProcessingUrl("/api/login").permitAll())
+                .logout(logout -> logout.logoutUrl("/api/logout").permitAll())
                 .cors(CorsConfigurer::disable)
                 .csrf(CsrfConfigurer::disable)
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+                .authenticationProvider(authenticationProvider);
         return http.build();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider(UserDetailsService userDetailsService) {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/user/domain/User.java
+++ b/src/main/java/com/sivalabs/ft/features/user/domain/User.java
@@ -1,0 +1,130 @@
+package com.sivalabs.ft.features.user.domain;
+
+import jakarta.persistence.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Entity
+@Table(name = "users")
+public class User implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "role")
+    private Set<String> roles = new HashSet<>();
+
+    @Column(name = "account_non_expired")
+    private boolean accountNonExpired = true;
+
+    @Column(name = "account_non_locked")
+    private boolean accountNonLocked = true;
+
+    @Column(name = "credentials_non_expired")
+    private boolean credentialsNonExpired = true;
+
+    @Column(name = "enabled")
+    private boolean enabled = true;
+
+    public User() {}
+
+    public User(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    public void addRole(String role) {
+        this.roles.add(role);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return accountNonExpired;
+    }
+
+    public void setAccountNonExpired(boolean accountNonExpired) {
+        this.accountNonExpired = accountNonExpired;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return accountNonLocked;
+    }
+
+    public void setAccountNonLocked(boolean accountNonLocked) {
+        this.accountNonLocked = accountNonLocked;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return credentialsNonExpired;
+    }
+
+    public void setCredentialsNonExpired(boolean credentialsNonExpired) {
+        this.credentialsNonExpired = credentialsNonExpired;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/user/domain/UserRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/user/domain/UserRepository.java
@@ -1,0 +1,19 @@
+package com.sivalabs.ft.features.user.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long>, UserDetailsService {
+    Optional<User> findByUsername(String username);
+
+    @Override
+    default UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User " + username + " not found"));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,14 +25,14 @@ spring.jpa.show-sql=true
 ####### OAuth2 Configuration  #########
 OAUTH2_SERVER_URL=http://localhost:9191
 REALM_URL=${OAUTH2_SERVER_URL}/realms/feature-tracker
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${REALM_URL}
+# Commented out as we're now using database authentication
+# spring.security.oauth2.resourceserver.jwt.issuer-uri=${REALM_URL}
 
 ######## Kafka Configuration  #########
 KAFKA_BROKER=localhost:9092
 spring.kafka.bootstrap-servers=${KAFKA_BROKER}
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
-
 spring.kafka.consumer.group-id=${spring.application.name}
 spring.kafka.consumer.auto-offset-reset=latest
 #spring.kafka.consumer.auto-offset-reset=earliest

--- a/src/main/resources/db/migration/V5__create_user_tables.sql
+++ b/src/main/resources/db/migration/V5__create_user_tables.sql
@@ -1,0 +1,18 @@
+-- Create users table
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(100) NOT NULL,
+    account_non_expired BOOLEAN DEFAULT TRUE,
+    account_non_locked BOOLEAN DEFAULT TRUE,
+    credentials_non_expired BOOLEAN DEFAULT TRUE,
+    enabled BOOLEAN DEFAULT TRUE
+);
+
+-- Create user_roles table
+CREATE TABLE user_roles (
+    user_id BIGINT NOT NULL,
+    role VARCHAR(50) NOT NULL,
+    PRIMARY KEY (user_id, role),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V6__insert_default_users.sql
+++ b/src/main/resources/db/migration/V6__insert_default_users.sql
@@ -1,0 +1,18 @@
+-- Password: admin123 (BCrypt encoded)
+INSERT INTO users (username, password, account_non_expired, account_non_locked, credentials_non_expired, enabled)
+VALUES ('admin', '$2a$10$REzSx0w4StPQ7lXMb.Ki6OpSTHY5blkPs9Cqv8.7l87mC7lzwMDJq', true, true, true, true);
+
+-- Password: user123 (BCrypt encoded)
+INSERT INTO users (username, password, account_non_expired, account_non_locked, credentials_non_expired, enabled)
+VALUES ('user', '$2a$10$fkCIJsZQtul4y6y0bylRd.4g1MBD0jA/zdLF699ExWKfkjtEP61zi', true, true, true, true);
+
+-- Add roles for admin user
+INSERT INTO user_roles (user_id, role) 
+VALUES 
+    ((SELECT id FROM users WHERE username = 'admin'), 'USER'),
+    ((SELECT id FROM users WHERE username = 'admin'), 'ADMIN');
+
+-- Add roles for regular user
+INSERT INTO user_roles (user_id, role) 
+VALUES 
+    ((SELECT id FROM users WHERE username = 'user'), 'USER');

--- a/src/test/java/com/sivalabs/ft/features/security/SecurityConfigTest.java
+++ b/src/test/java/com/sivalabs/ft/features/security/SecurityConfigTest.java
@@ -1,0 +1,135 @@
+package com.sivalabs.ft.features.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sivalabs.ft.features.AbstractIT;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@AutoConfigureMockMvc
+@Import({SecurityConfigTest.TestController.class})
+public class SecurityConfigTest extends AbstractIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldAuthenticateWithValidCredentials() throws Exception {
+        // Test authentication with admin user
+        mockMvc.perform(formLogin("/api/login").user("admin").password("admin123"))
+                .andExpect(authenticated())
+                .andExpect(authenticated().withRoles("ADMIN", "USER"));
+
+        // Test authentication with regular user
+        mockMvc.perform(formLogin("/api/login").user("user").password("user123"))
+                .andExpect(authenticated())
+                .andExpect(authenticated().withRoles("USER"));
+    }
+
+    @Test
+    void shouldNotAuthenticateWithInvalidCredentials() throws Exception {
+        // Test with invalid username
+        mockMvc.perform(formLogin("/api/login").user("nonexistent").password("password"))
+                .andExpect(unauthenticated());
+
+        // Test with invalid password
+        mockMvc.perform(formLogin("/api/login").user("admin").password("wrongpassword"))
+                .andExpect(unauthenticated());
+    }
+
+    @Test
+    void shouldAllowAccessToPublicEndpoints() throws Exception {
+        // Test access to a public endpoint (no authentication required)
+        mockMvc.perform(get("/api/products")).andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(
+            username = "user",
+            roles = {"USER"})
+    void shouldAllowAccessToProtectedEndpointsForAuthenticatedUsers() throws Exception {
+        // Test access to a protected endpoint with authenticated user
+        mockMvc.perform(get("/api/protected-resource")).andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldAuthenticateAdminUser() throws Exception {
+        mockMvc.perform(formLogin("/api/login").user("admin").password("admin123"))
+                .andExpect(authenticated())
+                .andExpect(authenticated().withUsername("admin"))
+                .andExpect(authenticated().withRoles("ADMIN", "USER"));
+    }
+
+    @Test
+    void shouldAuthenticateRegularUser() throws Exception {
+        mockMvc.perform(formLogin("/api/login").user("user").password("user123"))
+                .andExpect(authenticated())
+                .andExpect(authenticated().withUsername("user"))
+                .andExpect(authenticated().withRoles("USER"));
+    }
+
+    @Test
+    void shouldConfigureLogout() throws Exception {
+        mockMvc.perform(get("/api/logout").with(user("admin").roles("ADMIN", "USER")))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(result ->
+                        assertTrue(result.getResponse().getRedirectedUrl().contains("/login")));
+
+        mockMvc.perform(get("/api/logout").with(user("user").roles("USER")))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(result ->
+                        assertTrue(result.getResponse().getRedirectedUrl().contains("/login")));
+    }
+
+    @Test
+    void shouldSupportAPILoginEndpoint() throws Exception {
+        // Admin login via API
+        mockMvc.perform(post("/api/login")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("username", "admin")
+                        .param("password", "admin123"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(result -> assertEquals("/", result.getResponse().getRedirectedUrl()));
+
+        // Regular user login via API
+        mockMvc.perform(post("/api/login")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("username", "user")
+                        .param("password", "user123"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(result -> assertEquals("/", result.getResponse().getRedirectedUrl()));
+    }
+
+    @RestController
+    public static class TestController {
+
+        @GetMapping("/api/protected-resource")
+        @ResponseStatus(HttpStatus.OK)
+        public String protectedResource() {
+            return "protected-resource";
+        }
+
+        @GetMapping("/api/protected-endpoint")
+        @ResponseStatus(HttpStatus.OK)
+        public String protectedEndpoint() {
+            return "protected-endpoint";
+        }
+    }
+}


### PR DESCRIPTION
Set up login form user authentication using database storage with Spring Data JPA, including password encryption and UserDetailsService.
Implement User entity with long id, username, password, and roles.
Create predefined users:
- `admin` username, `admin123` password and `USER`, `ADMIN` roles
- `user` username, `user123` password, and `USER` role