### PR TITLE
Release Chains: Add endpoint to retrieve all features associated with the specified release and all its parent releases

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests#shouldGetFeaturesFromReleaseAndParentReleases",
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests#shouldLimitFeaturesToRequestedParentRelease"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
@@ -91,6 +91,29 @@ class FeatureController {
         return featureDtos;
     }
 
+    @GetMapping("/all-features")
+    @Operation(
+            summary = "Find features by release including parent releases",
+            description = "Find features by release including parent releases",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = FeatureDto.class))))
+            })
+    List<FeatureDto> getAllFeatures(
+            @RequestParam("releaseCode") String releaseCode,
+            @RequestParam(value = "fromParentRelease", required = false) String fromParentRelease) {
+        if (StringUtils.isBlank(releaseCode)) {
+            return List.of();
+        }
+        String username = SecurityUtils.getCurrentUsername();
+        return featureService.findFeaturesByReleaseAndParents(username, releaseCode, fromParentRelease);
+    }
+
     @GetMapping("/{code}")
     @Operation(
             summary = "Find feature by code",

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
@@ -99,7 +99,8 @@ class ReleaseController {
             })
     ResponseEntity<Void> createRelease(@RequestBody @Valid CreateReleasePayload payload) {
         var username = SecurityUtils.getCurrentUsername();
-        var cmd = new CreateReleaseCommand(payload.productCode(), payload.code(), payload.description(), username);
+        var cmd = new CreateReleaseCommand(
+                payload.productCode(), payload.code(), payload.parentCode(), payload.description(), username);
         String code = releaseService.createRelease(cmd);
         log.info("Created release with code {}", code);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()

--- a/src/main/java/com/sivalabs/ft/features/api/models/CreateReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/CreateReleasePayload.java
@@ -6,4 +6,5 @@ import jakarta.validation.constraints.Size;
 public record CreateReleasePayload(
         @NotEmpty(message = "Product code is required") String productCode,
         @Size(max = 50, message = "Release code cannot exceed 50 characters") @NotEmpty(message = "Release code is required") String code,
+        String parentCode,
         String description) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/Commands.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/Commands.java
@@ -15,7 +15,8 @@ public class Commands {
             String code, String prefix, String name, String description, String imageUrl, String updatedBy) {}
 
     /* Release Commands */
-    public record CreateReleaseCommand(String productCode, String code, String description, String createdBy) {}
+    public record CreateReleaseCommand(
+            String productCode, String code, String parentCode, String description, String createdBy) {}
 
     public record UpdateReleaseCommand(
             String code, String description, ReleaseStatus status, Instant releasedAt, String updatedBy) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -64,6 +64,26 @@ public class FeatureService {
     }
 
     @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesByReleaseAndParents(
+            String username, String releaseCode, String fromParentReleaseCode) {
+        Optional<Release> releaseOptional = releaseRepository.findByCode(releaseCode);
+        if (releaseOptional.isEmpty()) {
+            return List.of();
+        }
+
+        List<Feature> features = new java.util.ArrayList<>();
+        Release currentRelease = releaseOptional.get();
+        while (currentRelease != null) {
+            features.addAll(featureRepository.findByReleaseCode(currentRelease.getCode()));
+            if (currentRelease.getCode().equals(fromParentReleaseCode)) {
+                break;
+            }
+            currentRelease = currentRelease.getParent();
+        }
+        return updateFavoriteStatus(features, username);
+    }
+
+    @Transactional(readOnly = true)
     public List<FeatureDto> findFeaturesByProduct(String username, String productCode) {
         List<Feature> features = featureRepository.findByProductCode(productCode);
         return updateFavoriteStatus(features, username);

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseRepository.java
@@ -4,9 +4,11 @@ import com.sivalabs.ft.features.domain.entities.Release;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 
 interface ReleaseRepository extends ListCrudRepository<Release, Long> {
+    @Query("select r from Release r left join fetch r.parent where r.code = :code")
     Optional<Release> findByCode(String code);
 
     List<Release> findByProductCode(String productCode);

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
@@ -11,6 +11,7 @@ import com.sivalabs.ft.features.domain.models.ReleaseStatus;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,6 +60,10 @@ public class ReleaseService {
         }
         Release release = new Release();
         release.setProduct(product);
+        if (StringUtils.isNotBlank(cmd.parentCode())) {
+            Release parent = releaseRepository.findByCode(cmd.parentCode()).orElseThrow();
+            release.setParent(parent);
+        }
         release.setCode(code);
         release.setDescription(cmd.description());
         release.setStatus(ReleaseStatus.DRAFT);

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
@@ -34,6 +34,10 @@ public class Release {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Release parent;
+
     @Size(max = 50) @NotNull @Column(name = "code", nullable = false, length = 50)
     private String code;
 
@@ -77,6 +81,14 @@ public class Release {
 
     public void setProduct(Product product) {
         this.product = product;
+    }
+
+    public Release getParent() {
+        return parent;
+    }
+
+    public void setParent(Release parent) {
+        this.parent = parent;
     }
 
     public String getCode() {

--- a/src/main/resources/db/migration/V1__create_feature_tables.sql
+++ b/src/main/resources/db/migration/V1__create_feature_tables.sql
@@ -22,6 +22,7 @@ create table releases
 (
     id          bigint       not null default nextval('release_id_seq'),
     product_id  bigint       not null,
+    parent_id   bigint,
     code        varchar(50)  not null unique,
     description text,
     status      varchar(50)  not null,
@@ -31,7 +32,8 @@ create table releases
     updated_by  varchar(255),
     updated_at  timestamp,
     primary key (id),
-    constraint fk_releases_product_id foreign key (product_id) references products (id)
+    constraint fk_releases_product_id foreign key (product_id) references products (id),
+    constraint fk_releases_parent_id foreign key (parent_id) references releases (id)
 );
 
 create sequence feature_id_seq start with 100 increment by 50;

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
@@ -26,6 +26,43 @@ class FeatureControllerTests extends AbstractIT {
     }
 
     @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldGetFeaturesFromReleaseAndParentReleases() {
+        createReleaseChainWithFeatures();
+
+        var result = mvc.get()
+                .uri("/api/features/all-features?releaseCode={code}", "IDEA-CHAIN-CHILD")
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.size()")
+                .asNumber()
+                .isEqualTo(3);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldLimitFeaturesToRequestedParentRelease() {
+        createReleaseChainWithFeatures();
+
+        var result = mvc.get()
+                .uri(
+                        "/api/features/all-features?releaseCode={code}&fromParentRelease={parentCode}",
+                        "IDEA-CHAIN-CHILD",
+                        "IDEA-CHAIN-PARENT")
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.size()")
+                .asNumber()
+                .isEqualTo(2);
+    }
+
+    @Test
     void shouldGetFeatureByCode() {
         String code = "IDEA-1";
         var result = mvc.get().uri("/api/features/{code}", code).exchange();
@@ -122,5 +159,56 @@ class FeatureControllerTests extends AbstractIT {
         // Verify deletion
         var getResult = mvc.get().uri("/api/features/{code}", "IDEA-2").exchange();
         assertThat(getResult).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    private void createReleaseChainWithFeatures() {
+        createRelease("IDEA-CHAIN-ROOT", null);
+        createRelease("IDEA-CHAIN-PARENT", "IDEA-CHAIN-ROOT");
+        createRelease("IDEA-CHAIN-CHILD", "IDEA-CHAIN-PARENT");
+
+        createFeature("IDEA-CHAIN-ROOT", "Root release feature");
+        createFeature("IDEA-CHAIN-PARENT", "Parent release feature");
+        createFeature("IDEA-CHAIN-CHILD", "Child release feature");
+    }
+
+    private void createRelease(String releaseCode, String parentCode) {
+        String parentJson = parentCode == null ? "" : String.format(",%n    \"parentCode\": \"%s\"", parentCode);
+        var payload = String.format(
+                """
+            {
+                "productCode": "intellij",
+                "code": "%s"%s,
+                "description": "%s"
+            }
+            """,
+                releaseCode, parentJson, releaseCode);
+
+        var result = mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+    }
+
+    private void createFeature(String releaseCode, String title) {
+        var payload = String.format(
+                """
+            {
+                "productCode": "intellij",
+                "releaseCode": "%s",
+                "title": "%s",
+                "description": "%s",
+                "assignedTo": "siva"
+            }
+            """,
+                releaseCode, title, title);
+
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.CREATED);
     }
 }


### PR DESCRIPTION
Add /api/all-features Endpoint to FeatureController that retrieves all features associated with the specified release and all its parent releases. Add a non-required attribute 'fromParentRelease' to restrict search by release with this code