### PR TITLE
Wrong date/time field format in Kafka event

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "KafkaEventsIntegrationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -5,5 +5,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "ft")
 public record ApplicationProperties(EventsProperties events) {
 
-    public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
+    public record EventsProperties(
+            String newFeatures,
+            String updatedFeatures,
+            String deletedFeatures,
+            String updatedReleases,
+            String updatedMilestones) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -37,6 +39,24 @@ class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException.class)
     ProblemDetail handle(BadRequestException e) {
         log.error("Bad Request", e);
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    ProblemDetail handle(HttpMessageNotReadableException e) {
+        log.warn("Invalid JSON request", e);
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ProblemDetail handle(MethodArgumentNotValidException e) {
+        log.warn("Validation failed", e);
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
         problemDetail.setTitle("Bad Request");
         problemDetail.setProperty("timestamp", Instant.now());

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/MilestoneController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/MilestoneController.java
@@ -1,0 +1,179 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.api.models.CreateMilestonePayload;
+import com.sivalabs.ft.features.api.models.UpdateMilestonePayload;
+import com.sivalabs.ft.features.api.utils.SecurityUtils;
+import com.sivalabs.ft.features.domain.Commands.CreateMilestoneCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateMilestoneCommand;
+import com.sivalabs.ft.features.domain.MilestoneService;
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneSummaryDto;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/milestones")
+@Tag(name = "Milestones API")
+class MilestoneController {
+    private static final Logger log = LoggerFactory.getLogger(MilestoneController.class);
+    private final MilestoneService milestoneService;
+
+    MilestoneController(MilestoneService milestoneService) {
+        this.milestoneService = milestoneService;
+    }
+
+    @GetMapping("")
+    @Operation(
+            summary = "Find milestones by product code",
+            description = "Find milestones by product code with optional filters",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = MilestoneSummaryDto.class)))),
+                @ApiResponse(responseCode = "400", description = "Missing required parameter"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    List<MilestoneSummaryDto> getMilestones(
+            @RequestParam(value = "productCode", required = false) String productCode,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "owner", required = false) String owner) {
+        if (StringUtils.isBlank(productCode)) {
+            throw new BadRequestException("productCode is required");
+        }
+        return milestoneService.findMilestonesByProductCode(productCode, status, owner);
+    }
+
+    @GetMapping("/{code}")
+    @Operation(
+            summary = "Find milestone by code",
+            description = "Find milestone by code with associated releases",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = MilestoneDto.class))),
+                @ApiResponse(responseCode = "404", description = "Milestone not found"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    ResponseEntity<MilestoneDto> getMilestone(@PathVariable String code) {
+        return milestoneService
+                .findMilestoneByCode(code)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("")
+    @Operation(
+            summary = "Create a new milestone",
+            description = "Create a new milestone",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Successful response",
+                        headers =
+                                @Header(
+                                        name = "Location",
+                                        required = true,
+                                        description = "URI of the created milestone")),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+            })
+    ResponseEntity<Void> createMilestone(@RequestBody @Valid CreateMilestonePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new CreateMilestoneCommand(
+                payload.productCode(),
+                payload.code(),
+                payload.name(),
+                payload.description(),
+                payload.targetDate(),
+                payload.status(),
+                payload.owner(),
+                payload.notes(),
+                username);
+        String code = milestoneService.createMilestone(cmd);
+        log.info("Created milestone with code {}", code);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{code}")
+                .buildAndExpand(code)
+                .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+    @PutMapping("/{code}")
+    @Operation(
+            summary = "Update an existing milestone",
+            description = "Update an existing milestone",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Successful response"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Milestone not found")
+            })
+    void updateMilestone(@PathVariable String code, @RequestBody @Valid UpdateMilestonePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new UpdateMilestoneCommand(
+                code,
+                payload.name(),
+                payload.description(),
+                payload.targetDate(),
+                payload.actualDate(),
+                payload.status(),
+                payload.owner(),
+                payload.notes(),
+                username);
+        milestoneService.updateMilestone(cmd);
+    }
+
+    @DeleteMapping("/{code}")
+    @Operation(
+            summary = "Delete an existing milestone",
+            description = "Delete an existing milestone",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Successful response"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Milestone not found")
+            })
+    ResponseEntity<Void> deleteMilestone(@PathVariable String code) {
+        if (!milestoneService.isMilestoneExists(code)) {
+            return ResponseEntity.notFound().build();
+        }
+        milestoneService.deleteMilestone(code);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
@@ -1,12 +1,24 @@
 package com.sivalabs.ft.features.api.controllers;
 
+import com.sivalabs.ft.features.api.models.AssignFeatureToReleasePayload;
 import com.sivalabs.ft.features.api.models.CreateReleasePayload;
+import com.sivalabs.ft.features.api.models.MoveFeaturePayload;
+import com.sivalabs.ft.features.api.models.RemoveFeaturePayload;
+import com.sivalabs.ft.features.api.models.UpdateFeaturePlanningPayload;
 import com.sivalabs.ft.features.api.models.UpdateReleasePayload;
 import com.sivalabs.ft.features.api.utils.SecurityUtils;
+import com.sivalabs.ft.features.domain.Commands.AssignFeatureToReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.CreateReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.MoveFeatureToReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.RemoveFeatureFromReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateFeaturePlanningCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateReleaseCommand;
+import com.sivalabs.ft.features.domain.FeatureService;
 import com.sivalabs.ft.features.domain.ReleaseService;
+import com.sivalabs.ft.features.domain.dtos.FeatureDto;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -22,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -37,9 +50,11 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 class ReleaseController {
     private static final Logger log = LoggerFactory.getLogger(ReleaseController.class);
     private final ReleaseService releaseService;
+    private final FeatureService featureService;
 
-    ReleaseController(ReleaseService releaseService) {
+    ReleaseController(ReleaseService releaseService, FeatureService featureService) {
         this.releaseService = releaseService;
+        this.featureService = featureService;
     }
 
     @GetMapping("")
@@ -121,8 +136,8 @@ class ReleaseController {
             })
     void updateRelease(@PathVariable String code, @RequestBody UpdateReleasePayload payload) {
         var username = SecurityUtils.getCurrentUsername();
-        var cmd =
-                new UpdateReleaseCommand(code, payload.description(), payload.status(), payload.releasedAt(), username);
+        var cmd = new UpdateReleaseCommand(
+                code, payload.description(), payload.status(), payload.releasedAt(), payload.milestoneCode(), username);
         releaseService.updateRelease(cmd);
     }
 
@@ -141,6 +156,152 @@ class ReleaseController {
             return ResponseEntity.notFound().build();
         }
         releaseService.deleteRelease(code);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{releaseCode}/features")
+    @Operation(
+            summary = "Assign a feature to a release",
+            description = "Assign a feature to a release with planning details",
+            responses = {
+                @ApiResponse(responseCode = "201", description = "Feature assigned successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+                @ApiResponse(responseCode = "409", description = "Feature already assigned to this release"),
+            })
+    ResponseEntity<Void> assignFeatureToRelease(
+            @PathVariable String releaseCode, @RequestBody @Valid AssignFeatureToReleasePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new AssignFeatureToReleaseCommand(
+                payload.featureCode(),
+                releaseCode,
+                payload.plannedCompletionDate(),
+                payload.featureOwner(),
+                payload.notes(),
+                username);
+        featureService.assignFeatureToRelease(cmd);
+        log.info("Feature {} assigned to release {} by user {}", payload.featureCode(), releaseCode, username);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{featureCode}")
+                .buildAndExpand(payload.featureCode())
+                .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+    @GetMapping("/{releaseCode}/features")
+    @Operation(
+            summary = "Get all features assigned to a release",
+            description =
+                    "Get all features assigned to a release with planning details. Supports filtering by planningStatus, owner, overdue, and blocked status.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = FeatureDto.class)))),
+                @ApiResponse(responseCode = "404", description = "Release not found"),
+            })
+    List<FeatureDto> getFeaturesByRelease(
+            @PathVariable String releaseCode,
+            @RequestParam(required = false) String planningStatus,
+            @RequestParam(required = false) String owner,
+            @RequestParam(required = false) Boolean overdue,
+            @RequestParam(required = false) Boolean blocked) {
+
+        // Convert string planningStatus to enum if provided
+        FeaturePlanningStatus planningStatusEnum = null;
+        if (planningStatus != null && !planningStatus.trim().isEmpty()) {
+            try {
+                planningStatusEnum = FeaturePlanningStatus.valueOf(planningStatus.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("Invalid planningStatus: " + planningStatus);
+            }
+        }
+
+        return featureService.findFeaturesWithPlanningByReleaseCode(
+                releaseCode, planningStatusEnum, owner, overdue, blocked);
+    }
+
+    @PatchMapping("/{releaseCode}/features/{featureCode}/planning")
+    @Operation(
+            summary = "Update feature planning details",
+            description = "Update planning details (dates, status, owner, blockage reason) for a feature in a release",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Planning updated successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid request or invalid status transition"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+            })
+    ResponseEntity<Void> updateFeaturePlanning(
+            @PathVariable String releaseCode,
+            @PathVariable String featureCode,
+            @RequestBody UpdateFeaturePlanningPayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new UpdateFeaturePlanningCommand(
+                featureCode,
+                payload.plannedCompletionDate(),
+                payload.planningStatus(),
+                payload.featureOwner(),
+                payload.notes(),
+                payload.blockageReason(),
+                username);
+        featureService.updateFeaturePlanning(cmd);
+        log.info("Feature {} planning updated in release {} by user {}", featureCode, releaseCode, username);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{targetReleaseCode}/features/{featureCode}/move")
+    @Operation(
+            summary = "Move a feature between releases",
+            description = "Move a feature from its current release to another release",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Feature moved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+                @ApiResponse(responseCode = "409", description = "Feature already assigned to target release"),
+            })
+    ResponseEntity<Void> moveFeature(
+            @PathVariable String targetReleaseCode,
+            @PathVariable String featureCode,
+            @RequestBody MoveFeaturePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd = new MoveFeatureToReleaseCommand(featureCode, targetReleaseCode, payload.rationale(), username);
+        featureService.moveFeatureToRelease(cmd);
+        log.info(
+                "Feature {} moved to release {} by user {} with rationale: {}",
+                featureCode,
+                targetReleaseCode,
+                username,
+                payload.rationale());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{releaseCode}/features/{featureCode}")
+    @Operation(
+            summary = "Remove a feature from a release",
+            description = "Remove a feature from a release",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Feature removed successfully"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Feature or release not found"),
+            })
+    ResponseEntity<Void> removeFeatureFromRelease(
+            @PathVariable String releaseCode,
+            @PathVariable String featureCode,
+            @RequestBody(required = false) RemoveFeaturePayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var rationale = payload != null ? payload.rationale() : null;
+        var cmd = new RemoveFeatureFromReleaseCommand(featureCode, rationale, username);
+        featureService.removeFeatureFromRelease(cmd);
+        log.info("Feature {} removed from release {} by user {}", featureCode, releaseCode, username);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/api/models/AssignFeatureToReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/AssignFeatureToReleasePayload.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.api.models;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+public record AssignFeatureToReleasePayload(
+        @NotBlank String featureCode, LocalDate plannedCompletionDate, String featureOwner, String notes) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/CreateMilestonePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/CreateMilestonePayload.java
@@ -1,0 +1,17 @@
+package com.sivalabs.ft.features.api.models;
+
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+public record CreateMilestonePayload(
+        @NotEmpty(message = "Product code is required") String productCode,
+        @Size(max = 50, message = "Milestone code cannot exceed 50 characters") @NotEmpty(message = "Milestone code is required") String code,
+        @Size(max = 255, message = "Milestone name cannot exceed 255 characters") @NotEmpty(message = "Milestone name is required") String name,
+        String description,
+        @NotNull(message = "Target date is required") Instant targetDate,
+        @NotNull(message = "Status is required") MilestoneStatus status,
+        String owner,
+        String notes) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/MoveFeaturePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/MoveFeaturePayload.java
@@ -1,0 +1,5 @@
+package com.sivalabs.ft.features.api.models;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MoveFeaturePayload(@NotBlank String targetReleaseCode, String rationale) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/RemoveFeaturePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/RemoveFeaturePayload.java
@@ -1,0 +1,3 @@
+package com.sivalabs.ft.features.api.models;
+
+public record RemoveFeaturePayload(String rationale) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateFeaturePlanningPayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateFeaturePlanningPayload.java
@@ -1,0 +1,11 @@
+package com.sivalabs.ft.features.api.models;
+
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
+import java.time.LocalDate;
+
+public record UpdateFeaturePlanningPayload(
+        LocalDate plannedCompletionDate,
+        FeaturePlanningStatus planningStatus,
+        String featureOwner,
+        String notes,
+        String blockageReason) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateMilestonePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateMilestonePayload.java
@@ -1,0 +1,16 @@
+package com.sivalabs.ft.features.api.models;
+
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+public record UpdateMilestonePayload(
+        @Size(max = 255, message = "Milestone name cannot exceed 255 characters") @NotEmpty(message = "Milestone name is required") String name,
+        String description,
+        @NotNull(message = "Target date is required") Instant targetDate,
+        Instant actualDate,
+        @NotNull(message = "Status is required") MilestoneStatus status,
+        String owner,
+        String notes) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
@@ -1,6 +1,11 @@
 package com.sivalabs.ft.features.api.models;
 
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import jakarta.validation.constraints.Size;
 import java.time.Instant;
 
-public record UpdateReleasePayload(String description, ReleaseStatus status, Instant releasedAt) {}
+public record UpdateReleasePayload(
+        String description,
+        ReleaseStatus status,
+        Instant releasedAt,
+        @Size(max = 50, message = "Milestone code cannot exceed 50 characters") String milestoneCode) {}

--- a/src/main/java/com/sivalabs/ft/features/config/KafkaConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/KafkaConfig.java
@@ -1,0 +1,16 @@
+package com.sivalabs.ft.features.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.kafka.DefaultKafkaProducerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+class KafkaConfig {
+
+    @Bean
+    DefaultKafkaProducerFactoryCustomizer kafkaJsonSerializerCustomizer(ObjectMapper objectMapper) {
+        return producerFactory -> producerFactory.setValueSerializer(new JsonSerializer<>(objectMapper));
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/OpenAPIConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/OpenAPIConfig.java
@@ -33,7 +33,10 @@ class OpenAPIConfig {
         List<Tag> tags = List.of(
                 new Tag().name("Products API").description("API endpoints to manage products"),
                 new Tag().name("Releases API").description("API endpoints to manage releases"),
-                new Tag().name("Features API").description("API endpoints to manage features"));
+                new Tag().name("Features API").description("API endpoints to manage features"),
+                new Tag().name("Comments API").description("API endpoints to manage comments"),
+                new Tag().name("Favorite Features API").description("API endpoints to manage favorite features"),
+                new Tag().name("Milestones API").description("API endpoints to manage milestones"));
         return new OpenAPI()
                 .info(info)
                 .addSecurityItem(new SecurityRequirement().addList("Authorization"))

--- a/src/main/java/com/sivalabs/ft/features/domain/Commands.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/Commands.java
@@ -1,8 +1,11 @@
 package com.sivalabs.ft.features.domain;
 
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
 import java.time.Instant;
+import java.time.LocalDate;
 
 public class Commands {
     private Commands() {}
@@ -18,7 +21,12 @@ public class Commands {
     public record CreateReleaseCommand(String productCode, String code, String description, String createdBy) {}
 
     public record UpdateReleaseCommand(
-            String code, String description, ReleaseStatus status, Instant releasedAt, String updatedBy) {}
+            String code,
+            String description,
+            ReleaseStatus status,
+            Instant releasedAt,
+            String milestoneCode,
+            String updatedBy) {}
 
     /* Feature Commands */
     public record CreateFeatureCommand(
@@ -40,6 +48,52 @@ public class Commands {
 
     public record DeleteFeatureCommand(String code, String deletedBy) {}
 
+    /* Feature Planning Commands */
+    public record AssignFeatureToReleaseCommand(
+            String featureCode,
+            String releaseCode,
+            LocalDate plannedCompletionDate,
+            String featureOwner,
+            String notes,
+            String assignedBy) {}
+
+    public record UpdateFeaturePlanningCommand(
+            String featureCode,
+            LocalDate plannedCompletionDate,
+            FeaturePlanningStatus planningStatus,
+            String featureOwner,
+            String notes,
+            String blockageReason,
+            String updatedBy) {}
+
+    public record MoveFeatureToReleaseCommand(
+            String featureCode, String targetReleaseCode, String rationale, String movedBy) {}
+
+    public record RemoveFeatureFromReleaseCommand(String featureCode, String rationale, String removedBy) {}
+
     /* Comment Commands */
     public record CreateCommentCommand(String featureCode, String content, String createdBy) {}
+
+    /* Milestone Commands */
+    public record CreateMilestoneCommand(
+            String productCode,
+            String code,
+            String name,
+            String description,
+            Instant targetDate,
+            MilestoneStatus status,
+            String owner,
+            String notes,
+            String createdBy) {}
+
+    public record UpdateMilestoneCommand(
+            String code,
+            String name,
+            String description,
+            Instant targetDate,
+            Instant actualDate,
+            MilestoneStatus status,
+            String owner,
+            String notes,
+            String updatedBy) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -1,26 +1,37 @@
 package com.sivalabs.ft.features.domain;
 
+import com.sivalabs.ft.features.domain.Commands.AssignFeatureToReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.CreateFeatureCommand;
 import com.sivalabs.ft.features.domain.Commands.DeleteFeatureCommand;
+import com.sivalabs.ft.features.domain.Commands.MoveFeatureToReleaseCommand;
+import com.sivalabs.ft.features.domain.Commands.RemoveFeatureFromReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateFeatureCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateFeaturePlanningCommand;
 import com.sivalabs.ft.features.domain.dtos.FeatureDto;
 import com.sivalabs.ft.features.domain.entities.Feature;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.entities.Release;
 import com.sivalabs.ft.features.domain.events.EventPublisher;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.FeatureMapper;
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class FeatureService {
+    private static final Logger log = LoggerFactory.getLogger(FeatureService.class);
     public static final String FEATURE_SEPARATOR = "-";
     private final FavoriteFeatureService favoriteFeatureService;
     private final ReleaseRepository releaseRepository;
@@ -134,5 +145,245 @@ public class FeatureService {
         favoriteFeatureRepository.deleteByFeatureCode(cmd.code());
         featureRepository.deleteByCode(cmd.code());
         eventPublisher.publishFeatureDeletedEvent(feature, cmd.deletedBy(), Instant.now());
+    }
+
+    // Feature Planning Methods
+
+    /**
+     * Validates if a status transition is allowed according to the state machine rules.
+     * Allowed transitions:
+     * - NOT_STARTED -> IN_PROGRESS, BLOCKED
+     * - IN_PROGRESS -> DONE, BLOCKED, NOT_STARTED
+     * - BLOCKED -> IN_PROGRESS, NOT_STARTED
+     * - DONE -> NOT_STARTED, IN_PROGRESS
+     */
+    private void validatePlanningStatusTransition(FeaturePlanningStatus fromStatus, FeaturePlanningStatus toStatus) {
+        if (fromStatus == toStatus) {
+            return; // Same status is always valid
+        }
+
+        Set<FeaturePlanningStatus> allowedTransitions =
+                switch (fromStatus) {
+                    case NOT_STARTED -> Set.of(FeaturePlanningStatus.IN_PROGRESS, FeaturePlanningStatus.BLOCKED);
+                    case IN_PROGRESS ->
+                        Set.of(
+                                FeaturePlanningStatus.DONE,
+                                FeaturePlanningStatus.BLOCKED,
+                                FeaturePlanningStatus.NOT_STARTED);
+                    case BLOCKED -> Set.of(FeaturePlanningStatus.IN_PROGRESS, FeaturePlanningStatus.NOT_STARTED);
+                    case DONE -> Set.of(FeaturePlanningStatus.NOT_STARTED, FeaturePlanningStatus.IN_PROGRESS);
+                };
+
+        if (!allowedTransitions.contains(toStatus)) {
+            throw new BadRequestException("Invalid planning status transition from " + fromStatus + " to " + toStatus);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesWithPlanningByReleaseCode(String releaseCode) {
+        return findFeaturesWithPlanningByReleaseCode(releaseCode, null, null, false, false);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesWithPlanningByReleaseCode(
+            String releaseCode, FeaturePlanningStatus status, String owner, Boolean overdue, Boolean blocked) {
+        var features = featureRepository.findByReleaseCode(releaseCode).stream()
+                .filter(feature -> {
+                    // Filter by planning status
+                    if (status != null && !status.equals(feature.getPlanningStatus())) {
+                        return false;
+                    }
+
+                    // Filter by owner
+                    if (owner != null && !owner.trim().isEmpty()) {
+                        String featureOwner = feature.getFeatureOwner();
+                        if (featureOwner == null || !featureOwner.toLowerCase().contains(owner.toLowerCase())) {
+                            return false;
+                        }
+                    }
+
+                    // Filter by overdue status
+                    if (overdue != null && overdue) {
+                        var plannedDate = feature.getPlannedCompletionDate();
+                        if (plannedDate == null || !plannedDate.isBefore(LocalDate.now())) {
+                            return false;
+                        }
+                    }
+
+                    // Filter by blocked status
+                    if (blocked != null && blocked) {
+                        String blockageReason = feature.getBlockageReason();
+                        if (blockageReason == null || blockageReason.trim().isEmpty()) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                })
+                .toList();
+
+        return features.stream().map(featureMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public FeatureDto findFeatureWithPlanning(String featureCode) {
+        Feature feature = featureRepository
+                .findByCode(featureCode)
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + featureCode));
+        return featureMapper.toDto(feature);
+    }
+
+    @Transactional
+    public void assignFeatureToRelease(AssignFeatureToReleaseCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+        Release release = releaseRepository
+                .findByCode(cmd.releaseCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Release not found: " + cmd.releaseCode()));
+
+        // Check if feature is already assigned to any release (including same release)
+        if (feature.getRelease() != null) {
+            if (feature.getRelease().getCode().equals(cmd.releaseCode())) {
+                throw new BadRequestException(
+                        "Feature " + cmd.featureCode() + " is already assigned to release " + cmd.releaseCode());
+            } else {
+                throw new BadRequestException("Feature " + cmd.featureCode() + " is already assigned to release "
+                        + feature.getRelease().getCode() + ". Use move operation to reassign.");
+            }
+        }
+
+        // Assign feature to release and set planning details
+        feature.setRelease(release);
+        feature.setPlannedCompletionDate(cmd.plannedCompletionDate());
+        feature.setFeatureOwner(cmd.featureOwner());
+        feature.setNotes(cmd.notes());
+        feature.setPlanningStatus(FeaturePlanningStatus.NOT_STARTED);
+        feature.setUpdatedBy(cmd.assignedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        // Publish enhanced feature updated event
+        FeatureDto featureDto = featureMapper.toDto(feature);
+        eventPublisher.publishEnhancedFeatureUpdatedEvent(featureDto);
+
+        log.info(
+                "Feature {} assigned to release {} by user {}", cmd.featureCode(), cmd.releaseCode(), cmd.assignedBy());
+    }
+
+    @Transactional
+    public void updateFeaturePlanning(UpdateFeaturePlanningCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+
+        // Validate planning status transition
+        if (cmd.planningStatus() != null) {
+            FeaturePlanningStatus currentStatus = feature.getPlanningStatus() != null
+                    ? feature.getPlanningStatus()
+                    : FeaturePlanningStatus.NOT_STARTED;
+            validatePlanningStatusTransition(currentStatus, cmd.planningStatus());
+            feature.setPlanningStatus(cmd.planningStatus());
+
+            // Clear blockage reason when moving away from BLOCKED status
+            if (currentStatus == FeaturePlanningStatus.BLOCKED
+                    && cmd.planningStatus() != FeaturePlanningStatus.BLOCKED) {
+                feature.setBlockageReason(null);
+            }
+        }
+
+        if (cmd.plannedCompletionDate() != null) {
+            feature.setPlannedCompletionDate(cmd.plannedCompletionDate());
+        }
+        if (cmd.featureOwner() != null) {
+            feature.setFeatureOwner(cmd.featureOwner());
+        }
+        if (cmd.notes() != null) {
+            feature.setNotes(cmd.notes());
+        }
+        if (cmd.blockageReason() != null) {
+            feature.setBlockageReason(cmd.blockageReason());
+        }
+
+        feature.setUpdatedBy(cmd.updatedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        // Publish enhanced feature updated event
+        FeatureDto featureDto = featureMapper.toDto(feature);
+        eventPublisher.publishEnhancedFeatureUpdatedEvent(featureDto);
+
+        log.info("Feature planning updated for feature {} by user {}", cmd.featureCode(), cmd.updatedBy());
+    }
+
+    @Transactional
+    public void moveFeatureToRelease(MoveFeatureToReleaseCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+
+        Release targetRelease = releaseRepository
+                .findByCode(cmd.targetReleaseCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Release not found: " + cmd.targetReleaseCode()));
+
+        String sourceReleaseCode =
+                feature.getRelease() != null ? feature.getRelease().getCode() : "unassigned";
+
+        // Move feature to target release and reset planning status
+        feature.setRelease(targetRelease);
+        feature.setPlanningStatus(FeaturePlanningStatus.NOT_STARTED);
+        feature.setNotes("Moved from " + sourceReleaseCode + ": " + cmd.rationale());
+        feature.setPlannedCompletionDate(null);
+        feature.setBlockageReason(null);
+        feature.setUpdatedBy(cmd.movedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        // Publish enhanced feature updated event
+        FeatureDto featureDto = featureMapper.toDto(feature);
+        eventPublisher.publishEnhancedFeatureUpdatedEvent(featureDto);
+
+        log.info(
+                "Feature {} moved from {} to release {} by user {} with rationale: {}",
+                cmd.featureCode(),
+                sourceReleaseCode,
+                cmd.targetReleaseCode(),
+                cmd.movedBy(),
+                cmd.rationale());
+    }
+
+    @Transactional
+    public void removeFeatureFromRelease(RemoveFeatureFromReleaseCommand cmd) {
+        Feature feature = featureRepository
+                .findByCode(cmd.featureCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Feature not found: " + cmd.featureCode()));
+
+        String releaseCode = feature.getRelease() != null ? feature.getRelease().getCode() : "no release";
+
+        // Remove feature from release and clear planning details
+        feature.setRelease(null);
+        feature.setPlanningStatus(null);
+        feature.setPlannedCompletionDate(null);
+        feature.setFeatureOwner(null);
+        feature.setNotes(null);
+        feature.setBlockageReason(null);
+        feature.setUpdatedBy(cmd.removedBy());
+        feature.setUpdatedAt(Instant.now());
+
+        featureRepository.save(feature);
+
+        // Publish enhanced feature updated event
+        FeatureDto featureDto = featureMapper.toDto(feature);
+        eventPublisher.publishEnhancedFeatureUpdatedEvent(featureDto);
+
+        log.info(
+                "Feature {} removed from release {} by user {} with rationale: {}",
+                cmd.featureCode(),
+                releaseCode,
+                cmd.removedBy(),
+                cmd.rationale());
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/MilestoneRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/MilestoneRepository.java
@@ -1,0 +1,34 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Milestone;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
+
+interface MilestoneRepository extends ListCrudRepository<Milestone, Long> {
+    Optional<Milestone> findByCode(String code);
+
+    @Query(
+            """
+            select m from Milestone m
+            left join fetch m.releases
+            where m.code = :code
+            """)
+    Optional<Milestone> findByCodeWithReleases(String code);
+
+    List<Milestone> findByProductCode(String productCode);
+
+    List<Milestone> findByProductCodeAndStatus(String productCode, MilestoneStatus status);
+
+    List<Milestone> findByProductCodeAndOwner(String productCode, String owner);
+
+    List<Milestone> findByProductCodeAndStatusAndOwner(String productCode, MilestoneStatus status, String owner);
+
+    @Modifying
+    void deleteByCode(String code);
+
+    boolean existsByCode(String code);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/MilestoneService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/MilestoneService.java
@@ -1,0 +1,206 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.Commands.CreateMilestoneCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateMilestoneCommand;
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneReleaseDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneSummaryDto;
+import com.sivalabs.ft.features.domain.entities.Milestone;
+import com.sivalabs.ft.features.domain.entities.Product;
+import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.events.EventPublisher;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import com.sivalabs.ft.features.domain.mappers.MilestoneMapper;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MilestoneService {
+    private final MilestoneRepository milestoneRepository;
+    private final ProductRepository productRepository;
+    private final ReleaseRepository releaseRepository;
+    private final MilestoneMapper milestoneMapper;
+    private final EventPublisher eventPublisher;
+
+    MilestoneService(
+            MilestoneRepository milestoneRepository,
+            ProductRepository productRepository,
+            ReleaseRepository releaseRepository,
+            MilestoneMapper milestoneMapper,
+            EventPublisher eventPublisher) {
+        this.milestoneRepository = milestoneRepository;
+        this.productRepository = productRepository;
+        this.releaseRepository = releaseRepository;
+        this.milestoneMapper = milestoneMapper;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MilestoneDto> findMilestoneByCode(String code) {
+        Optional<Milestone> milestoneOptional = milestoneRepository.findByCodeWithReleases(code);
+        if (milestoneOptional.isEmpty()) {
+            return Optional.empty();
+        }
+        Milestone milestone = milestoneOptional.get();
+        MilestoneDto dto = milestoneMapper.toDto(milestone);
+        Integer progress = calculateProgress(new ArrayList<>(milestone.getReleases()));
+        List<MilestoneReleaseDto> releaseDtos =
+                milestoneMapper.toReleaseDtoList(new ArrayList<>(milestone.getReleases()));
+        dto = new MilestoneDto(
+                dto.id(),
+                dto.code(),
+                dto.name(),
+                dto.description(),
+                dto.targetDate(),
+                dto.actualDate(),
+                dto.status(),
+                dto.productCode(),
+                dto.owner(),
+                dto.notes(),
+                progress,
+                releaseDtos,
+                dto.createdBy(),
+                dto.createdAt(),
+                dto.updatedBy(),
+                dto.updatedAt());
+
+        return Optional.of(dto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MilestoneSummaryDto> findMilestonesByProductCode(String productCode, String status, String owner) {
+        List<Milestone> milestones;
+
+        if (StringUtils.isNotBlank(status) && StringUtils.isNotBlank(owner)) {
+            MilestoneStatus milestoneStatus = MilestoneStatus.valueOf(status);
+            milestones = milestoneRepository.findByProductCodeAndStatusAndOwner(productCode, milestoneStatus, owner);
+        } else if (StringUtils.isNotBlank(status)) {
+            MilestoneStatus milestoneStatus = MilestoneStatus.valueOf(status);
+            milestones = milestoneRepository.findByProductCodeAndStatus(productCode, milestoneStatus);
+        } else if (StringUtils.isNotBlank(owner)) {
+            milestones = milestoneRepository.findByProductCodeAndOwner(productCode, owner);
+        } else {
+            milestones = milestoneRepository.findByProductCode(productCode);
+        }
+
+        return milestones.stream()
+                .map(milestone -> {
+                    MilestoneSummaryDto dto = milestoneMapper.toSummaryDto(milestone);
+                    Integer progress = calculateProgress(new ArrayList<>(milestone.getReleases()));
+                    return new MilestoneSummaryDto(
+                            dto.id(),
+                            dto.code(),
+                            dto.name(),
+                            dto.description(),
+                            dto.targetDate(),
+                            dto.actualDate(),
+                            dto.status(),
+                            dto.productCode(),
+                            dto.owner(),
+                            dto.notes(),
+                            progress,
+                            dto.createdBy(),
+                            dto.createdAt(),
+                            dto.updatedBy(),
+                            dto.updatedAt());
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isMilestoneExists(String code) {
+        return milestoneRepository.existsByCode(code);
+    }
+
+    @Transactional
+    public String createMilestone(CreateMilestoneCommand cmd) {
+        if (milestoneRepository.existsByCode(cmd.code())) {
+            throw new BadRequestException("Milestone with code %s already exists".formatted(cmd.code()));
+        }
+        Product product = productRepository
+                .findByCode(cmd.productCode())
+                .orElseThrow(
+                        () -> new BadRequestException("Product with code %s not found".formatted(cmd.productCode())));
+
+        Milestone milestone = new Milestone();
+        milestone.setCode(cmd.code());
+        milestone.setName(cmd.name());
+        milestone.setDescription(cmd.description());
+        milestone.setTargetDate(cmd.targetDate());
+        milestone.setStatus(cmd.status());
+        milestone.setProduct(product);
+        milestone.setOwner(cmd.owner());
+        milestone.setNotes(cmd.notes());
+        milestone.setCreatedBy(cmd.createdBy());
+        milestone.setCreatedAt(Instant.now());
+
+        milestoneRepository.save(milestone);
+
+        // Publish milestone created event
+        Optional<MilestoneDto> milestoneDto = findMilestoneByCode(milestone.getCode());
+        milestoneDto.ifPresent(eventPublisher::publishMilestoneCreatedEvent);
+
+        return milestone.getCode();
+    }
+
+    @Transactional
+    public void updateMilestone(UpdateMilestoneCommand cmd) {
+        Milestone milestone = milestoneRepository
+                .findByCode(cmd.code())
+                .orElseThrow(
+                        () -> new ResourceNotFoundException("Milestone with code %s not found".formatted(cmd.code())));
+
+        milestone.setName(cmd.name());
+        milestone.setDescription(cmd.description());
+        milestone.setTargetDate(cmd.targetDate());
+        milestone.setActualDate(cmd.actualDate());
+        milestone.setStatus(cmd.status());
+        milestone.setOwner(cmd.owner());
+        milestone.setNotes(cmd.notes());
+        milestone.setUpdatedBy(cmd.updatedBy());
+        milestone.setUpdatedAt(Instant.now());
+
+        milestoneRepository.save(milestone);
+
+        // Publish milestone updated event
+        Optional<MilestoneDto> milestoneDto = findMilestoneByCode(milestone.getCode());
+        milestoneDto.ifPresent(eventPublisher::publishMilestoneUpdatedEvent);
+    }
+
+    @Transactional
+    public void deleteMilestone(String code) {
+        if (!milestoneRepository.existsByCode(code)) {
+            throw new ResourceNotFoundException("Milestone with code %s not found".formatted(code));
+        }
+
+        // TODO: Implement milestone deleted event publishing
+        // Currently disabled due to Hibernate TransientObjectException
+        // when trying to access milestone with releases after unsetMilestone operation
+
+        releaseRepository.unsetMilestone(code);
+        milestoneRepository.deleteByCode(code);
+
+        // Note: Milestone deleted event publishing is temporarily disabled
+        // to avoid Hibernate issues. This should be implemented in a separate task.
+    }
+
+    private Integer calculateProgress(List<Release> releases) {
+        if (releases == null || releases.isEmpty()) {
+            return 0;
+        }
+
+        long completedCount = releases.stream()
+                .filter(release -> release.getStatus() == ReleaseStatus.RELEASED)
+                .count();
+
+        return (int) Math.round((completedCount * 100.0) / releases.size());
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
@@ -4,6 +4,7 @@ import com.sivalabs.ft.features.domain.entities.Release;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 
 interface ReleaseRepository extends ListCrudRepository<Release, Long> {
@@ -15,4 +16,8 @@ interface ReleaseRepository extends ListCrudRepository<Release, Long> {
     void deleteByCode(String code);
 
     boolean existsByCode(String code);
+
+    @Modifying
+    @Query("update Release r set r.milestone = null where r.milestone.code = :code")
+    void unsetMilestone(String code);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
@@ -3,8 +3,11 @@ package com.sivalabs.ft.features.domain;
 import com.sivalabs.ft.features.domain.Commands.CreateReleaseCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateReleaseCommand;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
+import com.sivalabs.ft.features.domain.entities.Milestone;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.events.EventPublisher;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.ReleaseMapper;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
@@ -21,16 +24,22 @@ public class ReleaseService {
     private final ProductRepository productRepository;
     private final FeatureRepository featureRepository;
     private final ReleaseMapper releaseMapper;
+    private final MilestoneRepository milestoneRepository;
+    private final EventPublisher eventPublisher;
 
     ReleaseService(
             ReleaseRepository releaseRepository,
             ProductRepository productRepository,
             FeatureRepository featureRepository,
-            ReleaseMapper releaseMapper) {
+            ReleaseMapper releaseMapper,
+            MilestoneRepository milestoneRepository,
+            EventPublisher eventPublisher) {
         this.releaseRepository = releaseRepository;
         this.productRepository = productRepository;
         this.featureRepository = featureRepository;
         this.releaseMapper = releaseMapper;
+        this.milestoneRepository = milestoneRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -65,6 +74,11 @@ public class ReleaseService {
         release.setCreatedBy(cmd.createdBy());
         release.setCreatedAt(Instant.now());
         releaseRepository.save(release);
+
+        // Publish release created event
+        ReleaseDto releaseDto = releaseMapper.toDto(release);
+        eventPublisher.publishReleaseCreatedEvent(releaseDto);
+
         return code;
     }
 
@@ -74,9 +88,27 @@ public class ReleaseService {
         release.setDescription(cmd.description());
         release.setStatus(cmd.status());
         release.setReleasedAt(cmd.releasedAt());
+        if (cmd.milestoneCode() != null) {
+            Milestone milestone = milestoneRepository
+                    .findByCode(cmd.milestoneCode())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Milestone with code %s not found".formatted(cmd.milestoneCode())));
+
+            if (!milestone.getProduct().getId().equals(release.getProduct().getId())) {
+                throw new BadRequestException("Milestone and Release must belong to the same Product");
+            }
+
+            release.setMilestone(milestone);
+        } else {
+            release.setMilestone(null);
+        }
         release.setUpdatedBy(cmd.updatedBy());
         release.setUpdatedAt(Instant.now());
         releaseRepository.save(release);
+
+        // Publish release updated event
+        ReleaseDto releaseDto = releaseMapper.toDto(release);
+        eventPublisher.publishReleaseUpdatedEvent(releaseDto);
     }
 
     @Transactional

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
@@ -1,8 +1,10 @@
 package com.sivalabs.ft.features.domain.dtos;
 
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import java.io.Serializable;
 import java.time.Instant;
+import java.time.LocalDate;
 
 public record FeatureDto(
         Long id,
@@ -16,7 +18,13 @@ public record FeatureDto(
         String createdBy,
         Instant createdAt,
         String updatedBy,
-        Instant updatedAt)
+        Instant updatedAt,
+        // Planning fields
+        LocalDate plannedCompletionDate,
+        FeaturePlanningStatus planningStatus,
+        String featureOwner,
+        String notes,
+        String blockageReason)
         implements Serializable {
 
     public FeatureDto makeFavorite(boolean favorite) {
@@ -32,6 +40,11 @@ public record FeatureDto(
                 createdBy,
                 createdAt,
                 updatedBy,
-                updatedAt);
+                updatedAt,
+                plannedCompletionDate,
+                planningStatus,
+                featureOwner,
+                notes,
+                blockageReason);
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneDto.java
@@ -1,17 +1,23 @@
 package com.sivalabs.ft.features.domain.dtos;
 
-import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.List;
 
-public record ReleaseDto(
+public record MilestoneDto(
         Long id,
         String code,
+        String name,
         String description,
-        ReleaseStatus status,
-        Instant releasedAt,
-        String milestoneCode,
+        Instant targetDate,
+        Instant actualDate,
+        MilestoneStatus status,
         String productCode,
+        String owner,
+        String notes,
+        Integer progress,
+        List<MilestoneReleaseDto> releases,
         String createdBy,
         Instant createdAt,
         String updatedBy,

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneReleaseDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneReleaseDto.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import java.io.Serializable;
+
+public record MilestoneReleaseDto(Long id, String code, String description, ReleaseStatus status)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneSummaryDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/MilestoneSummaryDto.java
@@ -1,17 +1,21 @@
 package com.sivalabs.ft.features.domain.dtos;
 
-import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
 import java.io.Serializable;
 import java.time.Instant;
 
-public record ReleaseDto(
+public record MilestoneSummaryDto(
         Long id,
         String code,
+        String name,
         String description,
-        ReleaseStatus status,
-        Instant releasedAt,
-        String milestoneCode,
+        Instant targetDate,
+        Instant actualDate,
+        MilestoneStatus status,
         String productCode,
+        String owner,
+        String notes,
+        Integer progress,
         String createdBy,
         Instant createdAt,
         String updatedBy,

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
@@ -1,10 +1,12 @@
 package com.sivalabs.ft.features.domain.entities;
 
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.time.LocalDate;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
@@ -52,6 +54,23 @@ public class Feature {
 
     @Column(name = "updated_at")
     private Instant updatedAt;
+
+    // Feature Planning fields
+    @Column(name = "planned_completion_date")
+    private LocalDate plannedCompletionDate;
+
+    @Column(name = "planning_status", length = 50)
+    @Enumerated(EnumType.STRING)
+    private FeaturePlanningStatus planningStatus = FeaturePlanningStatus.NOT_STARTED;
+
+    @Size(max = 255) @Column(name = "feature_owner")
+    private String featureOwner;
+
+    @Column(name = "notes", length = Integer.MAX_VALUE)
+    private String notes;
+
+    @Column(name = "blockage_reason", length = Integer.MAX_VALUE)
+    private String blockageReason;
 
     public Long getId() {
         return id;
@@ -147,5 +166,45 @@ public class Feature {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public LocalDate getPlannedCompletionDate() {
+        return plannedCompletionDate;
+    }
+
+    public void setPlannedCompletionDate(LocalDate plannedCompletionDate) {
+        this.plannedCompletionDate = plannedCompletionDate;
+    }
+
+    public FeaturePlanningStatus getPlanningStatus() {
+        return planningStatus;
+    }
+
+    public void setPlanningStatus(FeaturePlanningStatus planningStatus) {
+        this.planningStatus = planningStatus;
+    }
+
+    public String getFeatureOwner() {
+        return featureOwner;
+    }
+
+    public void setFeatureOwner(String featureOwner) {
+        this.featureOwner = featureOwner;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getBlockageReason() {
+        return blockageReason;
+    }
+
+    public void setBlockageReason(String blockageReason) {
+        this.blockageReason = blockageReason;
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Milestone.java
@@ -1,0 +1,199 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "milestones")
+public class Milestone {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "milestones_id_gen")
+    @SequenceGenerator(name = "milestones_id_gen", sequenceName = "milestone_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "code", nullable = false, length = 50, unique = true)
+    private String code;
+
+    @Size(max = 255) @NotNull @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @NotNull @Column(name = "target_date", nullable = false)
+    private Instant targetDate;
+
+    @Column(name = "actual_date")
+    private Instant actualDate;
+
+    @NotNull @Column(name = "status", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private MilestoneStatus status;
+
+    @NotNull @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Size(max = 255) @Column(name = "owner")
+    private String owner;
+
+    @Column(name = "notes", length = Integer.MAX_VALUE)
+    private String notes;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Size(max = 255) @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @OneToMany(mappedBy = "milestone")
+    private Set<Release> releases = new LinkedHashSet<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        if (updatedAt == null) {
+            this.updatedAt = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Instant getTargetDate() {
+        return targetDate;
+    }
+
+    public void setTargetDate(Instant targetDate) {
+        this.targetDate = targetDate;
+    }
+
+    public Instant getActualDate() {
+        return actualDate;
+    }
+
+    public void setActualDate(Instant actualDate) {
+        this.actualDate = actualDate;
+    }
+
+    public MilestoneStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(MilestoneStatus status) {
+        this.status = status;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(String updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Set<Release> getReleases() {
+        return releases;
+    }
+
+    public void setReleases(Set<Release> releases) {
+        this.releases = releases;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
@@ -34,6 +34,10 @@ public class Release {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "milestone_id")
+    private Milestone milestone;
+
     @Size(max = 50) @NotNull @Column(name = "code", nullable = false, length = 50)
     private String code;
 
@@ -77,6 +81,14 @@ public class Release {
 
     public void setProduct(Product product) {
         this.product = product;
+    }
+
+    public Milestone getMilestone() {
+        return milestone;
+    }
+
+    public void setMilestone(Milestone milestone) {
+        this.milestone = milestone;
     }
 
     public String getCode() {

--- a/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
@@ -1,6 +1,9 @@
 package com.sivalabs.ft.features.domain.events;
 
 import com.sivalabs.ft.features.ApplicationProperties;
+import com.sivalabs.ft.features.domain.dtos.FeatureDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Feature;
 import java.time.Instant;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -62,5 +65,131 @@ public class EventPublisher {
                 deletedBy,
                 deletedAt);
         kafkaTemplate.send(properties.events().deletedFeatures(), event);
+    }
+
+    // Enhanced feature event publishing using FeatureDto
+    public void publishEnhancedFeatureUpdatedEvent(FeatureDto featureDto) {
+        FeatureEvent event = new FeatureEvent(
+                featureDto.id(),
+                featureDto.code(),
+                featureDto.title(),
+                featureDto.description(),
+                featureDto.status(),
+                featureDto.releaseCode(),
+                featureDto.isFavorite(),
+                featureDto.assignedTo(),
+                featureDto.createdBy(),
+                featureDto.createdAt(),
+                featureDto.updatedBy(),
+                featureDto.updatedAt(),
+                featureDto.plannedCompletionDate(),
+                featureDto.planningStatus(),
+                featureDto.featureOwner(),
+                featureDto.notes(),
+                featureDto.blockageReason(),
+                "UPDATED");
+        kafkaTemplate.send(properties.events().updatedFeatures(), event);
+    }
+
+    // Release event publishing
+    public void publishReleaseCreatedEvent(ReleaseDto releaseDto) {
+        ReleaseEvent event = new ReleaseEvent(
+                releaseDto.id(),
+                releaseDto.code(),
+                releaseDto.description(),
+                releaseDto.status(),
+                releaseDto.releasedAt(),
+                releaseDto.milestoneCode(),
+                releaseDto.productCode(),
+                releaseDto.createdBy(),
+                releaseDto.createdAt(),
+                releaseDto.updatedBy(),
+                releaseDto.updatedAt(),
+                "CREATED");
+        kafkaTemplate.send(properties.events().updatedReleases(), event);
+    }
+
+    public void publishReleaseUpdatedEvent(ReleaseDto releaseDto) {
+        ReleaseEvent event = new ReleaseEvent(
+                releaseDto.id(),
+                releaseDto.code(),
+                releaseDto.description(),
+                releaseDto.status(),
+                releaseDto.releasedAt(),
+                releaseDto.milestoneCode(),
+                releaseDto.productCode(),
+                releaseDto.createdBy(),
+                releaseDto.createdAt(),
+                releaseDto.updatedBy(),
+                releaseDto.updatedAt(),
+                "UPDATED");
+        kafkaTemplate.send(properties.events().updatedReleases(), event);
+    }
+
+    // Milestone event publishing
+    public void publishMilestoneCreatedEvent(MilestoneDto milestoneDto) {
+        MilestoneEvent event = new MilestoneEvent(
+                milestoneDto.id(),
+                milestoneDto.code(),
+                milestoneDto.name(),
+                milestoneDto.description(),
+                milestoneDto.targetDate(),
+                milestoneDto.actualDate(),
+                milestoneDto.status(),
+                milestoneDto.productCode(),
+                milestoneDto.owner(),
+                milestoneDto.notes(),
+                milestoneDto.progress(),
+                milestoneDto.releases(),
+                milestoneDto.createdBy(),
+                milestoneDto.createdAt(),
+                milestoneDto.updatedBy(),
+                milestoneDto.updatedAt(),
+                "CREATED");
+        kafkaTemplate.send(properties.events().updatedMilestones(), event);
+    }
+
+    public void publishMilestoneUpdatedEvent(MilestoneDto milestoneDto) {
+        MilestoneEvent event = new MilestoneEvent(
+                milestoneDto.id(),
+                milestoneDto.code(),
+                milestoneDto.name(),
+                milestoneDto.description(),
+                milestoneDto.targetDate(),
+                milestoneDto.actualDate(),
+                milestoneDto.status(),
+                milestoneDto.productCode(),
+                milestoneDto.owner(),
+                milestoneDto.notes(),
+                milestoneDto.progress(),
+                milestoneDto.releases(),
+                milestoneDto.createdBy(),
+                milestoneDto.createdAt(),
+                milestoneDto.updatedBy(),
+                milestoneDto.updatedAt(),
+                "UPDATED");
+        kafkaTemplate.send(properties.events().updatedMilestones(), event);
+    }
+
+    public void publishMilestoneDeletedEvent(MilestoneDto milestoneDto) {
+        MilestoneEvent event = new MilestoneEvent(
+                milestoneDto.id(),
+                milestoneDto.code(),
+                milestoneDto.name(),
+                milestoneDto.description(),
+                milestoneDto.targetDate(),
+                milestoneDto.actualDate(),
+                milestoneDto.status(),
+                milestoneDto.productCode(),
+                milestoneDto.owner(),
+                milestoneDto.notes(),
+                milestoneDto.progress(),
+                milestoneDto.releases(),
+                milestoneDto.createdBy(),
+                milestoneDto.createdAt(),
+                milestoneDto.updatedBy(),
+                milestoneDto.updatedAt(),
+                "DELETED");
+        kafkaTemplate.send(properties.events().updatedMilestones(), event);
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEvent.java
@@ -1,0 +1,27 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.domain.models.FeaturePlanningStatus;
+import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record FeatureEvent(
+        Long id,
+        String code,
+        String title,
+        String description,
+        FeatureStatus status,
+        String releaseCode,
+        boolean isFavorite,
+        String assignedTo,
+        String createdBy,
+        Instant createdAt,
+        String updatedBy,
+        Instant updatedAt,
+        // Planning fields
+        LocalDate plannedCompletionDate,
+        FeaturePlanningStatus planningStatus,
+        String featureOwner,
+        String notes,
+        String blockageReason,
+        String eventType) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/MilestoneEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/MilestoneEvent.java
@@ -1,0 +1,25 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.domain.dtos.MilestoneReleaseDto;
+import com.sivalabs.ft.features.domain.models.MilestoneStatus;
+import java.time.Instant;
+import java.util.List;
+
+public record MilestoneEvent(
+        Long id,
+        String code,
+        String name,
+        String description,
+        Instant targetDate,
+        Instant actualDate,
+        MilestoneStatus status,
+        String productCode,
+        String owner,
+        String notes,
+        Integer progress,
+        List<MilestoneReleaseDto> releases,
+        String createdBy,
+        Instant createdAt,
+        String updatedBy,
+        Instant updatedAt,
+        String eventType) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/ReleaseEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/ReleaseEvent.java
@@ -1,10 +1,9 @@
-package com.sivalabs.ft.features.domain.dtos;
+package com.sivalabs.ft.features.domain.events;
 
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
-import java.io.Serializable;
 import java.time.Instant;
 
-public record ReleaseDto(
+public record ReleaseEvent(
         Long id,
         String code,
         String description,
@@ -15,5 +14,5 @@ public record ReleaseDto(
         String createdBy,
         Instant createdAt,
         String updatedBy,
-        Instant updatedAt)
-        implements Serializable {}
+        Instant updatedAt,
+        String eventType) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/MilestoneMapper.java
@@ -1,0 +1,26 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.MilestoneDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneReleaseDto;
+import com.sivalabs.ft.features.domain.dtos.MilestoneSummaryDto;
+import com.sivalabs.ft.features.domain.entities.Milestone;
+import com.sivalabs.ft.features.domain.entities.Release;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface MilestoneMapper {
+    @Mapping(target = "productCode", source = "product.code")
+    @Mapping(target = "progress", ignore = true)
+    @Mapping(target = "releases", ignore = true)
+    MilestoneDto toDto(Milestone milestone);
+
+    @Mapping(target = "productCode", source = "product.code")
+    @Mapping(target = "progress", ignore = true)
+    MilestoneSummaryDto toSummaryDto(Milestone milestone);
+
+    MilestoneReleaseDto toReleaseDto(Release release);
+
+    List<MilestoneReleaseDto> toReleaseDtoList(List<Release> releases);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
@@ -3,8 +3,11 @@ package com.sivalabs.ft.features.domain.mappers;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Release;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ReleaseMapper {
+    @Mapping(target = "milestoneCode", source = "milestone.code")
+    @Mapping(target = "productCode", source = "product.code")
     ReleaseDto toDto(Release release);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/models/FeaturePlanningStatus.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/FeaturePlanningStatus.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum FeaturePlanningStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    DONE,
+    BLOCKED
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/MilestoneStatus.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/MilestoneStatus.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum MilestoneStatus {
+    PLANNED,
+    IN_PROGRESS,
+    COMPLETED,
+    DELAYED
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ ft.openapi.contact.email=support@sivalabs.in
 ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
+ft.events.updated-releases=updated_releases
+ft.events.updated-milestones=updated_milestones
 
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}

--- a/src/main/resources/db/migration/V5__create_feature_planning_table.sql
+++ b/src/main/resources/db/migration/V5__create_feature_planning_table.sql
@@ -1,0 +1,15 @@
+-- Add feature planning fields to existing features table
+ALTER TABLE features ADD COLUMN planned_completion_date DATE;
+ALTER TABLE features ADD COLUMN planning_status VARCHAR(50);
+ALTER TABLE features ADD COLUMN feature_owner VARCHAR(255);
+ALTER TABLE features ADD COLUMN notes TEXT;
+ALTER TABLE features ADD COLUMN blockage_reason TEXT;
+
+-- Add index for querying features by planning status
+CREATE INDEX idx_features_planning_status ON features(planning_status);
+
+-- Add index for querying features by feature owner
+CREATE INDEX idx_features_feature_owner ON features(feature_owner);
+
+-- Add index for querying overdue features (planned completion date in the past)
+CREATE INDEX idx_features_planned_completion ON features(planned_completion_date);

--- a/src/main/resources/db/migration/V6__create_milestones_table.sql
+++ b/src/main/resources/db/migration/V6__create_milestones_table.sql
@@ -1,0 +1,31 @@
+create sequence milestone_id_seq start with 100 increment by 50;
+
+create table milestones
+(
+    id          bigint       not null default nextval('milestone_id_seq'),
+    code        varchar(50)  not null unique,
+    name        varchar(255) not null,
+    description text,
+    target_date timestamp    not null,
+    actual_date timestamp,
+    status      varchar(50)  not null,
+    product_id  bigint       not null,
+    owner       varchar(255),
+    notes       text,
+    created_by  varchar(255) not null,
+    created_at  timestamp    not null default current_timestamp,
+    updated_by  varchar(255),
+    updated_at  timestamp,
+    primary key (id),
+    constraint fk_milestones_product foreign key (product_id) references products(id)
+);
+
+create index idx_milestones_product_id on milestones(product_id);
+create index idx_milestones_status on milestones(status);
+create index idx_milestones_owner on milestones(owner);
+
+alter table releases add column milestone_id bigint;
+alter table releases add constraint fk_releases_milestone
+    foreign key (milestone_id) references milestones(id) on delete set null;
+
+create index idx_releases_milestone_id on releases(milestone_id);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/KafkaEventsIntegrationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/KafkaEventsIntegrationTests.java
@@ -1,0 +1,249 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.testcontainers.kafka.KafkaContainer;
+
+@WithMockOAuth2User(username = "event-user")
+class KafkaEventsIntegrationTests extends AbstractIT {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${ft.events.updated-releases}")
+    private String updatedReleasesTopic;
+
+    @Value("${ft.events.updated-features}")
+    private String updatedFeaturesTopic;
+
+    @Value("${ft.events.updated-milestones}")
+    private String updatedMilestonesTopic;
+
+    @Autowired
+    private KafkaContainer kafkaContainer;
+
+    @Test
+    void shouldPublishReleaseUpdatedEvent() throws Exception {
+        var payload =
+                """
+            {
+                "description": "Updated release description",
+                "status": "RELEASED",
+                "releasedAt": "2024-03-30T00:00:00Z",
+                "milestoneCode": "Q1-2024"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedReleasesTopic, () -> {
+            var result = mvc.put()
+                    .uri("/api/releases/{code}", "IDEA-2023.3.8")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/releases/IDEA-2023.3.8");
+    }
+
+    @Test
+    void shouldPublishFeatureUpdatedEventOnAssign() throws Exception {
+        var payload =
+                """
+            {
+                "featureCode": "IDEA-3",
+                "plannedCompletionDate": "2024-05-01",
+                "featureOwner": "alice"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedFeaturesTopic, () -> {
+            var result = mvc.post()
+                    .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatus(HttpStatus.CREATED);
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/features/IDEA-3");
+    }
+
+    @Test
+    void shouldPublishFeatureUpdatedEventWithIsoTemporalFields() throws Exception {
+        var payload =
+                """
+            {
+                "title": "Updated Feature",
+                "description": "Updated description",
+                "assignedTo": "jane.doe",
+                "status": "IN_PROGRESS"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedFeaturesTopic, () -> {
+            var result = mvc.put()
+                    .uri("/api/features/{code}", "IDEA-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        Map<String, Object> expected = getPayloadMap("/api/features/IDEA-1");
+        assertTemporalFieldMatchesExpected(event, expected, "createdAt");
+        assertTemporalFieldMatchesExpected(event, expected, "updatedAt");
+    }
+
+    @Test
+    void shouldPublishMilestoneUpdatedEvent() throws Exception {
+        var payload =
+                """
+            {
+                "name": "Q2 2024 Release Updated",
+                "description": "Updated milestone",
+                "targetDate": "2024-06-30T23:59:59Z",
+                "actualDate": "2024-06-20T10:00:00Z",
+                "status": "COMPLETED",
+                "owner": "bob@example.com",
+                "notes": "Updated for test"
+            }
+            """;
+
+        Map<String, Object> event = readEvent(updatedMilestonesTopic, () -> {
+            var result = mvc.put()
+                    .uri("/api/milestones/{code}", "Q2-2024")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .exchange();
+            assertThat(result).hasStatusOk();
+        });
+
+        assertEventMatchesGet(event, "UPDATED", "/api/milestones/Q2-2024");
+    }
+
+    private Map<String, Object> readEvent(String topic, Runnable action) throws Exception {
+        Consumer<String, String> consumer = createConsumer();
+        consumer.subscribe(List.of(topic));
+        waitForAssignment(consumer);
+        consumer.seekToEnd(consumer.assignment());
+        // seekToEnd is lazy; touching position forces the end offset before publishing.
+        consumer.assignment().forEach(consumer::position);
+        try {
+            action.run();
+            ConsumerRecord<String, String> record = pollForRecord(consumer, topic, Duration.ofSeconds(10));
+            return toMap(record.value());
+        } finally {
+            consumer.close();
+        }
+    }
+
+    private Consumer<String, String> createConsumer() {
+        String groupId = "test-" + UUID.randomUUID();
+        var props = new java.util.HashMap<String, Object>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<String, String>(props).createConsumer();
+    }
+
+    private void waitForAssignment(Consumer<String, String> consumer) {
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(5).toMillis();
+        while (consumer.assignment().isEmpty() && System.currentTimeMillis() < deadline) {
+            consumer.poll(Duration.ofMillis(100));
+        }
+    }
+
+    private ConsumerRecord<String, String> pollForRecord(
+            Consumer<String, String> consumer, String topic, Duration timeout) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(250));
+            for (ConsumerRecord<String, String> record : records.records(topic)) {
+                return record;
+            }
+        }
+        throw new IllegalStateException("No records found for topic");
+    }
+
+    private void assertEventMatchesGet(Map<String, Object> event, String expectedEventType, String getUri)
+            throws Exception {
+        assertThat(event.get("eventType")).isEqualTo(expectedEventType);
+        event.remove("eventType");
+        Map<String, Object> expected = getPayloadMap(getUri);
+        assertThat(normalizePayload(event)).isEqualTo(normalizePayload(expected));
+    }
+
+    private void assertTemporalFieldMatchesExpected(
+            Map<String, Object> event, Map<String, Object> expected, String temporalField) {
+        assertThat(event.get(temporalField))
+                .as("Kafka event field %s should be serialized as a string", temporalField)
+                .isInstanceOf(String.class);
+        assertThat(normalizeValue(event.get(temporalField)))
+                .as("Kafka event field %s should match GET payload", temporalField)
+                .isEqualTo(normalizeValue(expected.get(temporalField)));
+    }
+
+    private Map<String, Object> getPayloadMap(String uri) throws Exception {
+        var result = mvc.get().uri(uri).exchange();
+        assertThat(result).hasStatusOk();
+        String body = result.getMvcResult().getResponse().getContentAsString();
+        return toMap(body);
+    }
+
+    private Map<String, Object> toMap(String json) throws Exception {
+        return objectMapper.readValue(json, new TypeReference<>() {});
+    }
+
+    private Map<String, Object> normalizePayload(Map<String, Object> payload) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> normalized = (Map<String, Object>) normalizeValue(payload);
+        return normalized;
+    }
+
+    private Object normalizeValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            var result = new java.util.LinkedHashMap<String, Object>();
+            for (var entry : map.entrySet()) {
+                result.put(String.valueOf(entry.getKey()), normalizeValue(entry.getValue()));
+            }
+            return result;
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::normalizeValue).toList();
+        }
+        if (value instanceof String str) {
+            try {
+                Instant instant = Instant.parse(str);
+                return instant.truncatedTo(ChronoUnit.MILLIS).toString();
+            } catch (Exception ignored) {
+                return str;
+            }
+        }
+        return value;
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/MilestoneControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/MilestoneControllerTests.java
@@ -1,0 +1,1205 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class MilestoneControllerTests extends AbstractIT {
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockOAuth2User
+    void shouldGetMilestonesByProductCode() throws Exception {
+        var result =
+                mvc.get().uri("/api/milestones?productCode={code}", "intellij").exchange();
+
+        assertThat(result).as("Should return milestones for intellij product").hasStatusOk();
+
+        String json = result.getMvcResult().getResponse().getContentAsString();
+        List<Map<String, Object>> milestones = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(milestones.size())
+                .as("Should have exactly 2 milestones for intellij")
+                .isEqualTo(2);
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldReturn400WhenProductCodeMissing() {
+        var result = mvc.get().uri("/api/milestones").exchange();
+        assertThat(result).as("Should return 400 when productCode is missing").hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldFilterMilestonesByStatus() {
+        var result = mvc.get()
+                .uri("/api/milestones?productCode={code}&status={status}", "intellij", "COMPLETED")
+                .exchange();
+        assertThat(result)
+                .as("Should filter milestones by COMPLETED status")
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$[*].status")
+                .asArray()
+                .allSatisfy(status -> assertThat(status)
+                        .as("All returned milestones should have COMPLETED status")
+                        .isEqualTo("COMPLETED"));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldFilterMilestonesByOwner() {
+        var result = mvc.get()
+                .uri("/api/milestones?productCode={code}&owner={owner}", "intellij", "alice@example.com")
+                .exchange();
+        assertThat(result)
+                .as("Should filter milestones by owner")
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$[*].owner")
+                .asArray()
+                .allSatisfy(owner -> assertThat(owner)
+                        .as("All returned milestones should be owned by alice@example.com")
+                        .isEqualTo("alice@example.com"));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldGetMilestoneByCode() throws Exception {
+        var result = mvc.get().uri("/api/milestones/{code}", "Q1-2024").exchange();
+
+        assertThat(result).as("Should return milestone by code").hasStatusOk();
+
+        String json = result.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(milestone.get("code")).isEqualTo("Q1-2024");
+        assertThat(milestone.get("name")).isEqualTo("Q1 2024 Release");
+        assertThat(milestone.get("productCode")).isEqualTo("intellij");
+        assertThat(milestone.get("status")).isEqualTo("COMPLETED");
+        assertThat(milestone.get("owner")).isEqualTo("alice@example.com");
+        assertThat(milestone.get("progress")).isEqualTo(100);
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldReturn404WhenMilestoneNotFound() {
+        var result =
+                mvc.get().uri("/api/milestones/{code}", "NON_EXISTENT_CODE").exchange();
+        assertThat(result).as("Should return 404 for non-existent milestone").hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldCreateNewMilestone() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "Q4-2024",
+                                    "name": "Q4 2024 Release",
+                                    "description": "Fourth quarter objectives and deliverables",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED",
+                                    "owner": "frank@example.com",
+                                    "notes": "Year-end release"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).as("Should create new milestone with 201 Created").hasStatus(HttpStatus.CREATED);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldUpdateMilestone() {
+        var payload =
+                """
+                                {
+                                    "name": "Updated Q2 2024 Release",
+                                    "description": "Updated description for Q2",
+                                    "targetDate": "2024-06-30T23:59:59Z",
+                                    "actualDate": "2024-06-25T10:30:00Z",
+                                    "status": "COMPLETED",
+                                    "owner": "updated.bob@example.com",
+                                    "notes": "Completed early"
+                                }
+                                """;
+
+        var result = mvc.put()
+                .uri("/api/milestones/{code}", "Q2-2024")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).as("Should update milestone successfully").hasStatusOk();
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldDeleteMilestone() {
+        var createPayload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "DELETE-TEST",
+                                    "name": "To Delete",
+                                    "description": "Test milestone to delete",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createPayload)
+                .exchange();
+
+        var result = mvc.delete().uri("/api/milestones/{code}", "DELETE-TEST").exchange();
+        assertThat(result).as("Should delete milestone successfully").hasStatusOk();
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingDuplicateMilestoneCode() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "Q1-2024",
+                                    "name": "Duplicate Q1",
+                                    "description": "Should fail",
+                                    "targetDate": "2024-03-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).as("Should return 400 for duplicate milestone code").hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingWithInvalidProduct() {
+        var payload =
+                """
+                                {
+                                    "productCode": "INVALID_PRODUCT",
+                                    "code": "M1",
+                                    "name": "Milestone",
+                                    "description": "Description",
+                                    "targetDate": "2024-03-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result.getMvcResult().getResponse().getStatus())
+                .as("Should return 400 or 404 for invalid product code")
+                .isIn(HttpStatus.BAD_REQUEST.value(), HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldAssociateReleaseWithMilestone() {
+        var payload =
+                """
+                                {
+                                    "description": "Release associated with Q2 milestone",
+                                    "status": "RELEASED",
+                                    "releasedAt": "2024-06-15T10:00:00Z",
+                                    "milestoneCode": "Q2-2024"
+                                }
+                                """;
+
+        var result = mvc.put()
+                .uri("/api/releases/{code}", "IDEA-2024.2.3")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).as("Should associate release with milestone").hasStatusOk();
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldOrphanReleasesWhenMilestoneDeleted() throws Exception {
+        var releaseBefore =
+                mvc.get().uri("/api/releases/{code}", "IDEA-2023.3.8").exchange();
+        assertThat(releaseBefore).hasStatusOk();
+
+        String jsonBefore = releaseBefore.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> releaseDataBefore = objectMapper.readValue(jsonBefore, new TypeReference<>() {});
+        assertThat(releaseDataBefore.get("milestoneCode"))
+                .as("Release should be linked to Q1-2024 before deletion")
+                .isEqualTo("Q1-2024");
+
+        var deleteResult = mvc.delete().uri("/api/milestones/{code}", "Q1-2024").exchange();
+        assertThat(deleteResult).hasStatusOk();
+
+        var releaseAfter =
+                mvc.get().uri("/api/releases/{code}", "IDEA-2023.3.8").exchange();
+        assertThat(releaseAfter).hasStatusOk();
+
+        String jsonAfter = releaseAfter.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> releaseDataAfter = objectMapper.readValue(jsonAfter, new TypeReference<>() {});
+        assertThat(releaseDataAfter.get("milestoneCode"))
+                .as("Release should be orphaned (milestoneCode null) after milestone deletion")
+                .isNull();
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectCrossProductMilestoneAssociation() {
+        var milestonePayload =
+                """
+                                {
+                                    "productCode": "vscode",
+                                    "code": "VS-2024",
+                                    "name": "VS Code 2024",
+                                    "description": "VS Code milestone",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(milestonePayload)
+                .exchange();
+
+        var updatePayload =
+                """
+                                {
+                                    "description": "Updated release",
+                                    "status": "RELEASED",
+                                    "milestoneCode": "Q3-2024"
+                                }
+                                """;
+
+        var result = mvc.put()
+                .uri("/api/releases/{code}", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should reject linking intellij release to goland milestone")
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldCalculateProgressBasedOnReleasedCount() throws Exception {
+        var result1 = mvc.get().uri("/api/milestones/{code}", "Q2-2024").exchange();
+        assertThat(result1).hasStatusOk();
+
+        String json1 = result1.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone1 = objectMapper.readValue(json1, new TypeReference<>() {});
+
+        assertThat(milestone1.get("progress"))
+                .as("Progress should be 100% when all releases are RELEASED (1/1)")
+                .isEqualTo(100);
+
+        var result2 = mvc.get().uri("/api/milestones/{code}", "Q1-2024").exchange();
+        assertThat(result2).hasStatusOk();
+
+        String json2 = result2.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone2 = objectMapper.readValue(json2, new TypeReference<>() {});
+
+        assertThat(milestone2.get("progress"))
+                .as("Progress should be 100% when the only release is RELEASED")
+                .isEqualTo(100);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldCalculateProgressWithMixedReleaseStatuses() throws Exception {
+        var createMilestone =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "PROGRESS-TEST",
+                                    "name": "Progress Test Milestone",
+                                    "description": "Testing progress calculation",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createMilestone)
+                .exchange();
+
+        var resultEmpty =
+                mvc.get().uri("/api/milestones/{code}", "PROGRESS-TEST").exchange();
+        assertThat(resultEmpty).hasStatusOk();
+
+        String jsonEmpty = resultEmpty.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestoneEmpty = objectMapper.readValue(jsonEmpty, new TypeReference<>() {});
+
+        assertThat(milestoneEmpty.get("progress"))
+                .as("Progress should be 0% when milestone has no releases")
+                .isEqualTo(0);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldCalculateProgressWithVariousReleaseStatuses() throws Exception {
+        var createMilestone =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "CALC-TEST",
+                                    "name": "Calculation Test",
+                                    "description": "Testing progress calculation",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createMilestone)
+                .exchange();
+
+        var result0 = mvc.get().uri("/api/milestones/{code}", "CALC-TEST").exchange();
+        String json0 = result0.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone0 = objectMapper.readValue(json0, new TypeReference<>() {});
+        assertThat(milestone0.get("progress"))
+                .as("Initial progress should be 0%")
+                .isEqualTo(0);
+
+        var release1 =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "REL-1",
+                                    "description": "Release 1"
+                                }
+                                """;
+        mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(release1)
+                .exchange();
+
+        var updateRelease1 =
+                """
+                                {
+                                    "description": "Release 1 - DRAFT",
+                                    "status": "DRAFT",
+                                    "milestoneCode": "CALC-TEST"
+                                }
+                                """;
+        mvc.put()
+                .uri("/api/releases/{code}", "IDEA-REL-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRelease1)
+                .exchange();
+
+        var result1 = mvc.get().uri("/api/milestones/{code}", "CALC-TEST").exchange();
+        String json1 = result1.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone1 = objectMapper.readValue(json1, new TypeReference<>() {});
+
+        assertThat(milestone1.get("progress"))
+                .as("Progress should be 0% with 1 DRAFT release (0/1)")
+                .isEqualTo(0);
+
+        var release2 =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "REL-2",
+                                    "description": "Release 2"
+                                }
+                                """;
+        mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(release2)
+                .exchange();
+
+        var updateRelease2 =
+                """
+                                {
+                                    "description": "Release 2 - DRAFT",
+                                    "status": "DRAFT",
+                                    "milestoneCode": "CALC-TEST"
+                                }
+                                """;
+        mvc.put()
+                .uri("/api/releases/{code}", "IDEA-REL-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRelease2)
+                .exchange();
+
+        var result2 = mvc.get().uri("/api/milestones/{code}", "CALC-TEST").exchange();
+        String json2 = result2.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone2 = objectMapper.readValue(json2, new TypeReference<>() {});
+
+        assertThat(milestone2.get("progress"))
+                .as("Progress should be 0% with 2 DRAFT releases (0/2)")
+                .isEqualTo(0);
+
+        var release3 =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "REL-3",
+                                    "description": "Release 3"
+                                }
+                                """;
+        mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(release3)
+                .exchange();
+
+        var updateRelease3 =
+                """
+                                {
+                                    "description": "Release 3 - RELEASED",
+                                    "status": "RELEASED",
+                                    "milestoneCode": "CALC-TEST"
+                                }
+                                """;
+        mvc.put()
+                .uri("/api/releases/{code}", "IDEA-REL-3")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRelease3)
+                .exchange();
+
+        var result3 = mvc.get().uri("/api/milestones/{code}", "CALC-TEST").exchange();
+        String json3 = result3.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone3 = objectMapper.readValue(json3, new TypeReference<>() {});
+
+        assertThat(milestone3.get("progress"))
+                .as("Progress should be 33% with 1 RELEASED out of 3 (1/3)")
+                .isEqualTo(33);
+
+        var release4 =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "REL-4",
+                                    "description": "Release 4"
+                                }
+                                """;
+        mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(release4)
+                .exchange();
+
+        var updateRelease4 =
+                """
+                                {
+                                    "description": "Release 4 - RELEASED",
+                                    "status": "RELEASED",
+                                    "milestoneCode": "CALC-TEST"
+                                }
+                                """;
+        mvc.put()
+                .uri("/api/releases/{code}", "IDEA-REL-4")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRelease4)
+                .exchange();
+
+        var result4 = mvc.get().uri("/api/milestones/{code}", "CALC-TEST").exchange();
+        String json4 = result4.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone4 = objectMapper.readValue(json4, new TypeReference<>() {});
+
+        assertThat(milestone4.get("progress"))
+                .as("Progress should be 50% with 2 RELEASED out of 4 (2/4)")
+                .isEqualTo(50);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateSameProductForMilestoneReleaseAssociation() {
+        var milestonePayload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "TEST-MILESTONE",
+                                    "name": "Test Milestone",
+                                    "description": "Test milestone for validation",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(milestonePayload)
+                .exchange();
+
+        var correctPayload =
+                """
+                                {
+                                    "description": "Associate with correct milestone",
+                                    "status": "DRAFT",
+                                    "milestoneCode": "TEST-MILESTONE"
+                                }
+                                """;
+
+        var result = mvc.put()
+                .uri("/api/releases/{code}", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(correctPayload)
+                .exchange();
+
+        assertThat(result).as("Should allow association when products match").hasStatusOk();
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldEnforceGlobalUniquenessOfMilestoneCode() {
+        var milestone1 =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "GLOBAL-UNIQUE-TEST",
+                                    "name": "Test Milestone 1",
+                                    "description": "First milestone",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result1 = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(milestone1)
+                .exchange();
+        assertThat(result1).hasStatus(HttpStatus.CREATED);
+
+        var milestone2 =
+                """
+                                {
+                                    "productCode": "goland",
+                                    "code": "GLOBAL-UNIQUE-TEST",
+                                    "name": "Test Milestone 2",
+                                    "description": "Second milestone",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result2 = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(milestone2)
+                .exchange();
+
+        assertThat(result2)
+                .as("Should reject duplicate milestone code across different products")
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldReturnEmptyListWhenNoMilestonesExistForProduct()
+            throws UnsupportedEncodingException, JsonProcessingException {
+        var result =
+                mvc.get().uri("/api/milestones?productCode={code}", "pycharm").exchange();
+
+        assertThat(result).hasStatusOk();
+        String responseBody = result.getResponse().getContentAsString();
+        List<?> response = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldIncludeAllRequiredFieldsInListResponse() throws Exception {
+        var result =
+                mvc.get().uri("/api/milestones?productCode={code}", "intellij").exchange();
+
+        assertThat(result).hasStatusOk();
+
+        String json = result.getMvcResult().getResponse().getContentAsString();
+        List<Map<String, Object>> milestones = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(milestones).isNotEmpty();
+
+        Map<String, Object> milestone = milestones.getFirst();
+        assertThat(milestone)
+                .containsKeys(
+                        "id",
+                        "code",
+                        "name",
+                        "description",
+                        "targetDate",
+                        "status",
+                        "productCode",
+                        "progress",
+                        "createdBy",
+                        "createdAt");
+        assertThat(milestone).doesNotContainKey("releases");
+    }
+
+    @Test
+    @WithMockOAuth2User
+    void shouldIncludeReleasesArrayInDetailResponse() throws Exception {
+        var result = mvc.get().uri("/api/milestones/{code}", "Q1-2024").exchange();
+
+        assertThat(result).hasStatusOk();
+
+        String json = result.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(milestone).containsKey("releases");
+        assertThat(milestone.get("releases")).isInstanceOf(List.class);
+    }
+
+    @Test
+    void shouldReturn401WhenCreatingMilestoneWithoutAuthentication() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "AUTH-TEST",
+                                    "name": "Auth Test Milestone",
+                                    "description": "Testing authentication",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 401 when creating milestone without authentication")
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturn401WhenUpdatingMilestoneWithoutAuthentication() {
+        var payload =
+                """
+                                {
+                                    "name": "Updated Name",
+                                    "description": "Updated description",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.put()
+                .uri("/api/milestones/{code}", "Q1-2024")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 401 when updating milestone without authentication")
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturn401WhenDeletingMilestoneWithoutAuthentication() {
+        var result = mvc.delete().uri("/api/milestones/{code}", "Q1-2024").exchange();
+
+        assertThat(result)
+                .as("Should return 401 when deleting milestone without authentication")
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturn401WhenGettingMilestonesWithoutAuthentication() {
+        var result =
+                mvc.get().uri("/api/milestones?productCode={code}", "intellij").exchange();
+
+        assertThat(result)
+                .as("Should return 401 when listing milestones without authentication")
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturn401WhenGettingMilestoneByCodeWithoutAuthentication() {
+        var result = mvc.get().uri("/api/milestones/{code}", "Q1-2024").exchange();
+
+        assertThat(result)
+                .as("Should return 401 when getting milestone by code without authentication")
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingMilestoneWithMissingCode() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "name": "Missing Code Test",
+                                    "description": "Code field is missing",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 400 when milestone code is missing")
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingMilestoneWithMissingName() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "MISSING-NAME",
+                                    "description": "Name field is missing",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 400 when milestone name is missing")
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingMilestoneWithMissingTargetDate() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "MISSING-DATE",
+                                    "name": "Missing Date Test",
+                                    "description": "TargetDate field is missing",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 400 when milestone targetDate is missing")
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingMilestoneWithMissingStatus() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "MISSING-STATUS",
+                                    "name": "Missing Status Test",
+                                    "description": "Status field is missing",
+                                    "targetDate": "2024-12-31T23:59:59Z"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 400 when milestone status is missing")
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingMilestoneWithMissingProductCode() {
+        var payload =
+                """
+                                {
+                                    "code": "MISSING-PRODUCT",
+                                    "name": "Missing Product Test",
+                                    "description": "ProductCode field is missing",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).as("Should return 400 when productCode is missing").hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn400WhenCreatingMilestoneWithInvalidStatus() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "INVALID-STATUS",
+                                    "name": "Invalid Status Test",
+                                    "description": "Testing invalid status enum value",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "INVALID_STATUS_VALUE"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 400 when status has invalid enum value")
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn404WhenUpdatingNonExistentMilestone() {
+        var payload =
+                """
+                                {
+                                    "name": "Updated Name",
+                                    "description": "Updated description",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.put()
+                .uri("/api/milestones/{code}", "NON-EXISTENT-MILESTONE")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 404 when updating non-existent milestone")
+                .hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn404WhenDeletingNonExistentMilestone() {
+        var result = mvc.delete()
+                .uri("/api/milestones/{code}", "NON-EXISTENT-MILESTONE")
+                .exchange();
+
+        assertThat(result)
+                .as("Should return 404 when deleting non-existent milestone")
+                .hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldCalculateZeroProgressWhenAllReleasesAreDraft() throws Exception {
+        var createMilestone =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "ZERO-PROGRESS",
+                                    "name": "Zero Progress Test",
+                                    "description": "All releases are DRAFT",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createMilestone)
+                .exchange();
+
+        var release1 =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "DRAFT-REL-1",
+                                    "description": "Draft Release 1"
+                                }
+                                """;
+        mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(release1)
+                .exchange();
+
+        var updateRelease1 =
+                """
+                                {
+                                    "description": "Draft Release 1",
+                                    "status": "DRAFT",
+                                    "milestoneCode": "ZERO-PROGRESS"
+                                }
+                                """;
+        mvc.put()
+                .uri("/api/releases/{code}", "IDEA-DRAFT-REL-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRelease1)
+                .exchange();
+
+        var result = mvc.get().uri("/api/milestones/{code}", "ZERO-PROGRESS").exchange();
+        assertThat(result).hasStatusOk();
+
+        String json = result.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(milestone.get("progress"))
+                .as("Progress should be 0% when no releases are RELEASED (0/1)")
+                .isEqualTo(0);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleProgressRoundingCorrectly() throws Exception {
+        var createMilestone =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "ROUNDING-TEST",
+                                    "name": "Rounding Test",
+                                    "description": "Test progress rounding to integer",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createMilestone)
+                .exchange();
+
+        for (int i = 1; i <= 3; i++) {
+            var release = String.format(
+                    """
+                                                        {
+                                                            "productCode": "intellij",
+                                                            "code": "ROUND-REL-%d",
+                                                            "description": "Release %d"
+                                                        }
+                                                        """,
+                    i, i);
+            mvc.post()
+                    .uri("/api/releases")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(release)
+                    .exchange();
+
+            String status = (i == 1) ? "RELEASED" : "DRAFT";
+            var updateRelease = String.format(
+                    """
+                                                        {
+                                                            "description": "Release %d",
+                                                            "status": "%s",
+                                                            "milestoneCode": "ROUNDING-TEST"
+                                                        }
+                                                        """,
+                    i, status);
+            mvc.put()
+                    .uri("/api/releases/{code}", "IDEA-ROUND-REL-" + i)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(updateRelease)
+                    .exchange();
+        }
+
+        var result = mvc.get().uri("/api/milestones/{code}", "ROUNDING-TEST").exchange();
+        assertThat(result).hasStatusOk();
+
+        String json = result.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(milestone.get("progress"))
+                .as("Progress should be 33% as integer (1/3 = 33.33% rounded)")
+                .isEqualTo(33);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldAcceptMilestoneWithAllOptionalFieldsOmitted() {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "MIN-FIELDS",
+                                    "name": "Minimal Fields Test",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var result = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result)
+                .as("Should accept milestone with only required fields")
+                .hasStatus(HttpStatus.CREATED);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldAcceptISO8601DateFormatWithTimezone() throws Exception {
+        var payload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "ISO-DATE-TEST",
+                                    "name": "ISO Date Format Test",
+                                    "description": "Testing ISO-8601 date format",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        var createResult = mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(createResult).hasStatus(HttpStatus.CREATED);
+
+        var getResult = mvc.get().uri("/api/milestones/{code}", "ISO-DATE-TEST").exchange();
+        assertThat(getResult).hasStatusOk();
+
+        String json = getResult.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestone = objectMapper.readValue(json, new TypeReference<>() {});
+
+        assertThat(milestone.get("targetDate"))
+                .as("TargetDate should be returned in ISO-8601 format")
+                .asString()
+                .matches(".*T.*Z");
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldPopulateAuditFieldsOnCreateAndUpdate() throws Exception {
+        var createPayload =
+                """
+                                {
+                                    "productCode": "intellij",
+                                    "code": "AUDIT-TEST",
+                                    "name": "Audit Fields Test",
+                                    "description": "Testing audit fields",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "PLANNED"
+                                }
+                                """;
+
+        mvc.post()
+                .uri("/api/milestones")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createPayload)
+                .exchange();
+
+        var getOriginal = mvc.get().uri("/api/milestones/{code}", "AUDIT-TEST").exchange();
+        assertThat(getOriginal).hasStatusOk();
+
+        String jsonOriginal = getOriginal.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestoneOriginal = objectMapper.readValue(jsonOriginal, new TypeReference<>() {});
+
+        assertThat(milestoneOriginal.get("createdBy"))
+                .as("CreatedBy should be populated on create")
+                .isNotNull();
+
+        assertThat(milestoneOriginal.get("createdAt"))
+                .as("CreatedAt should be populated on create")
+                .isNotNull();
+
+        String originalCreatedBy = (String) milestoneOriginal.get("createdBy");
+        String originalCreatedAt = (String) milestoneOriginal.get("createdAt");
+
+        var updatePayload =
+                """
+                                {
+                                    "name": "Updated Audit Test",
+                                    "description": "Updated description",
+                                    "targetDate": "2024-12-31T23:59:59Z",
+                                    "status": "IN_PROGRESS"
+                                }
+                                """;
+
+        mvc.put()
+                .uri("/api/milestones/{code}", "AUDIT-TEST")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+
+        var getUpdated = mvc.get().uri("/api/milestones/{code}", "AUDIT-TEST").exchange();
+        String jsonUpdated = getUpdated.getMvcResult().getResponse().getContentAsString();
+        Map<String, Object> milestoneUpdated = objectMapper.readValue(jsonUpdated, new TypeReference<>() {});
+
+        assertThat(milestoneUpdated.get("createdBy"))
+                .as("CreatedBy should remain unchanged after update")
+                .isEqualTo(originalCreatedBy);
+
+        assertThat(milestoneUpdated.get("createdAt"))
+                .as("CreatedAt should remain unchanged after update")
+                .isEqualTo(originalCreatedAt);
+
+        assertThat(milestoneUpdated.get("updatedBy"))
+                .as("UpdatedBy should be populated on update")
+                .isNotNull();
+
+        assertThat(milestoneUpdated.get("updatedAt"))
+                .as("UpdatedAt should be populated on update")
+                .isNotNull();
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/ProductControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/ProductControllerTests.java
@@ -54,14 +54,14 @@ class ProductControllerTests extends AbstractIT {
     void shouldCreateNewProduct() {
         var payload =
                 """
-            {
-                "code": "rover",
-                "prefix": "RVR",
-                "name": "Rust Rover",
-                "description": "JetBrains Rust Rover",
-                "imageUrl": "https://resources.jetbrains.com/storage/products/company/brand/logos/RustRover.png"
-            }
-            """;
+                {
+                    "code": "rover",
+                    "prefix": "RVR",
+                    "name": "Rust Rover",
+                    "description": "JetBrains Rust Rover",
+                    "imageUrl": "https://resources.jetbrains.com/storage/products/company/brand/logos/RustRover.png"
+                }
+                """;
 
         var result = mvc.post()
                 .uri("/api/products")
@@ -76,13 +76,13 @@ class ProductControllerTests extends AbstractIT {
     void shouldUpdateProduct() {
         var payload =
                 """
-            {
-                "prefix": "IDEA",
-                "name": "IntelliJ IDEA Ultimate",
-                "description": "Best IDE for Java",
-                "imageUrl": "https://resources.jetbrains.com/storage/products/company/brand/logos/IntelliJ_IDEA_Ultimate.png"
-            }
-            """;
+                {
+                    "prefix": "IDEA",
+                    "name": "IntelliJ IDEA Ultimate",
+                    "description": "Best IDE for Java",
+                    "imageUrl": "https://resources.jetbrains.com/storage/products/company/brand/logos/IntelliJ_IDEA_Ultimate.png"
+                }
+                """;
 
         var result = mvc.put()
                 .uri("/api/products/{code}", "intellij")

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseFeaturePlanningIntegrationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseFeaturePlanningIntegrationTests.java
@@ -1,0 +1,1793 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("Release Feature Planning Integration Tests")
+class ReleaseFeaturePlanningIntegrationTests extends AbstractIT {
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("Should assign feature to release")
+    @WithMockOAuth2User(username = "user")
+    void shouldAssignFeatureToRelease() throws JsonMappingException, JsonProcessingException {
+        var payload =
+                """
+        {
+        "featureCode": "IDEA-3",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Initial assignment"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Fetch the feature and assert all planning fields with exact matches
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> "IDEA-3".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("code")).isEqualTo("IDEA-3");
+        assertThat(feature.get("plannedCompletionDate")).isEqualTo("2024-12-31");
+        assertThat(feature.get("featureOwner")).isEqualTo("john.doe");
+        assertThat(feature.get("notes")).isEqualTo("Initial assignment");
+        assertThat(feature.get("planningStatus")).isEqualTo("NOT_STARTED");
+    }
+
+    @Test
+    @DisplayName("Should reject assign feature to release for unauthorized user")
+    void shouldRejectAssignFeatureToReleaseForUnauthorizedUser() {
+        var payload =
+                """
+        {
+        "featureCode": "IDEA-2",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "jane.doe",
+        "notes": "Unauthorized attempt"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("Should reject duplicate feature assignment")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectDuplicateFeatureAssignment() throws JsonMappingException, JsonProcessingException {
+        // First assignment should succeed
+        var payload =
+                """
+        {
+        "featureCode": "IDEA-3",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "First assignment"
+        }
+        """;
+        var firstResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(firstResult).hasStatus2xxSuccessful();
+        // Verify first assignment via GET with exact field matching
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> "IDEA-3".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("code")).isEqualTo("IDEA-3");
+        assertThat(feature.get("plannedCompletionDate")).isEqualTo("2024-12-31");
+        assertThat(feature.get("featureOwner")).isEqualTo("john.doe");
+        assertThat(feature.get("notes")).isEqualTo("First assignment");
+        assertThat(feature.get("planningStatus")).isEqualTo("NOT_STARTED");
+        // Second assignment should fail
+        var duplicatePayload =
+                """
+        {
+        "featureCode": "IDEA-3",
+        "plannedCompletionDate": "2025-01-15",
+        "featureOwner": "jane.doe",
+        "notes": "Duplicate assignment"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(duplicatePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when assigning to release")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenAssigningToRelease() {
+        var payload =
+                """
+        {
+        "featureCode": "NON_EXISTENT_FEATURE",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment of non-existent feature"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should handle release not found when assigning feature")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleReleaseNotFoundWhenAssigningFeature() {
+        var payload =
+                """
+        {
+        "featureCode": "IDEA-1",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment to non-existent release"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "NON_EXISTENT_RELEASE")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should get features assigned to release")
+    void shouldGetFeaturesAssignedToRelease() throws JsonMappingException, JsonProcessingException {
+        var result = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        assertThat(result.getResponse().getContentType()).isEqualTo("application/json");
+        // Verify response contains specific feature data from test-data.sql including planning fields
+        var responseBody = new String(result.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature1 = features.stream()
+                .filter(f -> "IDEA-1".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature1.get("code")).isEqualTo("IDEA-1");
+        assertThat(feature1.get("title")).isEqualTo("Redesign Structure Tool Window");
+        assertThat(feature1.get("plannedCompletionDate")).asString().isEqualTo("2024-03-01");
+        assertThat(feature1.get("planningStatus")).isEqualTo("NOT_STARTED");
+        assertThat(feature1.get("featureOwner")).isEqualTo("otheruser");
+        assertThat(feature1.get("notes")).isEqualTo("Initial notes");
+        var feature2 = features.stream()
+                .filter(f -> "IDEA-2".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature2.get("code")).isEqualTo("IDEA-2");
+        assertThat(feature2.get("title")).isEqualTo("SDJ Repository Method AutoCompletion");
+    }
+
+    @Test
+    @DisplayName("Should handle release not found when getting features")
+    void shouldHandleReleaseNotFoundWhenGettingFeatures() {
+        var result = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "NON_EXISTENT_RELEASE")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful(); // Should return empty list, not 404
+        assertThat(result.getResponse().getContentType()).isEqualTo("application/json");
+        // Verify response is an empty array for non-existent release
+        var responseBody = new String(result.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        assertThat(responseBody).isEqualTo("[]");
+    }
+
+    @Test
+    @DisplayName("Should update feature planning")
+    @WithMockOAuth2User(username = "user")
+    void shouldUpdateFeaturePlanning() throws JsonMappingException, JsonProcessingException {
+        // First assign a feature
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-4",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Initial assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        // Then update the planning
+        var updatePayload =
+                """
+        {
+        "plannedCompletionDate": "2024-11-30",
+        "planningStatus": "IN_PROGRESS",
+        "featureOwner": "jane.doe",
+        "notes": "Updated planning details"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-4")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Fetch the feature and assert with exact field matching
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> "IDEA-4".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("code")).isEqualTo("IDEA-4");
+        assertThat(feature.get("plannedCompletionDate")).isEqualTo("2024-11-30");
+        assertThat(feature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        assertThat(feature.get("featureOwner")).isEqualTo("jane.doe");
+        assertThat(feature.get("notes")).isEqualTo("Updated planning details");
+        assertThat(feature.get("blockageReason")).isNull();
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when updating planning")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenUpdatingPlanning() {
+        var updatePayload = """
+        {
+        "planningStatus": "IN_PROGRESS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "NON_EXISTENT")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should reject invalid status transition from NOT_STARTED to DONE")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectInvalidStatusTransition() {
+        // First assign a feature
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-5",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Initial assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        // Try invalid transition from NOT_STARTED to DONE
+        var invalidUpdatePayload = """
+        {
+        "planningStatus": "DONE"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidUpdatePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should allow transition from BLOCKED to IN_PROGRESS")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldAllowTransitionFromBlockedToInProgress() throws JsonMappingException, JsonProcessingException {
+        var featureCode = "IDEA-3";
+        // Assign and move to BLOCKED
+        var assignPayload = String.format(
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner",
+        "notes": "notes"
+        }
+        """,
+                featureCode);
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        // Move to BLOCKED
+        var blockedResult = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Waiting for dependencies\"}")
+                .exchange();
+        assertThat(blockedResult).hasStatus2xxSuccessful();
+        // Verify BLOCKED status via GET with exact field matching
+        var getBlockedResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var blockedResponseBody =
+                new String(getBlockedResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> blockedFeatures =
+                objectMapper.readValue(blockedResponseBody, new TypeReference<>() {});
+        var blockedFeature = blockedFeatures.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(blockedFeature.get("planningStatus")).isEqualTo("BLOCKED");
+        assertThat(blockedFeature.get("blockageReason")).isEqualTo("Waiting for dependencies");
+        // Move from BLOCKED to IN_PROGRESS
+        var updatePayload = """
+        {
+        "planningStatus": "IN_PROGRESS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify status change with exact field matching
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        assertThat(feature.get("blockageReason")).isNull();
+    }
+
+    @Test
+    @DisplayName("Should allow transition from IN_PROGRESS to DONE")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldAllowTransitionFromInProgressToDone() throws JsonMappingException, JsonProcessingException {
+        var featureCode = "IDEA-4";
+        // Assign and move to IN_PROGRESS
+        var assignPayload = String.format(
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner",
+        "notes": "notes"
+        }
+        """,
+                featureCode);
+        var assignResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        assertThat(assignResult).hasStatus2xxSuccessful();
+        var inProgressResult = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        assertThat(inProgressResult).hasStatus2xxSuccessful();
+        // Verify IN_PROGRESS status via GET with exact field matching
+        var getInProgressResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var inProgressResponseBody =
+                new String(getInProgressResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> inProgressFeatures =
+                objectMapper.readValue(inProgressResponseBody, new TypeReference<>() {});
+        var inProgressFeature = inProgressFeatures.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(inProgressFeature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        // Move from IN_PROGRESS to DONE
+        var updatePayload = """
+        {
+        "planningStatus": "DONE"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify status change
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("planningStatus")).isEqualTo("DONE");
+    }
+
+    @Test
+    @DisplayName("Should allow transition from IN_PROGRESS to BLOCKED with blockage reason")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldAllowTransitionFromInProgressToBlocked() throws JsonMappingException, JsonProcessingException {
+        var featureCode = "IDEA-5";
+        // Assign and move to IN_PROGRESS
+        var assignPayload = String.format(
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner",
+        "notes": "notes"
+        }
+        """,
+                featureCode);
+        var assignResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        assertThat(assignResult).hasStatus2xxSuccessful();
+        var inProgressResult = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        assertThat(inProgressResult).hasStatus2xxSuccessful();
+        // Verify IN_PROGRESS status via GET with exact field matching
+        var getInProgressResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var inProgressResponseBody =
+                new String(getInProgressResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> inProgressFeatures =
+                objectMapper.readValue(inProgressResponseBody, new TypeReference<>() {});
+        var inProgressFeature = inProgressFeatures.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(inProgressFeature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        // Move from IN_PROGRESS to BLOCKED
+        var updatePayload =
+                """
+        {
+        "planningStatus": "BLOCKED",
+        "blockageReason": "Waiting for dependencies"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify status and blockage reason
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("planningStatus")).isEqualTo("BLOCKED");
+        assertThat(feature.get("blockageReason")).isEqualTo("Waiting for dependencies");
+    }
+
+    @Test
+    @DisplayName("Should validate status transition from NOT_STARTED to BLOCKED")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldValidateStatusTransitionFromNotStartedToBlocked() throws JsonMappingException, JsonProcessingException {
+        var featureCode = "IDEA-6";
+        // Assign feature (defaults to NOT_STARTED)
+        var assignPayload = String.format(
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner",
+        "notes": "notes"
+        }
+        """,
+                featureCode);
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        // Move from NOT_STARTED to BLOCKED
+        var updatePayload =
+                """
+        {
+        "planningStatus": "BLOCKED",
+        "blockageReason": "Dependencies not ready"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify status and blockage reason
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("planningStatus")).isEqualTo("BLOCKED");
+        assertThat(feature.get("blockageReason")).isEqualTo("Dependencies not ready");
+    }
+
+    @Test
+    @DisplayName("Should preserve existing values when partial update")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldPreserveExistingValuesWhenPartialUpdate() throws JsonMappingException, JsonProcessingException {
+        var featureCode = "IDEA-8";
+        // Assign and move to IN_PROGRESS with specific values
+        var assignPayload = String.format(
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "existingowner",
+        "notes": "existing notes"
+        }
+        """,
+                featureCode);
+        var assignResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        assertThat(assignResult).hasStatus2xxSuccessful();
+        var inProgressResult = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        assertThat(inProgressResult).hasStatus2xxSuccessful();
+        // Verify initial IN_PROGRESS state via GET with exact field matching
+        var getInitialResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var initialResponseBody =
+                new String(getInitialResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> initialFeatures =
+                objectMapper.readValue(initialResponseBody, new TypeReference<>() {});
+        var initialFeature = initialFeatures.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(initialFeature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        assertThat(initialFeature.get("featureOwner")).isEqualTo("existingowner");
+        assertThat(initialFeature.get("notes")).isEqualTo("existing notes");
+        // Partial update - only update notes (should preserve owner)
+        var updatePayload =
+                """
+        {
+        "planningStatus": "IN_PROGRESS",
+        "notes": "updated notes only"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify the partial update (owner should be preserved, notes updated)
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        assertThat(responseBody)
+                .contains("IN_PROGRESS")
+                .contains("existingowner") // Should be preserved
+                .contains("updated notes only"); // Should be updated
+    }
+
+    @Test
+    @DisplayName("Should allow same status transition with field updates")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldAllowSameStatusTransitionWithUpdates() throws JsonMappingException, JsonProcessingException {
+        var featureCode = "GO-3";
+        // Assign and move to IN_PROGRESS
+        var assignPayload = String.format(
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner",
+        "notes": "initial notes"
+        }
+        """,
+                featureCode);
+        var assignResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        assertThat(assignResult).hasStatus2xxSuccessful();
+        var inProgressResult = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        assertThat(inProgressResult).hasStatus2xxSuccessful();
+        // Verify initial state via GET with exact field matching
+        var getInitialResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var initialResponseBody =
+                new String(getInitialResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> initialFeatures =
+                objectMapper.readValue(initialResponseBody, new TypeReference<>() {});
+        var initialFeature = initialFeatures.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(initialFeature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        assertThat(initialFeature.get("notes")).isEqualTo("initial notes");
+        // Update with same status but different notes and date
+        var updatePayload =
+                """
+        {
+        "plannedCompletionDate": "2025-01-15",
+        "planningStatus": "IN_PROGRESS",
+        "notes": "updated notes and timeline"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify the update - dates, status, notes
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        assertThat(feature.get("plannedCompletionDate")).isEqualTo("2025-01-15");
+        assertThat(feature.get("notes")).isEqualTo("updated notes and timeline");
+    }
+
+    @Test
+    @DisplayName("Should move feature between releases")
+    @WithMockOAuth2User(username = "user")
+    void shouldMoveFeatureBetweenReleases() throws JsonMappingException, JsonProcessingException {
+        // First assign a feature to a release
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-6",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Initial assignment"
+        }
+        """;
+        var assignResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        assertThat(assignResult).hasStatus2xxSuccessful();
+        // Verify initial assignment via GET with exact field matching
+        var getInitialResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var initialResponseBody =
+                new String(getInitialResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> initialFeatures =
+                objectMapper.readValue(initialResponseBody, new TypeReference<>() {});
+        var initialFeature = initialFeatures.stream()
+                .filter(f -> "IDEA-6".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(initialFeature.get("code")).isEqualTo("IDEA-6");
+        assertThat(initialFeature.get("featureOwner")).isEqualTo("john.doe");
+        // Move to another release
+        var movePayload =
+                """
+        {
+        "targetReleaseCode": "RIDER-2024.2.6",
+        "rationale": "Feature scope changed"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{targetReleaseCode}/features/{featureCode}/move", "RIDER-2024.2.6", "IDEA-6")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(movePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Fetch the feature from the target release and verify it moved with exact field matching
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "RIDER-2024.2.6")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> "IDEA-6".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("code")).isEqualTo("IDEA-6");
+        assertThat(feature.get("releaseCode")).isEqualTo("RIDER-2024.2.6");
+        assertThat(feature.get("planningStatus")).isEqualTo("NOT_STARTED");
+        assertThat(feature.get("notes")).asString().contains("Feature scope changed");
+        // Verify it's no longer in the source release
+        var getSourceResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var sourceResponseBody =
+                new String(getSourceResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> sourceFeatures = objectMapper.readValue(sourceResponseBody, new TypeReference<>() {});
+        var sourceFeature = sourceFeatures.stream()
+                .filter(f -> "IDEA-6".equals(f.get("code")))
+                .findFirst();
+        assertThat(sourceFeature).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should handle move of unassigned feature to release")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldHandleMoveOfUnassignedFeatureToRelease() throws JsonMappingException, JsonProcessingException {
+        // Use a feature that's not assigned to any release (like IDEA-1 from test data)
+        var movePayload =
+                """
+        {
+        "targetReleaseCode": "RIDER-2024.2.6",
+        "rationale": "Moving unassigned feature"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{targetReleaseCode}/features/{featureCode}/move", "RIDER-2024.2.6", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(movePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify the feature appears in the target release with exact field matching
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "RIDER-2024.2.6")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        var feature = features.stream()
+                .filter(f -> "IDEA-1".equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(feature.get("code")).isEqualTo("IDEA-1");
+    }
+
+    @Test
+    @DisplayName("Should handle release not found when moving feature")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleReleaseNotFoundWhenMovingFeature() {
+        var movePayload =
+                """
+        {
+        "targetReleaseCode": "NON_EXISTENT_RELEASE",
+        "rationale": "Moving to non-existent release"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{targetReleaseCode}/features/{featureCode}/move", "NON_EXISTENT_RELEASE", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(movePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when moving")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenMoving() {
+        var movePayload =
+                """
+        {
+        "targetReleaseCode": "RIDER-2024.2.6",
+        "rationale": "Moving non-existent feature"
+        }
+        """;
+        var result = mvc.post()
+                .uri(
+                        "/api/releases/{targetReleaseCode}/features/{featureCode}/move",
+                        "RIDER-2024.2.6",
+                        "NON_EXISTENT_FEATURE")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(movePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should remove feature from release")
+    @WithMockOAuth2User(username = "user")
+    void shouldRemoveFeatureFromRelease() throws JsonMappingException, JsonProcessingException {
+        // First assign a feature
+        // Use a unique feature code for isolation
+        var featureCode = "IDEA-7";
+        var assignPayload =
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Initial assignment"
+        }
+        """
+                        .formatted(featureCode);
+        var assignResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        assertThat(assignResult).hasStatus2xxSuccessful();
+        // Verify assignment via GET
+        var getAssignedResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var assignedResponseBody =
+                new String(getAssignedResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> assignedFeatures =
+                objectMapper.readValue(assignedResponseBody, new TypeReference<>() {});
+        var assignedFeature = assignedFeatures.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(assignedFeature.get("code")).isEqualTo(featureCode);
+        assertThat(assignedFeature.get("featureOwner")).isEqualTo("john.doe");
+        // Remove from release
+        var removePayload = """
+        {
+        "rationale": "Feature cancelled"
+        }
+        """;
+        var result = mvc.delete()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(removePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Fetch the features and assert the feature is not present
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        assertThat(responseBody).doesNotContain(featureCode);
+    }
+
+    @Test
+    @DisplayName("Should handle removal of unassigned feature gracefully")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldHandleRemovalOfUnassignedFeatureGracefully() {
+        // Try to remove a feature that's not assigned to any release
+        var removePayload = """
+        {
+        "rationale": "Removing unassigned feature"
+        }
+        """;
+        var result = mvc.delete()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(removePayload)
+                .exchange();
+        // Should succeed even if feature wasn't assigned to this specific release
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify the feature is still unassigned (not in the release)
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        assertThat(responseBody).doesNotContain("IDEA-1");
+    }
+
+    @Test
+    @DisplayName("Should properly clear all planning data when removing feature")
+    @WithMockOAuth2User(username = "testuser")
+    void shouldProperlyClearAllPlanningDataWhenRemovingFeature() throws JsonMappingException, JsonProcessingException {
+        var featureCode = "IDEA-3";
+        // First assign and fully plan a feature
+        var assignPayload = String.format(
+                """
+        {
+        "featureCode": "%s",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner",
+        "notes": "initial notes"
+        }
+        """,
+                featureCode);
+        var assignResult = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        assertThat(assignResult).hasStatus2xxSuccessful();
+        // Set it to BLOCKED with blockage reason
+        var blockedResult = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Some blockage\"}")
+                .exchange();
+        assertThat(blockedResult).hasStatus2xxSuccessful();
+        // Verify BLOCKED state via GET with exact field matching
+        var getBlockedResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var blockedResponseBody =
+                new String(getBlockedResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> blockedFeatures =
+                objectMapper.readValue(blockedResponseBody, new TypeReference<>() {});
+        var blockedFeature = blockedFeatures.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(blockedFeature.get("planningStatus")).isEqualTo("BLOCKED");
+        assertThat(blockedFeature.get("blockageReason")).isEqualTo("Some blockage");
+        // Now remove it
+        var removePayload = """
+        {
+        "rationale": "Removing fully planned feature"
+        }
+        """;
+        var result = mvc.delete()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}", "IDEA-2023.3.8", featureCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(removePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        // Verify feature is no longer in the release
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        assertThat(responseBody).doesNotContain(featureCode);
+    }
+
+    @Test
+    @DisplayName("Should handle feature not found when removing")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleFeatureNotFoundWhenRemoving() {
+        var removePayload = """
+        {
+        "rationale": "Removing non-existent feature"
+        }
+        """;
+        var result = mvc.delete()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}", "IDEA-2023.3.8", "NON_EXISTENT_FEATURE")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(removePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should validate required fields in assign feature payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateRequiredFieldsInAssignFeaturePayload() {
+        var invalidPayload =
+                """
+        {
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Missing featureCode"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidPayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should validate date format in assign feature payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateDateFormatInAssignFeaturePayload() {
+        var invalidDatePayload =
+                """
+        {
+        "featureCode": "IDEA-6",
+        "plannedCompletionDate": "invalid-date",
+        "featureOwner": "john.doe",
+        "notes": "Invalid date format"
+        }
+        """;
+        var result = mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidDatePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should validate date format in update feature planning payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateDateFormatInUpdateFeaturePlanningPayload() {
+        var invalidDatePayload =
+                """
+        {
+        "plannedCompletionDate": "invalid-date",
+        "planningStatus": "IN_PROGRESS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidDatePayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should validate status enum in update feature planning payload")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateStatusEnumInUpdateFeaturePlanningPayload() {
+        var invalidStatusPayload = """
+        {
+        "planningStatus": "INVALID_STATUS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidStatusPayload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should validate empty payload structure")
+    @WithMockOAuth2User(username = "user")
+    void shouldValidateEmptyPayloadStructure() {
+        // Test assign feature with empty payload - this is different from missing required fields
+        var result = mvc.post()
+                .uri("/api/releases/IDEA-2023.3.8/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should filter features by planning status")
+    @WithMockOAuth2User(username = "user")
+    void shouldFilterFeaturesByPlanningStatus() throws JsonMappingException, JsonProcessingException {
+        // Assign multiple features with different statuses
+        var feature1Payload =
+                """
+        {
+        "featureCode": "IDEA-3",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Feature 1"
+        }
+        """;
+        var feature2Payload =
+                """
+        {
+        "featureCode": "IDEA-4",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "jane.doe",
+        "notes": "Feature 2"
+        }
+        """;
+        // Assign features
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature1Payload)
+                .exchange();
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature2Payload)
+                .exchange();
+        // Update one feature to IN_PROGRESS
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-3")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        // Filter by NOT_STARTED status
+        var notStartedResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?planningStatus=NOT_STARTED", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(notStartedResult).hasStatus2xxSuccessful();
+        var notStartedResponseBody =
+                new String(notStartedResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> notStartedFeatures =
+                objectMapper.readValue(notStartedResponseBody, new TypeReference<>() {});
+        // Filter by status - check planning status
+        assertThat(notStartedFeatures.stream().anyMatch(f -> "IDEA-4".equals(f.get("code"))))
+                .isTrue();
+        assertThat(notStartedFeatures.stream().anyMatch(f -> "IDEA-3".equals(f.get("code"))))
+                .isFalse();
+        // Filter by IN_PROGRESS status
+        var inProgressResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?planningStatus=IN_PROGRESS", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(inProgressResult).hasStatus2xxSuccessful();
+        var inProgressResponseBody =
+                new String(inProgressResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> inProgressFeatures =
+                objectMapper.readValue(inProgressResponseBody, new TypeReference<>() {});
+        // Should contain IDEA-3 (IN_PROGRESS) but not IDEA-4 (NOT_STARTED)
+        assertThat(inProgressFeatures.stream().anyMatch(f -> "IDEA-3".equals(f.get("code"))))
+                .isTrue();
+        assertThat(inProgressFeatures.stream().anyMatch(f -> "IDEA-4".equals(f.get("code"))))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should filter features by owner")
+    @WithMockOAuth2User(username = "user")
+    void shouldFilterFeaturesByOwner() throws JsonMappingException, JsonProcessingException {
+        // Assign features with different owners
+        var feature1Payload =
+                """
+        {
+        "featureCode": "IDEA-5",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "alice.smith",
+        "notes": "Feature 1"
+        }
+        """;
+        var feature2Payload =
+                """
+        {
+        "featureCode": "IDEA-6",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "bob.jones",
+        "notes": "Feature 2"
+        }
+        """;
+        // Assign features
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature1Payload)
+                .exchange();
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature2Payload)
+                .exchange();
+        // Filter by owner "alice"
+        var aliceResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?owner=alice", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(aliceResult).hasStatus2xxSuccessful();
+        var aliceResponseBody = new String(aliceResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> aliceFeatures = objectMapper.readValue(aliceResponseBody, new TypeReference<>() {});
+        // Filter by owner
+        assertThat(aliceFeatures.stream().anyMatch(f -> "IDEA-5".equals(f.get("code"))))
+                .isTrue();
+        assertThat(aliceFeatures.stream().anyMatch(f -> "IDEA-6".equals(f.get("code"))))
+                .isFalse();
+        // Filter by owner "bob"
+        var bobResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?owner=bob", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(bobResult).hasStatus2xxSuccessful();
+        var bobResponseBody = new String(bobResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> bobFeatures = objectMapper.readValue(bobResponseBody, new TypeReference<>() {});
+        // Should contain IDEA-6 (bob.jones) but not IDEA-5 (alice.smith)
+        assertThat(bobFeatures.stream().anyMatch(f -> "IDEA-6".equals(f.get("code"))))
+                .isTrue();
+        assertThat(bobFeatures.stream().anyMatch(f -> "IDEA-5".equals(f.get("code"))))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should filter features by overdue status")
+    @WithMockOAuth2User(username = "user")
+    void shouldFilterFeaturesByOverdueStatus() throws JsonMappingException, JsonProcessingException {
+        // Assign features with past and future dates
+        var overdueFeaturePayload =
+                """
+        {
+        "featureCode": "IDEA-7",
+        "plannedCompletionDate": "2020-01-01",
+        "featureOwner": "overdue.owner",
+        "notes": "Overdue feature"
+        }
+        """;
+        var futureFeaturePayload =
+                """
+        {
+        "featureCode": "IDEA-8",
+        "plannedCompletionDate": "2030-12-31",
+        "featureOwner": "future.owner",
+        "notes": "Future feature"
+        }
+        """;
+        // Assign features
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(overdueFeaturePayload)
+                .exchange();
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(futureFeaturePayload)
+                .exchange();
+        // Filter by overdue=true
+        var overdueResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?overdue=true", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(overdueResult).hasStatus2xxSuccessful();
+        var overdueResponseBody =
+                new String(overdueResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> overdueFeatures =
+                objectMapper.readValue(overdueResponseBody, new TypeReference<>() {});
+        // Filter by overdue
+        assertThat(overdueFeatures.stream().anyMatch(f -> "IDEA-7".equals(f.get("code"))))
+                .isTrue();
+        assertThat(overdueFeatures.stream().anyMatch(f -> "IDEA-8".equals(f.get("code"))))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should filter features by blocked status")
+    @WithMockOAuth2User(username = "user")
+    void shouldFilterFeaturesByBlockedStatus() throws JsonMappingException, JsonProcessingException {
+        // Assign features using unique codes (tests run in isolation but share database state)
+        var feature1Payload =
+                """
+        {
+        "featureCode": "GO-3",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner1",
+        "notes": "Feature 1"
+        }
+        """;
+        var feature2Payload =
+                """
+        {
+        "featureCode": "IDEA-3",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "owner2",
+        "notes": "Feature 2"
+        }
+        """;
+        // Assign features
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature1Payload)
+                .exchange();
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature2Payload)
+                .exchange();
+        // Block one feature
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "GO-3")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Waiting for dependencies\"}")
+                .exchange();
+        // Filter by blocked=true
+        var blockedResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?blocked=true", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(blockedResult).hasStatus2xxSuccessful();
+        var blockedResponseBody =
+                new String(blockedResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> blockedFeatures =
+                objectMapper.readValue(blockedResponseBody, new TypeReference<>() {});
+        // Filter by blocked
+        assertThat(blockedFeatures.stream().anyMatch(f -> "GO-3".equals(f.get("code"))))
+                .isTrue();
+        assertThat(blockedFeatures.stream().anyMatch(f -> "IDEA-3".equals(f.get("code"))))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should handle multiple filters combined")
+    @WithMockOAuth2User(username = "user")
+    void shouldHandleMultipleFiltersCombined() throws JsonMappingException, JsonProcessingException {
+        // Assign features with different combinations
+        var feature1Payload =
+                """
+        {
+        "featureCode": "IDEA-4",
+        "plannedCompletionDate": "2020-01-01",
+        "featureOwner": "test.user",
+        "notes": "Test feature 1"
+        }
+        """;
+        var feature2Payload =
+                """
+        {
+        "featureCode": "IDEA-5",
+        "plannedCompletionDate": "2020-01-01",
+        "featureOwner": "other.user",
+        "notes": "Test feature 2"
+        }
+        """;
+        // Assign features
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature1Payload)
+                .exchange();
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(feature2Payload)
+                .exchange();
+        // Filter by overdue=true AND owner=test
+        var combinedResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?overdue=true&owner=test", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(combinedResult).hasStatus2xxSuccessful();
+        var combinedResponseBody =
+                new String(combinedResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> combinedFeatures =
+                objectMapper.readValue(combinedResponseBody, new TypeReference<>() {});
+        // Filter by multiple criteria - overdue AND owner
+        assertThat(combinedFeatures.stream().anyMatch(f -> "IDEA-4".equals(f.get("code"))))
+                .isTrue();
+        assertThat(combinedFeatures.stream().anyMatch(f -> "IDEA-5".equals(f.get("code"))))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should handle invalid planningStatus filter")
+    void shouldHandleInvalidPlanningStatusFilter() {
+        var result = mvc.get()
+                .uri("/api/releases/{releaseCode}/features?planningStatus=INVALID_STATUS", "IDEA-2023.3.8")
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+    // Planning Status Transition Tests
+    @Test
+    @DisplayName("Should allow NOT_STARTED → IN_PROGRESS transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowNotStartedToInProgressTransition() throws JsonMappingException, JsonProcessingException {
+        // Assign feature with NOT_STARTED status
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-3",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        // Transition to IN_PROGRESS
+        var updatePayload = """
+        {
+        "planningStatus": "IN_PROGRESS"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-3")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-3");
+        assertThat(feature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    @DisplayName("Should allow NOT_STARTED → BLOCKED transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowNotStartedToBlockedTransition() throws JsonMappingException, JsonProcessingException {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-4",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        var updatePayload =
+                """
+        {
+        "planningStatus": "BLOCKED",
+        "blockageReason": "Waiting for dependencies"
+        }
+        """;
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-4")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-4");
+        assertThat(feature.get("planningStatus")).isEqualTo("BLOCKED");
+        assertThat(feature.get("blockageReason")).isEqualTo("Waiting for dependencies");
+    }
+
+    @Test
+    @DisplayName("Should allow IN_PROGRESS → DONE transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowInProgressToDoneTransition() throws JsonMappingException, JsonProcessingException {
+        // Assign and set to IN_PROGRESS
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-5",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        // Transition to DONE
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-5");
+        assertThat(feature.get("planningStatus")).isEqualTo("DONE");
+    }
+
+    @Test
+    @DisplayName("Should allow IN_PROGRESS → BLOCKED transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowInProgressToBlockedTransition() throws JsonMappingException, JsonProcessingException {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-6",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-6")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-6")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Bug discovered\"}")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-6");
+        assertThat(feature.get("planningStatus")).isEqualTo("BLOCKED");
+    }
+
+    @Test
+    @DisplayName("Should allow IN_PROGRESS → NOT_STARTED transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowInProgressToNotStartedTransition() throws JsonMappingException, JsonProcessingException {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-7",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"NOT_STARTED\"}")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-7");
+        assertThat(feature.get("planningStatus")).isEqualTo("NOT_STARTED");
+    }
+
+    @Test
+    @DisplayName("Should allow BLOCKED → IN_PROGRESS transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowBlockedToInProgressTransition() throws JsonMappingException, JsonProcessingException {
+        // First assign GO-3 to release
+        var assignPayload =
+                """
+        {
+        "featureCode": "GO-3",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "GO-3")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Waiting\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "GO-3")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "GO-3");
+        assertThat(feature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+        assertThat(feature.get("blockageReason")).isNull();
+    }
+
+    @Test
+    @DisplayName("Should allow BLOCKED → NOT_STARTED transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowBlockedToNotStartedTransition() throws JsonMappingException, JsonProcessingException {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-8",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Waiting\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"NOT_STARTED\"}")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-8");
+        assertThat(feature.get("planningStatus")).isEqualTo("NOT_STARTED");
+    }
+
+    @Test
+    @DisplayName("Should allow DONE → NOT_STARTED transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowDoneToNotStartedTransition() throws JsonMappingException, JsonProcessingException {
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"NOT_STARTED\"}")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-2");
+        assertThat(feature.get("planningStatus")).isEqualTo("NOT_STARTED");
+    }
+
+    @Test
+    @DisplayName("Should allow DONE → IN_PROGRESS transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldAllowDoneToInProgressTransition() throws JsonMappingException, JsonProcessingException {
+        // Need a new feature for this test - let's create a release without IDEA-2023.3.8
+        // Since all unassigned features are used, we'll use IDEA-1 which is already assigned
+        // Actually, let's use the existing IDEA-1 and move it through states
+        // First, let's get a fresh feature - for this we need to use  existing assignment pattern
+        // Let's patch IDEA-1 which is already in IDEA-2023.3.8
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        var finalResult = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        assertThat(finalResult).hasStatus2xxSuccessful();
+        var feature = getFeatureFromRelease("IDEA-2023.3.8", "IDEA-1");
+        assertThat(feature.get("planningStatus")).isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    @DisplayName("Should reject NOT_STARTED → DONE transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectNotStartedToDoneTransition() throws JsonMappingException, JsonProcessingException {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-7",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should reject BLOCKED → DONE transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectBlockedToDoneTransition() throws JsonMappingException, JsonProcessingException {
+        var assignPayload =
+                """
+        {
+        "featureCode": "IDEA-8",
+        "plannedCompletionDate": "2024-12-31",
+        "featureOwner": "john.doe",
+        "notes": "Assignment"
+        }
+        """;
+        mvc.post()
+                .uri("/api/releases/{releaseCode}/features", "IDEA-2023.3.8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignPayload)
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Waiting\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should reject DONE → BLOCKED transition")
+    @WithMockOAuth2User(username = "user")
+    void shouldRejectDoneToBlockedTransition() throws JsonMappingException, JsonProcessingException {
+        // Use IDEA-2 which is already assigned to IDEA-2023.3.8
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"IN_PROGRESS\"}")
+                .exchange();
+        mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"DONE\"}")
+                .exchange();
+        var result = mvc.patch()
+                .uri("/api/releases/{releaseCode}/features/{featureCode}/planning", "IDEA-2023.3.8", "IDEA-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planningStatus\": \"BLOCKED\", \"blockageReason\": \"Should not work\"}")
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+    // Helper method to fetch feature from release
+    private Map<String, Object> getFeatureFromRelease(String releaseCode, String featureCode)
+            throws JsonMappingException, JsonProcessingException {
+        var getResult = mvc.get()
+                .uri("/api/releases/{releaseCode}/features", releaseCode)
+                .exchange();
+        var responseBody = new String(getResult.getResponse().getContentAsByteArray(), StandardCharsets.UTF_8);
+        List<Map<String, Object>> features = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        return features.stream()
+                .filter(f -> featureCode.equals(f.get("code")))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -1,7 +1,30 @@
+create table if not exists milestones
+(
+    id          bigint       not null,
+    code        varchar(50)  not null unique,
+    name        varchar(255) not null,
+    description text,
+    target_date timestamp    not null,
+    actual_date timestamp,
+    status      varchar(50)  not null,
+    product_id  bigint       not null,
+    owner       varchar(255),
+    notes       text,
+    created_by  varchar(255) not null,
+    created_at  timestamp    not null default current_timestamp,
+    updated_by  varchar(255),
+    updated_at  timestamp,
+    primary key (id)
+);
+
+create sequence if not exists milestone_id_seq start with 100 increment by 50;
+alter table releases add column if not exists milestone_id bigint;
+
 delete from favorite_features;
 delete from comments;
 delete from features;
 delete from releases;
+delete from milestones;
 delete from products;
 
 insert into products (id, code, prefix, name, description, image_url, disabled, created_by, created_at) values
@@ -9,22 +32,34 @@ insert into products (id, code, prefix, name, description, image_url, disabled, 
 (2, 'goland','GO','GoLand', 'JetBrains IDE for Go', 'https://resources.jetbrains.com/storage/products/company/brand/logos/GoLand.png',false, 'admin','2024-03-01 00:00:00'),
 (3, 'webstorm','WEB','WebStorm', 'JetBrains IDE for Web Development','https://resources.jetbrains.com/storage/products/company/brand/logos/WebStorm.png', false, 'admin','2024-03-01 00:00:00'),
 (4, 'pycharm','PY','PyCharm', 'JetBrains IDE for Python', 'https://resources.jetbrains.com/storage/products/company/brand/logos/PyCharm.png',false, 'admin','2024-03-01 00:00:00'),
-(5, 'rider','RIDER','Rider', 'JetBrains IDE for .NET', 'https://resources.jetbrains.com/storage/products/company/brand/logos/Rider.png',false, 'admin','2024-03-01 00:00:00')
+(5, 'rider', 'RIDER', 'Rider', 'JetBrains IDE for .NET', 'https://resources.jetbrains.com/storage/products/company/brand/logos/Rider.png', false, 'admin', '2024-03-01 00:00:00');
+
+insert into milestones (id, code, name, description, target_date, actual_date, status, product_id, owner, notes, created_by, created_at, updated_by, updated_at) values
+(1001, 'Q1-2024', 'Q1 2024 Release', 'First quarter objectives', '2024-03-31 23:59:59', '2024-03-28 15:30:00', 'COMPLETED', 1, 'alice@example.com', 'Completed ahead of schedule', 'admin', '2024-01-01 00:00:00', 'admin', '2024-03-28 15:30:00'),
+(1002, 'Q2-2024', 'Q2 2024 Release', 'Second quarter objectives', '2024-06-30 23:59:59', NULL, 'IN_PROGRESS', 1, 'bob@example.com', 'Focus on performance', 'admin', '2024-04-01 00:00:00', NULL, NULL),
+(1003, 'Q3-2024', 'Q3 2024 Release', 'Third quarter objectives', '2024-09-30 23:59:59', NULL, 'PLANNED', 2, 'charlie@example.com', 'New features planned', 'admin', '2024-07-01 00:00:00', NULL, NULL),
+(1004, 'MVP-1', 'MVP Release', 'Minimum Viable Product', '2024-05-15 23:59:59', NULL, 'PLANNED', 3, 'dave@example.com', 'Core features only', 'admin', '2024-01-15 00:00:00', NULL, NULL),
+(1005, 'PERF-2024', 'Performance Release', 'Performance improvements', '2024-08-31 23:59:59', NULL, 'PLANNED', 5, 'eve@example.com', 'Performance focus', 'admin', '2024-02-01 00:00:00', NULL, NULL);
+
+insert into releases (id, product_id, milestone_id, code, description, status, created_by, created_at) values
+(1, 1, 1001, 'IDEA-2023.3.8', 'IntelliJ IDEA 2023.3.8', 'RELEASED', 'admin','2023-03-25'),
+(2, 1, 1002, 'IDEA-2024.2.3', 'IntelliJ IDEA 2024.2.4', 'RELEASED', 'admin','2024-02-25'),
+(3, 2, 1003, 'GO-2024.2.3', 'GoLand 2024.2.4', 'RELEASED', 'admin','2024-02-15'),
+(4, 3, 1004, 'WEB-2024.2.3', 'WebStorm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
+(5, 4, NULL, 'PY-2024.2.3', 'PyCharm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
+(6, 5, 1005, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
 ;
 
-insert into releases (id, product_id, code, description, status, created_by, created_at) values
-(1, 1, 'IDEA-2023.3.8', 'IntelliJ IDEA 2023.3.8', 'RELEASED', 'admin','2023-03-25'),
-(2, 1, 'IDEA-2024.2.3', 'IntelliJ IDEA 2024.2.4', 'RELEASED', 'admin','2024-02-25'),
-(3, 2, 'GO-2024.2.3', 'GoLand 2024.2.4', 'RELEASED', 'admin','2024-02-15'),
-(4, 3, 'WEB-2024.2.3', 'WebStorm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
-(5, 4, 'PY-2024.2.3', 'PyCharm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
-(6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
-;
-
-insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at) values
-(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24'),
-(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14'),
-(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14')
+insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at, planned_completion_date, planning_status, feature_owner, notes, blockage_reason) values
+(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'otheruser', 'otheruser', '2024-02-24', '2024-03-01', 'NOT_STARTED', 'otheruser', 'Initial notes', null),
+(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'otheruser', 'otheruser', '2024-03-14', '2024-04-01', 'NOT_STARTED', 'otheruser', 'Initial notes', null),
+(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14', null, 'NOT_STARTED', null, null, null),
+(4, 1, null, 'IDEA-3', 'New unassigned feature 1', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-02-25', null, 'NOT_STARTED', null, null, null),
+(5, 1, null, 'IDEA-4', 'New unassigned feature 2', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-02-26', null, 'NOT_STARTED', null, null, null),
+(6, 1, null, 'IDEA-5', 'New unassigned feature 3', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-02-27', null, 'NOT_STARTED', null, null, null),
+(7, 1, null, 'IDEA-6', 'New unassigned feature 4', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-02-28', null, 'NOT_STARTED', null, null, null),
+(8, 1, null, 'IDEA-7', 'New unassigned feature 5', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-03-01', null, 'NOT_STARTED', null, null, null),
+(9, 1, null, 'IDEA-8', 'New unassigned feature 6', 'This feature is not assigned to any release yet', 'NEW', 'user', 'user', '2024-03-02', null, 'NOT_STARTED', null, null, null)
 ;
 
 insert into favorite_features (id, feature_id, user_id) values


### PR DESCRIPTION
## Description

Kafka events for release, feature, and milestone changes use wrong format for date/time fields.

Expected: ISO-8601 strings like `"2026-03-13T19:05:08.127746Z"`  
Actual: numeric timestamps like `1.773428708127746E9`

## Steps to Reproduce

1. Send `PUT /api/releases/IDEA-2023.3.8`
2. Receive the emitted message from `updated_releases` topic
3. Following fields have doubles instead of iso date/time strings: `createdAt`, `releasedAt`, and `updatedAt`:

```json
{
  "createdAt": 1.6797024E9,
  "releasedAt": 1.7117568E9,
  "updatedAt": 1.773428708127746E9
}
```

**Expected:**

```json
{
  "createdAt": "2023-03-25T00:00:00Z",
  "releasedAt": "2024-03-30T00:00:00Z",
  "updatedAt": "2026-03-13T19:05:08.127746Z"
}
```
