### PR TITLE
Invalid requests result in 500 Internal Server Error

### DIFF
--- a/.ee-bench/codegen/eval/scripts/ee_bench_eval.py
+++ b/.ee-bench/codegen/eval/scripts/ee_bench_eval.py
@@ -44,20 +44,60 @@ def _prefix(name):
     return re.sub(r"\(.*\)$", "", name)
 
 
+def _normalize_name(name):
+    """Normalize legacy expected/JUnit names before compatibility matching."""
+    name = name.replace("\\", "/")
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    if name.endswith(".java"):
+        name = name[:-5]
+    return name.replace("#", ".").replace("+", ".")
+
+
+def _class_key(name):
+    """Return a stable class key for class-level expected names."""
+    normalized = _prefix(_normalize_name(name))
+    parts = normalized.split(".")
+    for index, part in enumerate(parts):
+        if re.search(r"(Test|Tests|IT)$", part):
+            return ".".join(parts[: index + 1])
+    return normalized
+
+
+def _simple_class_key(name):
+    return _class_key(name).split(".")[-1]
+
+
 def _test_in(name, name_set):
     """Match by exact name, prefix (parameterized tests), or class-level prefix.
 
     Supports class-level expected names like 'com.example.FooTest' matching
     method-level actual names like 'com.example.FooTest.shouldDoSomething'.
+    Also accepts legacy issue metadata forms such as Class#method,
+    ClassName.java, and bare class names.
     """
-    if name in name_set:
+    normalized_name = _normalize_name(name)
+    normalized_set = {_normalize_name(n) for n in name_set}
+    if normalized_name in normalized_set:
         return True
-    pname = _prefix(name)
-    if pname in {_prefix(n) for n in name_set}:
+    pname = _prefix(normalized_name)
+    if pname in {_prefix(n) for n in normalized_set}:
+        return True
+    # Method-level legacy names may omit the package:
+    # 'FooTest.testA' should match 'pkg.FooTest.testA'.
+    if any(n.endswith("." + normalized_name) for n in normalized_set):
         return True
     # Class-level match: expected 'a.b.FooTest' matches 'a.b.FooTest.method'
-    class_prefix = name + "."
-    return any(n.startswith(class_prefix) for n in name_set)
+    class_key = _class_key(normalized_name)
+    is_class_level_expected = _prefix(normalized_name) == class_key
+    if not is_class_level_expected:
+        return False
+
+    class_prefix = class_key + "."
+    if any(n.startswith(class_prefix) for n in normalized_set):
+        return True
+    simple_class = _simple_class_key(normalized_name)
+    return any(_simple_class_key(n) == simple_class for n in normalized_set)
 
 
 def _evaluate_criterion(expected, eval_passed, baseline_passed, baseline_failed,

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,14 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "ReleaseFeaturePlanningIntegrationTests#shouldValidateEmptyPayloadStructure",
+      "ReleaseFeaturePlanningIntegrationTests#shouldValidateRequiredFieldsInAssignFeaturePayload",
+      "ReleaseFeaturePlanningIntegrationTests#shouldValidateDateFormatInAssignFeaturePayload",
+      "ReleaseFeaturePlanningIntegrationTests#shouldValidateDateFormatInUpdateFeaturePlanningPayload",
+      "ReleaseFeaturePlanningIntegrationTests#shouldValidateStatusEnumInUpdateFeaturePlanningPayload",
+      "ReleaseFeaturePlanningIntegrationTests#shouldHandleInvalidPlanningStatusFilter"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -1,44 +1,97 @@
 package com.sivalabs.ft.features.api;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import java.time.Instant;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    @ExceptionHandler(Exception.class)
-    ProblemDetail handle(Exception e) {
-        log.error("Unhandled exception", e);
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(INTERNAL_SERVER_ERROR, e.getMessage());
-        problemDetail.setTitle("Internal Server Error");
-        problemDetail.setProperty("timestamp", Instant.now());
-        return problemDetail;
-    }
-
     @ExceptionHandler(ResourceNotFoundException.class)
     ProblemDetail handle(ResourceNotFoundException e) {
         log.error("Resource not found", e);
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(NOT_FOUND, e.getMessage());
-        problemDetail.setTitle("Resource not found");
-        problemDetail.setProperty("timestamp", Instant.now());
-        return problemDetail;
+        return buildProblemDetail(NOT_FOUND, "Resource not found", e.getMessage());
     }
 
     @ExceptionHandler(BadRequestException.class)
     ProblemDetail handle(BadRequestException e) {
         log.error("Bad Request", e);
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
-        problemDetail.setTitle("Bad Request");
+        return buildProblemDetail(BAD_REQUEST, "Bad Request", e.getMessage());
+    }
+
+    @ExceptionHandler({
+        BindException.class,
+        HttpMessageNotReadableException.class,
+        MethodArgumentTypeMismatchException.class,
+        ConstraintViolationException.class,
+        MissingServletRequestParameterException.class
+    })
+    ProblemDetail handleBadRequest(Exception e) {
+        log.error("Bad Request", e);
+        String detail = resolveBadRequestDetail(e);
+        return buildProblemDetail(BAD_REQUEST, "Bad Request", detail);
+    }
+
+    @ExceptionHandler(Exception.class)
+    ProblemDetail handle(Exception e) {
+        log.error("Unhandled exception", e);
+        return buildProblemDetail(INTERNAL_SERVER_ERROR, "Internal Server Error", e.getMessage());
+    }
+
+    private String resolveBadRequestDetail(Exception e) {
+        if (e instanceof BindException ex) {
+            return formatBindingErrors(ex.getBindingResult());
+        }
+        if (e instanceof ConstraintViolationException ex) {
+            String detail = ex.getConstraintViolations().stream()
+                    .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                    .collect(Collectors.joining("; "));
+            return defaultIfBlank(detail, "Validation failed");
+        }
+        if (e instanceof MethodArgumentTypeMismatchException ex) {
+            String value = ex.getValue() == null ? "null" : ex.getValue().toString();
+            return "Invalid value '" + value + "' for parameter '" + ex.getName() + "'";
+        }
+        if (e instanceof HttpMessageNotReadableException ex) {
+            Throwable cause = ex.getMostSpecificCause();
+            String detail = cause != null ? cause.getMessage() : ex.getMessage();
+            return defaultIfBlank(detail, "Malformed JSON request");
+        }
+        if (e instanceof MissingServletRequestParameterException ex) {
+            return "Missing required parameter '" + ex.getParameterName() + "'";
+        }
+        return defaultIfBlank(e.getMessage(), "Bad request");
+    }
+
+    private String formatBindingErrors(BindingResult bindingResult) {
+        String detail = bindingResult.getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+        return defaultIfBlank(detail, "Validation failed");
+    }
+
+    private ProblemDetail buildProblemDetail(org.springframework.http.HttpStatus status, String title, String detail) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setTitle(title);
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;
     }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/MilestoneController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/MilestoneController.java
