### PR TITLE
Implement correlation ID support with `X-Correlation-ID` header

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.CorrelationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/advice/CorrelationIdAdvice.java
+++ b/src/main/java/com/sivalabs/ft/features/advice/CorrelationIdAdvice.java
@@ -1,0 +1,38 @@
+package com.sivalabs.ft.features.advice;
+
+import com.sivalabs.ft.features.config.CorrelationIdContext;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Controller advice to ensure correlation ID is included in all responses
+ */
+@ControllerAdvice
+public class CorrelationIdAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response) {
+
+        // Ensure correlation ID is included in response headers
+        String correlationId = CorrelationIdContext.getCorrelationIdOrDefault();
+        response.getHeaders().set(CorrelationIdContext.CORRELATION_ID_HEADER, correlationId);
+
+        return body;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/CorrelationIdContext.java
+++ b/src/main/java/com/sivalabs/ft/features/config/CorrelationIdContext.java
@@ -1,0 +1,29 @@
+package com.sivalabs.ft.features.config;
+
+import java.util.UUID;
+
+/**
+ * ThreadLocal context to store and retrieve correlation ID
+ */
+public class CorrelationIdContext {
+    private static final ThreadLocal<String> CORRELATION_ID = new ThreadLocal<>();
+
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-ID";
+
+    public static void setCorrelationId(String correlationId) {
+        CORRELATION_ID.set(correlationId);
+    }
+
+    public static String getCorrelationId() {
+        return CORRELATION_ID.get();
+    }
+
+    public static String getCorrelationIdOrDefault() {
+        String correlationId = CORRELATION_ID.get();
+        return correlationId != null ? correlationId : UUID.randomUUID().toString();
+    }
+
+    public static void clear() {
+        CORRELATION_ID.remove();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/CorrelationIdFilter.java
+++ b/src/main/java/com/sivalabs/ft/features/config/CorrelationIdFilter.java
@@ -1,0 +1,52 @@
+package com.sivalabs.ft.features.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter to extract or generate correlation ID from request headers
+ * and make it available in the context for the duration of the request
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorrelationIdFilter extends OncePerRequestFilter {
+
+    private static final String CORRELATION_ID_KEY = "correlationId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            // Extract the correlation ID from the incoming request, or generate a new one
+            String correlationId = request.getHeader(CorrelationIdContext.CORRELATION_ID_HEADER);
+            if (correlationId == null || correlationId.isBlank()) {
+                correlationId = CorrelationIdContext.getCorrelationIdOrDefault();
+            }
+
+            // Store in thread-local context
+            CorrelationIdContext.setCorrelationId(correlationId);
+
+            // Add to MDC for logging
+            MDC.put(CORRELATION_ID_KEY, correlationId);
+
+            // Add the correlation ID to the response
+            response.addHeader(CorrelationIdContext.CORRELATION_ID_HEADER, correlationId);
+
+            // Continue with the request
+            filterChain.doFilter(request, response);
+        } finally {
+            // Clean up
+            CorrelationIdContext.clear();
+            MDC.remove(CORRELATION_ID_KEY);
+        }
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/RestTemplateConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/RestTemplateConfig.java
@@ -1,0 +1,27 @@
+package com.sivalabs.ft.features.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Configuration for RestTemplate to propagate correlation ID
+ */
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.interceptors(correlationIdInterceptor()).build();
+    }
+
+    private ClientHttpRequestInterceptor correlationIdInterceptor() {
+        return (request, body, execution) -> {
+            request.getHeaders()
+                    .set(CorrelationIdContext.CORRELATION_ID_HEADER, CorrelationIdContext.getCorrelationIdOrDefault());
+            return execution.execute(request, body);
+        };
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="CONSOLE_LOG_PATTERN" 
+        value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr([%X{correlationId:-}]){yellow} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/CorrelationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/CorrelationTests.java
@@ -1,0 +1,31 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.sivalabs.ft.features.AbstractIT;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CorrelationTests extends AbstractIT {
+
+    private static final String CORRELATION_ID_HEADER = "X-Correlation-ID";
+
+    @Test
+    void shouldPropagateProvidedCorrelationId() {
+        // Given
+        String correlationId = UUID.randomUUID().toString();
+
+        // When/Then
+        var result = mvc.perform(get("/api/features").header(CORRELATION_ID_HEADER, correlationId));
+        assertThat(result).hasStatusOk().hasHeader(CORRELATION_ID_HEADER, correlationId);
+    }
+
+    @Test
+    void shouldGenerateCorrelationIdWhenNotProvided() throws Exception {
+
+        // When/Then
+        var result = mvc.perform(get("/api/features"));
+        assertThat(result).hasStatusOk().headers().containsHeader(CORRELATION_ID_HEADER);
+    }
+}


### PR DESCRIPTION
Implement correlation ID in the feature-service microservice to enhance observability, make logs more searchable and analyzable, and enable tracing of requests across the system. Correlation id must be tracked with `X-Correlation-ID` header.