### PR TITLE
Implement a Custom CacheManager for FeatureService

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.domain.FeatureServiceCacheTest#findByAssigneeForDifferentAssignees",
+      "com.sivalabs.ft.features.domain.FeatureServiceCacheTest#findByAssigneeForRepeatedCalls"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The feature-service microservice manages products, releases and features.
 * Java, Spring Boot
 * PostgreSQL, Flyway, Spring Data JPA
 * Spring Security OAuth 2
+* Spring Cache with Ehcache
 * Maven, JUnit 5, Testcontainers
 
 ## Prerequisites
@@ -30,4 +31,40 @@ $ ./mvnw spotless:apply
 # Run application
 # Once the dependent services (PostgreSQL, Keycloak, etc) are started, 
 # you can run/debug FeatureServiceApplication.java from your IDE.
+```
+
+## Cache Configuration
+
+The application uses Ehcache as the caching provider via Spring Cache abstraction to improve query performance. Two caches are configured:
+
+1. **featureById**: Caches Feature objects by their ID
+2. **featuresByStatus**: Caches lists of Features by their status
+
+### Cache Configuration Details
+
+- Cache configuration is defined in `src/main/resources/ehcache.xml`
+- Each cache has a TTL (Time-To-Live) of 30 minutes
+- Each cache can store up to 1000 entries
+- Cache statistics are enabled for monitoring
+
+### Cached Methods
+
+The following methods in `FeatureService` are cached:
+
+- `findById(Long id)`: Retrieves a Feature by its ID
+- `findByStatus(FeatureStatus status)`: Retrieves Features by their status
+
+### Monitoring Cache Usage
+
+Cache statistics can be monitored through Spring Boot Actuator endpoints:
+
+```shell
+# Get all available metrics
+curl http://localhost:8081/actuator/metrics
+
+# Get cache statistics for featureById cache
+curl http://localhost:8081/actuator/metrics/cache.gets?tag=name:featureById
+
+# Get cache statistics for featuresByStatus cache
+curl http://localhost:8081/actuator/metrics/cache.gets?tag=name:featuresByStatus
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,15 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>3.10.8</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -230,12 +238,12 @@
                 <version>${spotless-maven-plugin.version}</version>
                 <configuration>
                     <java>
-                        <importOrder />
-                        <removeUnusedImports />
+                        <importOrder/>
+                        <removeUnusedImports/>
                         <palantirJavaFormat>
                             <version>${palantir-java-format.version}</version>
                         </palantirJavaFormat>
-                        <formatAnnotations />
+                        <formatAnnotations/>
                     </java>
                 </configuration>
                 <executions>