@@ -1,0 +1,179 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.api.models.CreateMilestonePayload;
+import com.sivalabs.ft.features.api.models.UpdateMilestonePayload;
+import com.sivalabs.ft.features.api.utils.SecurityUtils;
+import com.sivalabs.ft.features.domain.Commands.CreateMilestoneCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateMilestoneCommand;
+import com.sivalabs.ft.features.domain.MilestoneService;
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneSummaryDto;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/milestones")
+@Tag(name = "Milestones API")
+class MilestoneController {
+    private static final Logger log = LoggerFactory.getLogger(MilestoneController.class);
+    private final MilestoneService milestoneService;
+
+    MilestoneController(MilestoneService milestoneService) {
+        this.milestoneService = milestoneService;
+    }
+
+    @GetMapping("")
+    @Operation(
+            summary = "Find milestones by product code",
+            description = "Find milestones by product code with optional filters",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = MilestoneSummaryDto.class)))),
+                @ApiResponse(responseCode = "400", description = "Missing required parameter"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    List<MilestoneSummaryDto> getMilestones(
+            @RequestParam(value = "productCode", required = false) String productCode,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "owner", required = false) String owner) {
+        if (StringUtils.isBlank(productCode)) {
+            throw new BadRequestException("productCode is required");
+        }
+        return milestoneService.findMilestonesByProductCode(productCode, status, owner);
+    }
+
+    @GetMapping("/{code}")
+    @Operation(
+            summary = "Find milestone by code",
+            description = "Find milestone by code with associated releases",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = MilestoneDto.class))),
+                @ApiResponse(responseCode = "404", description = "Milestone not found"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    ResponseEntity<MilestoneDto> getMilestone(@PathVariable String code) {
+        return milestoneService
+                .findMilestoneByCode(code)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("")
+    @Operation(
+            summary = "Create a new milestone",
+            description = "Create a new milestone",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Successful response",
+                        headers =
+                                @Header(
+                                        name = "Location",
+                                        required = true,
+                                        description = "URI of the created milestone")),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+            })
+    ResponseEntity<Void> createMilestone(@RequestBody @Valid CreateMilestonePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new CreateMilestoneCommand(
+                payload.productCode(),
+                payload.code(),
+                payload.name(),
+                payload.description(),
+                payload.targetDate(),
+                payload.status(),
+                payload.owner(),
+                payload.notes(),
+                username);
+        String code = milestoneService.createMilestone(cmd);
+        log.info("Created milestone with code {}", code);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{code}")
+                .buildAndExpand(code)
+                .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+    @PutMapping("/{code}")
+    @Operation(
+            summary = "Update an existing milestone",
+            description = "Update an existing milestone",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Successful response"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Milestone not found")
+            })
+    void updateMilestone(@PathVariable String code, @RequestBody @Valid UpdateMilestonePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new UpdateMilestoneCommand(
+                code,
+                payload.name(),
+                payload.description(),
+                payload.targetDate(),
+                payload.actualDate(),
+                payload.status(),
+                payload.owner(),
+                payload.notes(),
+                username);
+        milestoneService.updateMilestone(cmd);
+    }
+
+    @DeleteMapping("/{code}")
+    @Operation(
+            summary = "Delete an existing milestone",
+            description = "Delete an existing milestone",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Successful response"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Milestone not found")
+            })
+    ResponseEntity<Void> deleteMilestone(@PathVariable String code) {
+        if (!milestoneService.isMilestoneExists(code)) {
+            return ResponseEntity.notFound().build();
+        }
+        milestoneService.deleteMilestone(code);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
@@ -1,12 +1,24 @@
 package com.sivalabs.ft.features.api.controllers;
 
+import com.sivalabs.ft.features.api.models.AssignFeatureToReleasePayload;
 import com.sivalabs.ft.features.api.models.CreateReleasePayload;
+import com.sivalabs.ft.features.api.models.MoveFeaturePayload;
+import com.sivalabs.ft.features.api.models.RemoveFeaturePayload;
+import com.sivalabs.ft.features.api.models.UpdateFeaturePlanningPayload;
 import com.sivalabs.ft.features.api.models.UpdateReleasePayload;
 import com.sivalabs.ft.features.api.utils.SecurityUtils;
+import com.sivalabs.ft.features.domain.Commands.AssignFeatureToReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.CreateReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.MoveFeatureToReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.RemoveFeatureFromReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateFeaturePlanningCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateReleaseCommand;
+import com.sivalabs.ft.features.domain.FeatureService;
 import com.sivalabs.ft.features.domain.ReleaseService;
+import com.sivalabs.ft.features.domain.dtos.FeatureDto;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -22,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -37,9 +50,11 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 class ReleaseController {
     private static final Logger log = LoggerFactory.getLogger(ReleaseController.class);
     private final ReleaseService releaseService;
+    private final FeatureService featureService;
 
-    ReleaseController(ReleaseService releaseService) {
+    ReleaseController(ReleaseService releaseService, FeatureService featureService) {
         this.releaseService = releaseService;
+        this.featureService = featureService;
     }
 
     @GetMapping("")
@@ -121,8 +136,8 @@ class ReleaseController {
             })
     void updateRelease(@PathVariable String code, @RequestBody UpdateReleasePayload payload) {
         var username = SecurityUtils.getCurrentUsername();
-        var cmd =
-                new UpdateReleaseCommand(code, payload.description(), payload.status(), payload.releasedAt(), username);
+        var cmd = new UpdateReleaseCommand(
+                code, payload.description(), payload.status(), payload.releasedAt(), payload.milestoneCode(), username);
         releaseService.updateRelease(cmd);
     }
 
@@ -141,6 +156,152 @@ class ReleaseController {
             return ResponseEntity.notFound().build();
         }
         releaseService.deleteRelease(code);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{releaseCode}/features")
+    @Operation(
+            summary = "Assign a feature to a release",
+            description = "Assign a feature to a release with planning details",
+            responses = {
+                @ApiResponse(responseCode = "201", description = "Feature assigned successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+                @ApiResponse(responseCode = "409", description = "Feature already assigned to this release"),
+            })
+    ResponseEntity<Void> assignFeatureToRelease(
+            @PathVariable String releaseCode, @RequestBody @Valid AssignFeatureToReleasePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new AssignFeatureToReleaseCommand(
+                payload.featureCode(),
+                releaseCode,
+                payload.plannedCompletionDate(),
+                payload.featureOwner(),
+                payload.notes(),
+                username);
+        featureService.assignFeatureToRelease(cmd);
+        log.info("Feature {} assigned to release {} by user {}", payload.featureCode(), releaseCode, username);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{featureCode}")
+                .buildAndExpand(payload.featureCode())
+                .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+    @GetMapping("/{releaseCode}/features")
+    @Operation(
+            summary = "Get all features assigned to a release",
+            description =
+                    "Get all features assigned to a release with planning details. Supports filtering by planningStatus, owner, overdue, and blocked status.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = FeatureDto.class)))),
+                @ApiResponse(responseCode = "404", description = "Release not found"),
+            })
+    List<FeatureDto> getFeaturesByRelease(
+            @PathVariable String releaseCode,
+            @RequestParam(required = false) String planningStatus,
+            @RequestParam(required = false) String owner,
+            @RequestParam(required = false) Boolean overdue,
+            @RequestParam(required = false) Boolean blocked) {
+
+        // Convert string planningStatus to enum if provided
+        FeaturePlanningStatus planningStatusEnum = null;
+        if (planningStatus != null && !planningStatus.trim().isEmpty()) {
+            try {
+                planningStatusEnum = FeaturePlanningStatus.valueOf(planningStatus.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("Invalid planningStatus: " + planningStatus);
+            }
+        }
+
+        return featureService.findFeaturesWithPlanningByReleaseCode(
+                releaseCode, planningStatusEnum, owner, overdue, blocked);
+    }
+
+    @PatchMapping("/{releaseCode}/features/{featureCode}/planning")
+    @Operation(
+            summary = "Update feature planning details",
+            description = "Update planning details (dates, status, owner, blockage reason) for a feature in a release",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Planning updated successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid request or invalid status transition"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+            })
+    ResponseEntity<Void> updateFeaturePlanning(
+            @PathVariable String releaseCode,
+            @PathVariable String featureCode,
+            @RequestBody UpdateFeaturePlanningPayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new UpdateFeaturePlanningCommand(
+                featureCode,
+                payload.plannedCompletionDate(),
+                payload.planningStatus(),
+                payload.featureOwner(),
+                payload.notes(),
+                payload.blockageReason(),
+                username);
+        featureService.updateFeaturePlanning(cmd);
+        log.info("Feature {} planning updated in release {} by user {}", featureCode, releaseCode, username);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{targetReleaseCode}/features/{featureCode}/move")
+    @Operation(
+            summary = "Move a feature between releases",
+            description = "Move a feature from its current release to another release",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Feature moved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+                @ApiResponse(responseCode = "409", description = "Feature already assigned to target release"),
+            })
+    ResponseEntity<Void> moveFeature(
+            @PathVariable String targetReleaseCode,
+            @PathVariable String featureCode,
+            @RequestBody MoveFeaturePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new MoveFeatureToReleaseCommand(featureCode, targetReleaseCode, payload.rationale(), username);
+        featureService.moveFeatureToRelease(cmd);
+        log.info(
+                "Feature {} moved to release {} by user {} with rationale: {}",
+                featureCode,
+                targetReleaseCode,
+                username,
+                payload.rationale());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{releaseCode}/features/{featureCode}")
+    @Operation(
+            summary = "Remove a feature from a release",
+            description = "Remove a feature from a release",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Feature removed successfully"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+            })
+    ResponseEntity<Void> removeFeatureFromRelease(
+            @PathVariable String releaseCode,
+            @PathVariable String featureCode,
+            @RequestBody(required = false) RemoveFeaturePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var rationale = payload != null ? payload.rationale() : null;
+        var cmd = new RemoveFeatureFromReleaseCommand(featureCode, rationale, username);
+        featureService.removeFeatureFromRelease(cmd);
+        log.info("Feature {} removed from release {} by user {}", featureCode, releaseCode, username);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/api/models/AssignFeatureToReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/AssignFeatureToReleasePayload.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.api.models;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+public record AssignFeatureToReleasePayload(
+        @NotBlank String featureCode, LocalDate plannedCompletionDate, String featureOwner, String notes) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/CreateMilestonePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/CreateMilestonePayload.java
@@ -1,0 +1,17 @@
+package com.sivalabs.ft.features.api.models;
+
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+public record CreateMilestonePayload(
+        @NotEmpty(message = "Product code is required") String productCode,
+        @Size(max = 50, message = "Milestone code cannot exceed 50 characters") @NotEmpty(message = "Milestone code is required") String code,
+        @Size(max = 255, message = "Milestone name cannot exceed 255 characters") @NotEmpty(message = "Milestone name is required") String name,
+        String description,
+        @NotNull(message = "Target date is required") Instant targetDate,
+        @NotNull(message = "Status is required") MilestoneStatus status,
+        String owner,
+        String notes) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/MoveFeaturePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/MoveFeaturePayload.java
@@ -1,0 +1,5 @@
+package com.sivalabs.ft.features.api.models;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MoveFeaturePayload(@NotBlank String targetReleaseCode, String rationale) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/RemoveFeaturePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/RemoveFeaturePayload.java
@@ -1,0 +1,3 @@
+package com.sivalabs.ft.features.api.models;
+
+public record RemoveFeaturePayload(String rationale) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateFeaturePlanningPayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateFeaturePlanningPayload.java
@@ -1,0 +1,11 @@
+package com.sivalabs.ft.features.api.models;
+
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
+import java.time.LocalDate;
+
+public record UpdateFeaturePlanningPayload(
+        LocalDate plannedCompletionDate,
+        FeaturePlanningStatus planningStatus,
+        String featureOwner,
+        String notes,
+        String blockageReason) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateMilestonePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateMilestonePayload.java
@@ -1,0 +1,16 @@
+package com.sivalabs.ft.features.api.models;
+
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+public record UpdateMilestonePayload(
+        @Size(max = 255, message = "Milestone name cannot exceed 255 characters") @NotEmpty(message = "Milestone name is required") String name,
+        String description,
+        @NotNull(message = "Target date is required") Instant targetDate,
+        Instant actualDate,
+        @NotNull(message = "Status is required") MilestoneStatus status,
+        String owner,
+        String notes) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
@@ -1,6 +1,11 @@
 package com.sivalabs.ft.features.api.models;
 
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import jakarta.validation.constraints.Size;
 import java.time.Instant;
 
-public record UpdateReleasePayload(String description, ReleaseStatus status, Instant releasedAt) {}
+public record UpdateReleasePayload(
+        String description,
+        ReleaseStatus status,
+        Instant releasedAt,
+        @Size(max = 50, message = "Milestone code cannot exceed 50 characters") String milestoneCode) {}

--- a/src/main/java/com/sivalabs/ft/features/config/OpenAPIConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/OpenAPIConfig.java
@@ -33,7 +33,10 @@ class OpenAPIConfig {
         List<Tag> tags = List.of(
                 new Tag().name("Products API").description("API endpoints to manage products"),
                 new Tag().name("Releases API").description("API endpoints to manage releases"),
-                new Tag().name("Features API").description("API endpoints to manage features"));
+                new Tag().name("Features API").description("API endpoints to manage features"),
+                new Tag().name("Comments API").description("API endpoints to manage comments"),
+                new Tag().name("Favorite Features API").description("API endpoints to manage favorite features"),
+                new Tag().name("Milestones API").description("API endpoints to manage milestones"));
         return new OpenAPI()
                 .info(info)
                 .addSecurityItem(new SecurityRequirement().addList("Authorization"))

--- a/src/main/java/com/sivalabs/ft/features/domain/Commands.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/Commands.java
@@ -1,8 +1,11 @@
 package com.sivalabs.ft.features.domain;
 
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
 import java.time.Instant;
+import java.time.LocalDate;
 
 public class Commands {
     private Commands() {}
@@ -18,7 +21,12 @@ public class Commands {
     public record CreateReleaseCommand(String productCode, String code, String description, String createdBy) {}
 
     public record UpdateReleaseCommand(
-            String code, String description, ReleaseStatus status, Instant releasedAt, String updatedBy) {}
+            String code,
+            String description,
+            ReleaseStatus status,
+            Instant releasedAt,
+            String milestoneCode,
+            String updatedBy) {}
 
     /* Feature Commands */
     public record CreateFeatureCommand(
@@ -40,6 +48,52 @@ public class Commands {
 
     public record DeleteFeatureCommand(String code, String deletedBy) {}
 
+    /* Feature Planning Commands */
+    public record AssignFeatureToReleaseCommand(
+            String featureCode,
+            String releaseCode,
+            LocalDate plannedCompletionDate,
+            String featureOwner,
+            String notes,
+            String assignedBy) {}
+
+    public record UpdateFeaturePlanningCommand(
+            String featureCode,
+            LocalDate plannedCompletionDate,
+            FeaturePlanningStatus planningStatus,
+            String featureOwner,
+            String notes,
+            String blockageReason,
+            String updatedBy) {}
+
+    public record MoveFeatureToReleaseCommand(
+            String featureCode, String targetReleaseCode, String rationale, String movedBy) {}
+
+    public record RemoveFeatureFromReleaseCommand(String featureCode, String rationale, String removedBy) {}
+
     /* Comment Commands */
     public record CreateCommentCommand(String featureCode, String content, String createdBy) {}
+
+    /* Milestone Commands */
+    public record CreateMilestoneCommand(
+            String productCode,
+            String code,
+            String name,
+            String description,
+            Instant targetDate,
+            MilestoneStatus status,
+            String owner,
+            String notes,
+            String createdBy) {}
+
+    public record UpdateMilestoneCommand(
+            String code,
+            String name,
+            String description,
+            Instant targetDate,
+            Instant actualDate,
+            MilestoneStatus status,
+            String owner,
+            String notes,
+            String updatedBy) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -1,26 +1,37 @@
 package com.sivalabs.ft.features.domain;
 
+import com.sivalabs.ft.features.domain.Commands.AssignFeatureToReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.CreateFeatureCommand;
 import com.sivalabs.ft.features.domain.Commands.DeleteFeatureCommand;
+import com.sivalabs.ft.features.domain.Commands.MoveFeatureToReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.RemoveFeatureFromReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateFeatureCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateFeaturePlanningCommand;
 import com.sivalabs.ft.features.domain.dtos.FeatureDto;
 import com.sivalabs.ft.features.domain.entities.Feature;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.entities.Release;
 import com.sivalabs.ft.features.domain.events.EventPublisher;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.FeatureMapper;
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class FeatureService {
+    private static final Logger log = LoggerFactory.getLogger(FeatureService.class);
     public static final String FEATURE_SEPARATOR = "-";
     private final FavoriteFeatureService favoriteFeatureService;
     private final ReleaseRepository releaseRepository;
@@ -134,5 +145,229 @@ public class FeatureService {
         favoriteFeatureRepository.deleteByFeatureCode(cmd.code());
         featureRepository.deleteByCode(cmd.code());
         eventPublisher.publishFeatureDeletedEvent(feature, cmd.deletedBy(), Instant.now());
+    }
+
+    // Feature Planning Methods
+
+    /**
+     * Validates if a status transition is allowed according to the state machine rules.
+     * Allowed transitions:
+     * - NOT_STARTED -> IN_PROGRESS, BLOCKED
+     * - IN_PROGRESS -> DONE, BLOCKED, NOT_STARTED
+     * - BLOCKED -> IN_PROGRESS, NOT_STARTED
+     * - DONE -> NOT_STARTED, IN_PROGRESS
+     */
+    private void validatePlanningStatusTransition(FeaturePlanningStatus fromStatus, FeaturePlanningStatus toStatus) {
+        if (fromStatus == toStatus) {
+            return; // Same status is always valid
+        }
+
+        Set<FeaturePlanningStatus> allowedTransitions =
+                switch (fromStatus) {
+                    case NOT_STARTED -> Set.of(FeaturePlanningStatus.IN_PROGRESS, FeaturePlanningStatus.BLOCKED);
+                    case IN_PROGRESS ->
+                        Set.of(
+                                FeaturePlanningStatus.DONE,
+                                FeaturePlanningStatus.BLOCKED,
+                                FeaturePlanningStatus.NOT_STARTED);
+                    case BLOCKED -> Set.of(FeaturePlanningStatus.IN_PROGRESS, FeaturePlanningStatus.NOT_STARTED);
+                    case DONE -> Set.of(FeaturePlanningStatus.NOT_STARTED, FeaturePlanningStatus.IN_PROGRESS);
+                };
+
+        if (!allowedTransitions.contains(toStatus)) {
+            throw new BadRequestException("Invalid planning status transition from " + fromStatus + " to " + toStatus);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesWithPlanningByReleaseCode(String releaseCode) {
+        return findFeaturesWithPlanningByReleaseCode(releaseCode, null, null, false, false);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesWithPlanningByReleaseCode(
+            String releaseCode, FeaturePlanningStatus status, String owner, Boolean overdue, Boolean blocked) {
+        var features = featureRepository.findByReleaseCode(releaseCode).stream()
+                .filter(feature -> {
+                    // Filter by planning status
+                    if (status != null && !status.equals(feature.getPlanningStatus())) {
+                        return false;
+                    }
+
+                    // Filter by owner
+                    if (owner != null && !owner.trim().isEmpty()) {
+                        String featureOwner = feature.getFeatureOwner();
+                        if (featureOwner == null || !featureOwner.toLowerCase().contains(owner.toLowerCase())) {
+                            return false;
+                        }
+                    }
+
+                    // Filter by overdue status
+                    if (overdue != null && overdue) {
+                        var plannedDate = feature.getPlannedCompletionDate();
+                        if (plannedDate == null || !plannedDate.isBefore(LocalDate.now())) {
+                            return false;
+                        }
+                    }
+
+                    // Filter by blocked status
+                    if (blocked != null && blocked) {
+                        String blockageReason = feature.getBlockageReason();
+                        if (blockageReason == null || blockageReason.trim().isEmpty()) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                })
+                .toList();
+
+        return features.stream().map(featureMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public FeatureDto findFeatureWithPlanning(String featureCode) {
+        Feature feature = featureRepository
+                .findByCode(featureCode)
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + featureCode));
+        return featureMapper.toDto(feature);
+    }
+
+    @Transactional
+    public void assignFeatureToRelease(AssignFeatureToReleaseCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+        Release release = releaseRepository
+                .findByCode(cmd.releaseCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Release not found: " + cmd.releaseCode()));
+
+        // Check if feature is already assigned to any release (including same release)
+        if (feature.getRelease() != null) {
+            if (feature.getRelease().getCode().equals(cmd.releaseCode())) {
+                throw new BadRequestException(
+                        "Feature " + cmd.featureCode() + " is already assigned to release " + cmd.releaseCode());
+            } else {
+                throw new BadRequestException("Feature " + cmd.featureCode() + " is already assigned to release "
+                        + feature.getRelease().getCode() + ". Use move operation to reassign.");
+            }
+        }
+
+        // Assign feature to release and set planning details
+        feature.setRelease(release);
+        feature.setPlannedCompletionDate(cmd.plannedCompletionDate());
+        feature.setFeatureOwner(cmd.featureOwner());
+        feature.setNotes(cmd.notes());
+        feature.setPlanningStatus(FeaturePlanningStatus.NOT_STARTED);
+        feature.setUpdatedBy(cmd.assignedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        log.info(
+                "Feature {} assigned to release {} by user {}", cmd.featureCode(), cmd.releaseCode(), cmd.assignedBy());
+    }
+
+    @Transactional
+    public void updateFeaturePlanning(UpdateFeaturePlanningCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+
+        // Validate planning status transition
+        if (cmd.planningStatus() != null) {
+            FeaturePlanningStatus currentStatus = feature.getPlanningStatus() != null
+                    ? feature.getPlanningStatus()
+                    : FeaturePlanningStatus.NOT_STARTED;
+            validatePlanningStatusTransition(currentStatus, cmd.planningStatus());
+            feature.setPlanningStatus(cmd.planningStatus());
+
+            // Clear blockage reason when moving away from BLOCKED status
+            if (currentStatus == FeaturePlanningStatus.BLOCKED
+                    && cmd.planningStatus() != FeaturePlanningStatus.BLOCKED) {
+                feature.setBlockageReason(null);
+            }
+        }
+
+        if (cmd.plannedCompletionDate() != null) {
+            feature.setPlannedCompletionDate(cmd.plannedCompletionDate());
+        }
+        if (cmd.featureOwner() != null) {
+            feature.setFeatureOwner(cmd.featureOwner());
+        }
+        if (cmd.notes() != null) {
+            feature.setNotes(cmd.notes());
+        }
+        if (cmd.blockageReason() != null) {
+            feature.setBlockageReason(cmd.blockageReason());
+        }
+
+        feature.setUpdatedBy(cmd.updatedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        log.info("Feature planning updated for feature {} by user {}", cmd.featureCode(), cmd.updatedBy());
+    }
+
+    @Transactional
+    public void moveFeatureToRelease(MoveFeatureToReleaseCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+
+        Release targetRelease = releaseRepository
+                .findByCode(cmd.targetReleaseCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Release not found: " + cmd.targetReleaseCode()));
+
+        String sourceReleaseCode =
+                feature.getRelease() != null ? feature.getRelease().getCode() : "unassigned";
+
+        // Move feature to target release and reset planning status
+        feature.setRelease(targetRelease);
+        feature.setPlanningStatus(FeaturePlanningStatus.NOT_STARTED);
+        feature.setNotes("Moved from " + sourceReleaseCode + ": " + cmd.rationale());
+        feature.setPlannedCompletionDate(null);
+        feature.setBlockageReason(null);
+        feature.setUpdatedBy(cmd.movedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        log.info(
+                "Feature {} moved from {} to release {} by user {} with rationale: {}",
+                cmd.featureCode(),
+                sourceReleaseCode,
+                cmd.targetReleaseCode(),
+                cmd.movedBy(),
+                cmd.rationale());
+    }
+
+    @Transactional
+    public void removeFeatureFromRelease(RemoveFeatureFromReleaseCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+
+        String releaseCode = feature.getRelease() != null ? feature.getRelease().getCode() : "no release";
+
+        // Remove feature from release and clear planning details
+        feature.setRelease(null);
+        feature.setPlanningStatus(null);
+        feature.setPlannedCompletionDate(null);
+        feature.setFeatureOwner(null);
+        feature.setNotes(null);
+        feature.setBlockageReason(null);
+        feature.setUpdatedBy(cmd.removedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        log.info(
+                "Feature {} removed from release {} by user {} with rationale: {}",
+                cmd.featureCode(),
+                releaseCode,
+                cmd.removedBy(),
+                cmd.rationale());
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/MilestoneRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/MilestoneRepository.java
@@ -1,0 +1,34 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Milestone;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
+
+interface MilestoneRepository extends ListCrudRepository<Milestone, Long> {
+    Optional<Milestone> findByCode(String code);
+
+    @Query(
+            """
+            select m from Milestone m
+            left join fetch m.releases
+            where m.code = :code
+            """)
+    Optional<Milestone> findByCodeWithReleases(String code);
+
+    List<Milestone> findByProductCode(String productCode);
+
+    List<Milestone> findByProductCodeAndStatus(String productCode, MilestoneStatus status);
+
+    List<Milestone> findByProductCodeAndOwner(String productCode, String owner);
+
+    List<Milestone> findByProductCodeAndStatusAndOwner(String productCode, MilestoneStatus status, String owner);
+
+    @Modifying
+    void deleteByCode(String code);
+
+    boolean existsByCode(String code);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/MilestoneService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/MilestoneService.java
@@ -1,0 +1,185 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.Commands.CreateMilestoneCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateMilestoneCommand;
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneReleaseDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneSummaryDto;
+import com.sivalabs.ft.features.domain.entities.Milestone;
+import com.sivalabs.ft.features.domain.entities.Product;
+import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import com.sivalabs.ft.features.domain.mappers.MilestoneMapper;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MilestoneService {
+    private final MilestoneRepository milestoneRepository;
+    private final ProductRepository productRepository;
+    private final ReleaseRepository releaseRepository;
+    private final MilestoneMapper milestoneMapper;
+
+    MilestoneService(
+            MilestoneRepository milestoneRepository,
+            ProductRepository productRepository,
+            ReleaseRepository releaseRepository,
+            MilestoneMapper milestoneMapper) {
+        this.milestoneRepository = milestoneRepository;
+        this.productRepository = productRepository;
+        this.releaseRepository = releaseRepository;
+        this.milestoneMapper = milestoneMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MilestoneDto> findMilestoneByCode(String code) {
+        Optional<Milestone> milestoneOptional = milestoneRepository.findByCodeWithReleases(code);
+        if (milestoneOptional.isEmpty()) {
+            return Optional.empty();
+        }
+        Milestone milestone = milestoneOptional.get();
+        MilestoneDto dto = milestoneMapper.toDto(milestone);
+        Integer progress = calculateProgress(new ArrayList<>(milestone.getReleases()));
+        List<MilestoneReleaseDto> releaseDtos =
+                milestoneMapper.toReleaseDtoList(new ArrayList<>(milestone.getReleases()));
+        dto = new MilestoneDto(
+                dto.id(),
+                dto.code(),
+                dto.name(),
+                dto.description(),
+                dto.targetDate(),
+                dto.actualDate(),
+                dto.status(),
+                dto.productCode(),
+                dto.owner(),
+                dto.notes(),
+                progress,
+                releaseDtos,
+                dto.createdBy(),
+                dto.createdAt(),
+                dto.updatedBy(),
+                dto.updatedAt());
+
+        return Optional.of(dto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MilestoneSummaryDto> findMilestonesByProductCode(String productCode, String status, String owner) {
+        List<Milestone> milestones;
+
+        if (StringUtils.isNotBlank(status) && StringUtils.isNotBlank(owner)) {
+            MilestoneStatus milestoneStatus = MilestoneStatus.valueOf(status);
+            milestones = milestoneRepository.findByProductCodeAndStatusAndOwner(productCode, milestoneStatus, owner);
+        } else if (StringUtils.isNotBlank(status)) {
+            MilestoneStatus milestoneStatus = MilestoneStatus.valueOf(status);
+            milestones = milestoneRepository.findByProductCodeAndStatus(productCode, milestoneStatus);
+        } else if (StringUtils.isNotBlank(owner)) {
+            milestones = milestoneRepository.findByProductCodeAndOwner(productCode, owner);
+        } else {
+            milestones = milestoneRepository.findByProductCode(productCode);
+        }
+
+        return milestones.stream()
+                .map(milestone -> {
+                    MilestoneSummaryDto dto = milestoneMapper.toSummaryDto(milestone);
+                    Integer progress = calculateProgress(new ArrayList<>(milestone.getReleases()));
+                    return new MilestoneSummaryDto(
+                            dto.id(),
+                            dto.code(),
+                            dto.name(),
+                            dto.description(),
+                            dto.targetDate(),
+                            dto.actualDate(),
+                            dto.status(),
+                            dto.productCode(),
+                            dto.owner(),
+                            dto.notes(),
+                            progress,
+                            dto.createdBy(),
+                            dto.createdAt(),
+                            dto.updatedBy(),
+                            dto.updatedAt());
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isMilestoneExists(String code) {
+        return milestoneRepository.existsByCode(code);
+    }
+
+    @Transactional
+    public String createMilestone(CreateMilestoneCommand cmd) {
+        if (milestoneRepository.existsByCode(cmd.code())) {
+            throw new BadRequestException("Milestone with code %s already exists".formatted(cmd.code()));
+        }
+        Product product = productRepository
+                .findByCode(cmd.productCode())
+                .orElseThrow(
+                        () -> new BadRequestException("Product with code %s not found".formatted(cmd.productCode())));
+
+        Milestone milestone = new Milestone();
+        milestone.setCode(cmd.code());
+        milestone.setName(cmd.name());
+        milestone.setDescription(cmd.description());
+        milestone.setTargetDate(cmd.targetDate());
+        milestone.setStatus(cmd.status());
+        milestone.setProduct(product);
+        milestone.setOwner(cmd.owner());
+        milestone.setNotes(cmd.notes());
+        milestone.setCreatedBy(cmd.createdBy());
+        milestone.setCreatedAt(Instant.now());
+
+        milestoneRepository.save(milestone);
+        return milestone.getCode();
+    }
+
+    @Transactional
+    public void updateMilestone(UpdateMilestoneCommand cmd) {
+        Milestone milestone = milestoneRepository
+                .findByCode(cmd.code())
+                .orElseThrow(
+                        () -> new ResourceNotFoundException("Milestone with code %s not found".formatted(cmd.code())));
+
+        milestone.setName(cmd.name());
+        milestone.setDescription(cmd.description());
+        milestone.setTargetDate(cmd.targetDate());
+        milestone.setActualDate(cmd.actualDate());
+        milestone.setStatus(cmd.status());
+        milestone.setOwner(cmd.owner());
+        milestone.setNotes(cmd.notes());
+        milestone.setUpdatedBy(cmd.updatedBy());
+        milestone.setUpdatedAt(Instant.now());
+
+        milestoneRepository.save(milestone);
+    }
+
+    @Transactional
+    public void deleteMilestone(String code) {
+        if (!milestoneRepository.existsByCode(code)) {
+            throw new ResourceNotFoundException("Milestone with code %s not found".formatted(code));
+        }
+        releaseRepository.unsetMilestone(code);
+        milestoneRepository.deleteByCode(code);
+    }
+
+    private Integer calculateProgress(List<Release> releases) {
+        if (releases == null || releases.isEmpty()) {
+            return 0;
+        }
+
+        long completedCount = releases.stream()
+                .filter(release -> release.getStatus() == ReleaseStatus.RELEASED)
+                .count();
+
+        return (int) Math.round((completedCount * 100.0) / releases.size());
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
@@ -4,6 +4,7 @@ import com.sivalabs.ft.features.domain.entities.Release;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 
 interface ReleaseRepository extends ListCrudRepository<Release, Long> {
@@ -15,4 +16,8 @@ interface ReleaseRepository extends ListCrudRepository<Release, Long> {
     void deleteByCode(String code);
 
     boolean existsByCode(String code);
+
+    @Modifying
+    @Query("update Release r set r.milestone = null where r.milestone.code = :code")
+    void unsetMilestone(String code);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
@@ -3,8 +3,10 @@ package com.sivalabs.ft.features.domain;
 import com.sivalabs.ft.features.domain.Commands.CreateReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateReleaseCommand;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
+import com.sivalabs.ft.features.domain.entities.Milestone;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.ReleaseMapper;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
@@ -21,16 +23,19 @@ public class ReleaseService {
     private final ProductRepository productRepository;
     private final FeatureRepository featureRepository;
     private final ReleaseMapper releaseMapper;
+    private final MilestoneRepository milestoneRepository;
 
     ReleaseService(
             ReleaseRepository releaseRepository,
             ProductRepository productRepository,
             FeatureRepository featureRepository,
-            ReleaseMapper releaseMapper) {
+            ReleaseMapper releaseMapper,
+            MilestoneRepository milestoneRepository) {
         this.releaseRepository = releaseRepository;
         this.productRepository = productRepository;
         this.featureRepository = featureRepository;
         this.releaseMapper = releaseMapper;
+        this.milestoneRepository = milestoneRepository;
     }
 
     @Transactional(readOnly = true)
@@ -74,6 +79,20 @@ public class ReleaseService {
         release.setDescription(cmd.description());
         release.setStatus(cmd.status());
         release.setReleasedAt(cmd.releasedAt());
+        if (cmd.milestoneCode() != null) {
+            Milestone milestone = milestoneRepository
+                    .findByCode(cmd.milestoneCode())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Milestone with code %s not found".formatted(cmd.milestoneCode())));
+
+            if (!milestone.getProduct().getId().equals(release.getProduct().getId())) {
+                throw new BadRequestException("Milestone and Release must belong to the same Product");
+            }
+
+            release.setMilestone(milestone);
+        } else {
+            release.setMilestone(null);
+        }
         release.setUpdatedBy(cmd.updatedBy());
         release.setUpdatedAt(Instant.now());
         releaseRepository.save(release);

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
@@ -1,8 +1,10 @@
 package com.sivalabs.ft.features.domain.dtos;
 
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import java.io.Serializable;
 import java.time.Instant;
+import java.time.LocalDate;
 
 public record FeatureDto(
         Long id,
@@ -16,7 +18,13 @@ public record FeatureDto(
         String createdBy,
         Instant createdAt,
         String updatedBy,
-        Instant updatedAt)
+        Instant updatedAt,
+        // Planning fields
+        LocalDate plannedCompletionDate,
+        FeaturePlanningStatus planningStatus,
+        String featureOwner,
+        String notes,
+        String blockageReason)
         implements Serializable {
 
     public FeatureDto makeFavorite(boolean favorite) {
@@ -32,6 +40,11 @@ public record FeatureDto(
                 createdBy,
                 createdAt,
                 updatedBy,
-                updatedAt);
+                updatedAt,
+                plannedCompletionDate,
+                planningStatus,
+                featureOwner,
+                notes,
+                blockageReason);
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneDto.java
@@ -1,17 +1,23 @@
 package com.sivalabs.ft.features.domain.dtos;
 
-import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.List;
 
-public record ReleaseDto(
+public record MilestoneDto(
         Long id,
         String code,
+        String name,
         String description,
-        ReleaseStatus status,
-        Instant releasedAt,
-        String milestoneCode,
+        Instant targetDate,
+        Instant actualDate,
+        MilestoneStatus status,
         String productCode,
+        String owner,
+        String notes,
+        Integer progress,
+        List<MilestoneReleaseDto> releases,
         String createdBy,
         Instant createdAt,
         String updatedBy,

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneReleaseDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneReleaseDto.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import java.io.Serializable;
+
+public record MilestoneReleaseDto(Long id, String code, String description, ReleaseStatus status)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneSummaryDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneSummaryDto.java
@@ -1,17 +1,21 @@
 package com.sivalabs.ft.features.domain.dtos;
 
-import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
 import java.io.Serializable;
 import java.time.Instant;
 
-public record ReleaseDto(
+public record MilestoneSummaryDto(
         Long id,
         String code,
+        String name,
         String description,
-        ReleaseStatus status,
-        Instant releasedAt,
-        String milestoneCode,
+        Instant targetDate,
+        Instant actualDate,
+        MilestoneStatus status,
         String productCode,
+        String owner,
+        String notes,
+        Integer progress,
         String createdBy,
         Instant createdAt,
         String updatedBy,

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
@@ -1,10 +1,12 @@
 package com.sivalabs.ft.features.domain.entities;
 
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.time.LocalDate;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
@@ -52,6 +54,23 @@ public class Feature {
 
     @Column(name = "updated_at")
     private Instant updatedAt;
+
+    // Feature Planning fields
+    @Column(name = "planned_completion_date")
+    private LocalDate plannedCompletionDate;
+
+    @Column(name = "planning_status", length = 50)
+    @Enumerated(EnumType.STRING)
+    private FeaturePlanningStatus planningStatus = FeaturePlanningStatus.NOT_STARTED;
+
+    @Size(max = 255) @Column(name = "feature_owner")
+    private String featureOwner;
+
+    @Column(name = "notes", length = Integer.MAX_VALUE)
+    private String notes;
+
+    @Column(name = "blockage_reason", length = Integer.MAX_VALUE)
+    private String blockageReason;
 
     public Long getId() {
         return id;
@@ -147,5 +166,45 @@ public class Feature {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public LocalDate getPlannedCompletionDate() {
+        return plannedCompletionDate;
+    }
+
+    public void setPlannedCompletionDate(LocalDate plannedCompletionDate) {
+        this.plannedCompletionDate = plannedCompletionDate;
+    }
+
+    public FeaturePlanningStatus getPlanningStatus() {
+        return planningStatus;
+    }
+
+    public void setPlanningStatus(FeaturePlanningStatus planningStatus) {
+        this.planningStatus = planningStatus;
+    }
+
+    public String getFeatureOwner() {
+        return featureOwner;
+    }
+
+    public void setFeatureOwner(String featureOwner) {
+        this.featureOwner = featureOwner;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getBlockageReason() {
+        return blockageReason;
+    }
+
+    public void setBlockageReason(String blockageReason) {
+        this.blockageReason = blockageReason;
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java
@@ -1,0 +1,199 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "milestones")
+public class Milestone {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "milestones_id_gen")
+    @SequenceGenerator(name = "milestones_id_gen", sequenceName = "milestone_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "code", nullable = false, length = 50, unique = true)
+    private String code;
+
+    @Size(max = 255) @NotNull @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @NotNull @Column(name = "target_date", nullable = false)
+    private Instant targetDate;
+
+    @Column(name = "actual_date")
+    private Instant actualDate;
+
+    @NotNull @Column(name = "status", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private MilestoneStatus status;
+
+    @NotNull @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Size(max = 255) @Column(name = "owner")
+    private String owner;
+
+    @Column(name = "notes", length = Integer.MAX_VALUE)
+    private String notes;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Size(max = 255) @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @OneToMany(mappedBy = "milestone")
+    private Set<Release> releases = new LinkedHashSet<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        if (updatedAt == null) {
+            this.updatedAt = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Instant getTargetDate() {
+        return targetDate;
+    }
+
+    public void setTargetDate(Instant targetDate) {
+        this.targetDate = targetDate;
+    }
+
+    public Instant getActualDate() {
+        return actualDate;
+    }
+
+    public void setActualDate(Instant actualDate) {
+        this.actualDate = actualDate;
+    }
+
+    public MilestoneStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(MilestoneStatus status) {
+        this.status = status;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(String updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Set<Release> getReleases() {
+        return releases;
+    }
+
+    public void setReleases(Set<Release> releases) {
+        this.releases = releases;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
@@ -34,6 +34,10 @@ public class Release {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "milestone_id")
+    private Milestone milestone;
+
     @Size(max = 50) @NotNull @Column(name = "code", nullable = false, length = 50)
     private String code;
 
@@ -77,6 +81,14 @@ public class Release {
 
     public void setProduct(Product product) {
         this.product = product;
+    }
+
+    public Milestone getMilestone() {
+        return milestone;
+    }
+
+    public void setMilestone(Milestone milestone) {
+        this.milestone = milestone;
     }
 
     public String getCode() {

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
@@ -1,0 +1,26 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneReleaseDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneSummaryDto;
+import com.sivalabs.ft.features.domain.entities.Milestone;
+import com.sivalabs.ft.features.domain.entities.Release;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface MilestoneMapper {
+    @Mapping(target = "productCode", source = "product.code")
+    @Mapping(target = "progress", ignore = true)
+    @Mapping(target = "releases", ignore = true)
+    MilestoneDto toDto(Milestone milestone);
+
+    @Mapping(target = "productCode", source = "product.code")
+    @Mapping(target = "progress", ignore = true)
+    MilestoneSummaryDto toSummaryDto(Milestone milestone);
+
+    MilestoneReleaseDto toReleaseDto(Release release);
+
+    List<MilestoneReleaseDto> toReleaseDtoList(List<Release> releases);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
@@ -3,8 +3,11 @@ package com.sivalabs.ft.features.domain.mappers;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Release;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ReleaseMapper {
+    @Mapping(target = "milestoneCode", source = "milestone.code")
+    @Mapping(target = "productCode", source = "product.code")
     ReleaseDto toDto(Release release);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/models/FeaturePlanningStatus.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/FeaturePlanningStatus.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum FeaturePlanningStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    DONE,
+    BLOCKED
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/MilestoneStatus.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/MilestoneStatus.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum MilestoneStatus {
+    PLANNED,
+    IN_PROGRESS,
+    COMPLETED,
+    DELAYED
+}

--- a/src/main/resources/db/migration/V5__create_feature_planning_table.sql
+++ b/src/main/resources/db/migration/V5__create_feature_planning_table.sql
@@ -1,0 +1,15 @@
+-- Add feature planning fields to existing features table
+ALTER TABLE features ADD COLUMN planned_completion_date DATE;
+ALTER TABLE features ADD COLUMN planning_status VARCHAR(50);
+ALTER TABLE features ADD COLUMN feature_owner VARCHAR(255);
+ALTER TABLE features ADD COLUMN notes TEXT;
+ALTER TABLE features ADD COLUMN blockage_reason TEXT;
+
+-- Add index for querying features by planning status
+CREATE INDEX idx_features_planning_status ON features(planning_status);
+
+-- Add index for querying features by feature owner
+CREATE INDEX idx_features_feature_owner ON features(feature_owner);
+
+-- Add index for querying overdue features (planned completion date in the past)
+CREATE INDEX idx_features_planned_completion ON features(planned_completion_date);

--- a/src/main/resources/db/migration/V6__create_milestones_table.sql
+++ b/src/main/resources/db/migration/V6__create_milestones_table.sql
@@ -1,0 +1,31 @@
+create sequence milestone_id_seq start with 100 increment by 50;
+
+create table milestones
+(
+    id          bigint       not null default nextval('milestone_id_seq'),
+    code        varchar(50)  not null unique,
+    name        varchar(255) not null,
+    description text,
+    target_date timestamp    not null,
+    actual_date timestamp,
+    status      varchar(50)  not null,
+    product_id  bigint       not null,
+    owner       varchar(255),
+    notes       text,
+    created_by  varchar(255) not null,
+    created_at  timestamp    not null default current_timestamp,
+    updated_by  varchar(255),
+    updated_at  timestamp,
+    primary key (id),
+    constraint fk_milestones_product foreign key (product_id) references products(id)
+);
+
+create index idx_milestones_product_id on milestones(product_id);
+create index idx_milestones_status on milestones(status);
+create index idx_milestones_owner on milestones(owner);
+
+alter table releases add column milestone_id bigint;
+alter table releases add constraint fk_releases_milestone
+    foreign key (milestone_id) references milestones(id) on delete set null;
+
+create index idx_releases_milestone_id on releases(milestone_id);

--- a/src/test/java/com/sivalabs/ft/features/api/GlobalExceptionHandlerIntegrationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/GlobalExceptionHandlerIntegrationTests.java
@@ -1,0 +1,33 @@
+package com.sivalabs.ft.features.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.domain.FeatureService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class GlobalExceptionHandlerIntegrationTests extends AbstractIT {
+
+    @MockitoBean
+    private FeatureService featureService;
+
+    @Test
+    void shouldReturnInternalServerErrorForUnhandledException() {
+        when(featureService.findFeaturesWithPlanningByReleaseCode(any(), any(), any(), any(), any()))
+                .thenThrow(new RuntimeException("unexpected"));
+
+        var result = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+
+        assertThat(result)
+                .hasStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Internal Server Error");
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseFeaturePlanningIntegrationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseFeaturePlanningIntegrationTests.java
@@ -1,0 +1,404 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("Release Feature Planning Integration Tests")
+class ReleaseFeaturePlanningIntegrationTests extends AbstractIT {
+
+    @Test
+    @DisplayName("Should validate required fields in assign feature payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateRequiredFieldsInAssignFeaturePayload() {
+        var invalidPayload =
+                """
+        {
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Missing featureCode"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidPayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should validate date format in assign feature payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateDateFormatInAssignFeaturePayload() {
+        var invalidDatePayload =
+                """
+        {
+        "featureCode": "IDEA-6",
+        "plannedCompletionDate": "invalid-date",
+        "featureOwner": "john.doe",
+        "notes": "Invalid date format"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidDatePayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should validate date format in update feature planning payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateDateFormatInUpdateFeaturePlanningPayload() {
+        var invalidDatePayload =
+                """
+        {
+        "plannedCompletionDate": "invalid-date",
+        "planningStatus": "IN_PROGRESS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidDatePayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should validate status enum in update feature planning payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateStatusEnumInUpdateFeaturePlanningPayload() {
+        var invalidStatusPayload = """
+        {
+        "planningStatus": "INVALID_STATUS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidStatusPayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should validate empty payload structure")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateEmptyPayloadStructure() {
+        // Test assign feature with empty payload - this is different from missing required fields
+        var result = mvc.post()
+                .uri("/api/releases/IDEA-2023.3.8/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should handle invalid planningStatus filter")
+    void shouldHandleInvalidPlanningStatusFilter() {
+        var result = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?planningStatus=INVALID_STATUS", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should reject invalid status transition from NOT_STARTED to DONE")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectInvalidStatusTransition() {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-5",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Initial assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        var invalidUpdatePayload = """
+        {
+        "planningStatus": "DONE"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidUpdatePayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should reject NOT_STARTED → DONE transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectNotStartedToDoneTransition() {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-7",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should reject BLOCKED → DONE transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectBlockedToDoneTransition() {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-8",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Waiting\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should reject DONE → BLOCKED transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectDoneToBlockedTransition() {
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Should not work\"}")
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Bad Request");
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when assigning to release")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenAssigningToRelease() {
+        var payload =
+                """
+        {
+        "featureCode": "NON_EXISTENT_FEATURE",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment of non-existent feature"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Resource not found");
+    }
+
+    @Test
+    @DisplayName("Should handle release not found when assigning feature")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleReleaseNotFoundWhenAssigningFeature() {
+        var payload =
+                """
+        {
+        "featureCode": "IDEA-1",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment to non-existent release"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "NON_EXISTENT_RELEASE")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Resource not found");
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when updating planning")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenUpdatingPlanning() {
+        var updatePayload = """
+        {
+        "planningStatus": "IN_PROGRESS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "NON_EXISTENT")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Resource not found");
+    }
+
+    @Test
+    @DisplayName("Should handle release not found when moving feature")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleReleaseNotFoundWhenMovingFeature() {
+        var movePayload =
+                """
+        {
+        "targetReleaseCode": "NON_EXISTENT_RELEASE",
+        "rationale": "Moving to non-existent release"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{targetReleaseCode}/features/{featureCode}/move", "NON_EXISTENT_RELEASE", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(movePayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Resource not found");
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when moving")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenMoving() {
+        var movePayload =
+                """
+        {
+        "targetReleaseCode": "RIDER-2024.2.6",
+        "rationale": "Moving non-existent feature"
+        }
+        """;
+        var result = mvc.post()
+                .uri(
+                        "/api/releases/{targetReleaseCode}/features/{featureCode}/move",
+                        "RIDER-2024.2.6",
+                        "NON_EXISTENT_FEATURE")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(movePayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Resource not found");
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when removing")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenRemoving() {
+        var removePayload = """
+        {
+        "rationale": "Removing non-existent feature"
+        }
+        """;
+        var result = mvc.delete()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}", "IDEA-2023.3.8", "NON_EXISTENT_FEATURE")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(removePayload)
+                .exchange();
+        assertThat(result)
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.title")
+                .isEqualTo("Resource not found");
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -21,10 +21,13 @@ insert into releases (id, product_id, code, description, status, created_by, cre
 (6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
 ;
 
-insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at) values
-(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24'),
-(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14'),
-(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14')
+insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at, planning_status) values
+(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24', null),
+(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14', null),
+(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14', null),
+(4, 1, null, 'IDEA-5', 'New unassigned feature 3', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-02-27', 'NOT_STARTED'),
+(5, 1, null, 'IDEA-7', 'New unassigned feature 5', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-03-01', 'NOT_STARTED'),
+(6, 1, null, 'IDEA-8', 'New unassigned feature 6', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-03-02', 'NOT_STARTED')
 ;
 
 insert into favorite_features (id, feature_id, user_id) values


### PR DESCRIPTION
## Description

Sending a request with an invalid payload — such as a missing required field, a malformed date, or an unknown enum constant — causes an unhandled exception to propagate as a 500 Internal Server Error.

The same applies to requests with an invalid enum value as a query parameter.
In all these cases the API should respond with 400 Bad Request.

## Steps to Reproduce

### Scenario 1: Invalid request body

POST `/api/releases/IDEA-2023.3.8/features` with an empty body or invalid field value:

```json
{
  "featureCode": "IDEA-6",
  "plannedCompletionDate": "invalid-date",
  "featureOwner": "john.doe",
  "notes": "Invalid date format"
}
```

### Scenario 2: Invalid query parameter

GET `/api/releases/IDEA-2023.3.8/features?planningStatus=INVALID_STATUS`

## Expected Result

All of the above requests should return **400 Bad Request**.
Instead, the server responds with **500 Internal Server Error**.