--- a/src/main/java/com/sivalabs/ft/features/config/CacheConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/CacheConfig.java
@@ -1,0 +1,34 @@
+package com.sivalabs.ft.features.config;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Cache configuration class.
+ * This class configures a simple in-memory cache manager
+ * that uses ConcurrentHashMap for storing cache entries.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    @Primary
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        List<Cache> caches = Arrays.asList(
+                new ConcurrentMapCache("featureById"),
+                new ConcurrentMapCache("featuresByStatus"),
+                new ConcurrentMapCache("featuresByAssignee"));
+        cacheManager.setCaches(caches);
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -16,12 +16,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class FeatureService {
     public static final String FEATURE_SEPARATOR = "-";
+    private static final Logger logger = LoggerFactory.getLogger(FeatureService.class);
     private final FavoriteFeatureService favoriteFeatureService;
     private final ReleaseRepository releaseRepository;
     private final FeatureRepository featureRepository;
@@ -134,5 +138,42 @@ public class FeatureService {
         favoriteFeatureRepository.deleteByFeatureCode(cmd.code());
         featureRepository.deleteByCode(cmd.code());
         eventPublisher.publishFeatureDeletedEvent(feature, cmd.deletedBy(), Instant.now());
+    }
+    /**
+     * Find a feature by its ID.
+     * This method is cached to improve performance for frequently accessed features.
+     */
+    @Transactional(readOnly = true)
+    @Cacheable(value = "featureById", key = "#id")
+    public Optional<Feature> findById(Long id) {
+        logger.debug("Fetching feature with ID: {} (Cache miss)", id);
+        return featureRepository.findById(id);
+    }
+    /**
+     * Find features by their status.
+     * This method is cached to improve performance for frequently accessed status queries.
+     *
+     * @param status The status to filter features by
+     * @return A list of features with the specified status
+     */
+    @Transactional(readOnly = true)
+    @Cacheable(value = "featuresByStatus", key = "#status")
+    public List<Feature> findByStatus(FeatureStatus status) {
+        logger.debug("Fetching features with status: {} (Cache miss)", status);
+        return featureRepository.findAll().stream()
+                .filter(feature -> feature.getStatus() == status)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    @Cacheable(value = "featuresByAssignee", key = "#assignee")
+    public List<Feature> findByAssignee(String assignee) {
+        logger.debug("Fetching features assigned to: {} (Cache miss)", assignee);
+        if (assignee == null) {
+            return List.of();
+        }
+        return featureRepository.findAll().stream()
+                .filter(feature -> assignee.equals(feature.getAssignedTo()))
+                .toList();
     }
 }

--- a/src/test/java/com/sivalabs/ft/features/domain/FeatureServiceCacheTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/FeatureServiceCacheTest.java
@@ -1,0 +1,95 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import com.sivalabs.ft.features.domain.entities.Feature;
+import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Tests for verifying cache behavior in FeatureService.
+ * <p>
+ * These tests verify that:
+ * 1. Multiple calls with the same parameters return the same results (cache hit)
+ * 2. Calls with different parameters return different results (cache miss)
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class})
+@Sql(scripts = {"/test-data.sql"})
+@Transactional
+class FeatureServiceCacheTest {
+
+    @Autowired
+    private FeatureService featureService;
+
+    @Test
+    void findByIdForRepeatedCalls() {
+        Long featureId = 1L;
+        Optional<Feature> feature1 = featureService.findById(featureId);
+        Optional<Feature> feature2 = featureService.findById(featureId);
+
+        // Verify both calls returned the same result
+        assertThat(feature1).isPresent();
+        assertThat(feature2).isPresent();
+        assertThat(feature1).isEqualTo(feature2);
+    }
+
+    @Test
+    void findByIdWithDifferentIds() {
+        Long featureId1 = 1L;
+        Optional<Feature> feature1 = featureService.findById(featureId1);
+        Long featureId2 = 2L;
+        Optional<Feature> feature2 = featureService.findById(featureId2);
+
+        assertThat(feature1).isPresent();
+        assertThat(feature2).isPresent();
+        assertThat(feature1).isNotEqualTo(feature2);
+    }
+
+    @Test
+    void findByStatusForRepeatedCalls() {
+        FeatureStatus status = FeatureStatus.NEW;
+        List<Feature> features1 = featureService.findByStatus(status);
+        List<Feature> features2 = featureService.findByStatus(status);
+
+        assertThat(features1).isEqualTo(features2);
+    }
+
+    @Test
+    void findByStatusForDifferentStatuses() {
+        FeatureStatus status1 = FeatureStatus.NEW;
+        List<Feature> features1 = featureService.findByStatus(status1);
+        FeatureStatus status2 = FeatureStatus.IN_PROGRESS;
+        List<Feature> features2 = featureService.findByStatus(status2);
+
+        assertThat(features1).isNotEqualTo(features2);
+    }
+
+    @Test
+    void findByAssigneeForRepeatedCalls() {
+        String assignee = "andreybelyaev";
+        List<Feature> features1 = featureService.findByAssignee(assignee);
+        List<Feature> features2 = featureService.findByAssignee(assignee);
+
+        // Verify both calls returned the same result (cache hit)
+        assertThat(features1).isEqualTo(features2);
+    }
+
+    @Test
+    void findByAssigneeForDifferentAssignees() {
+        String assignee1 = "siva";
+        List<Feature> features1 = featureService.findByAssignee(assignee1);
+        String assignee2 = "andreybelyaev";
+        List<Feature> features2 = featureService.findByAssignee(assignee2);
+
+        assertThat(features1).isNotEqualTo(features2);
+    }
+}


### PR DESCRIPTION
Register `org.springframework.cache.support.SimpleCacheManager` as a Spring @Bean in a configuration class replacing other cache managers. 
Configure FeatureService's 'findByAssignee' method with @Cacheable to use the custom cache('featuresByAssignee').