### PR TITLE
Implement a new API endpoint that allows users to search for tags by name.

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.TagControllerTests#shouldSearchTagsByName"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/TagController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/TagController.java
@@ -1,0 +1,43 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.domain.TagService;
+import com.sivalabs.ft.features.domain.dtos.TagDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tags")
+@Tag(name = "Tags API")
+class TagController {
+    private final TagService tagService;
+
+    TagController(TagService tagService) {
+        this.tagService = tagService;
+    }
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "Search tags by name",
+            description = "Search tags by name",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = TagDto.class))))
+            })
+    List<TagDto> searchTags(@RequestParam(required = false) String name) {
+        return tagService.searchTags(name);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/TagRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/TagRepository.java
@@ -1,0 +1,9 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Tag;
+import java.util.List;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface TagRepository extends ListCrudRepository<Tag, Long> {
+    List<Tag> findByNameContainingIgnoreCase(String name);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/TagService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/TagService.java
@@ -1,0 +1,34 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.TagDto;
+import com.sivalabs.ft.features.domain.entities.Tag;
+import com.sivalabs.ft.features.domain.mappers.TagMapper;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TagService {
+    private final TagRepository tagRepository;
+    private final TagMapper tagMapper;
+
+    public TagService(TagRepository tagRepository, TagMapper tagMapper) {
+        this.tagRepository = tagRepository;
+        this.tagMapper = tagMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagDto> getAllTags() {
+        List<Tag> tags = tagRepository.findAll();
+        return tags.stream().map(tagMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagDto> searchTags(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return getAllTags();
+        }
+        List<Tag> tags = tagRepository.findByNameContainingIgnoreCase(name.trim());
+        return tags.stream().map(tagMapper::toDto).toList();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/TagDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/TagDto.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record TagDto(Long id, String name, String description, String createdBy, Instant createdAt)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
@@ -39,6 +41,13 @@ public class Feature {
 
     @Size(max = 255) @Column(name = "assigned_to")
     private String assignedTo;
+
+    @ManyToMany
+    @JoinTable(
+            name = "feature_tags",
+            joinColumns = @JoinColumn(name = "feature_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id"))
+    private Set<Tag> tags = new HashSet<>();
 
     @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
     private String createdBy;
@@ -115,6 +124,14 @@ public class Feature {
 
     public void setAssignedTo(String assignedTo) {
         this.assignedTo = assignedTo;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
     }
 
     public String getCreatedBy() {

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Tag.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Tag.java
@@ -1,0 +1,96 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tags_id_gen")
+    @SequenceGenerator(name = "tags_id_gen", sequenceName = "tag_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "name", nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Feature> features = new HashSet<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Tag tag = (Tag) o;
+        return Objects.equals(id, tag.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Set<Feature> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(Set<Feature> features) {
+        this.features = features;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/TagMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/TagMapper.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.TagDto;
+import com.sivalabs.ft.features.domain.entities.Tag;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface TagMapper {
+    TagDto toDto(Tag tag);
+}

--- a/src/main/resources/db/migration/V5__create_tags_table.sql
+++ b/src/main/resources/db/migration/V5__create_tags_table.sql
@@ -1,0 +1,20 @@
+create sequence tag_id_seq start with 100 increment by 50;
+
+create table tags
+(
+    id          bigint       not null default nextval('tag_id_seq'),
+    name        varchar(50)  not null unique,
+    description text,
+    created_by  varchar(255) not null,
+    created_at  timestamp    not null default current_timestamp,
+    primary key (id)
+);
+
+create table feature_tags
+(
+    feature_id  bigint not null,
+    tag_id      bigint not null,
+    primary key (feature_id, tag_id),
+    constraint fk_feature_tags_feature_id foreign key (feature_id) references features (id),
+    constraint fk_feature_tags_tag_id foreign key (tag_id) references tags (id)
+);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/TagControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/TagControllerTests.java
@@ -1,0 +1,41 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import org.junit.jupiter.api.Test;
+
+class TagControllerTests extends AbstractIT {
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldSearchTagsByName() {
+        var result = mvc.get().uri("/api/tags/search?name=bug").exchange();
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.size()")
+                .asNumber()
+                .isEqualTo(1);
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$[0].name")
+                .asString()
+                .isEqualTo("bug");
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturnAllTagsWhenSearchNameIsMissing() {
+        var result = mvc.get().uri("/api/tags/search").exchange();
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.size()")
+                .asNumber()
+                .isEqualTo(4);
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -1,3 +1,5 @@
+delete from feature_tags;
+delete from tags;
 delete from favorite_features;
 delete from comments;
 delete from features;
@@ -34,3 +36,9 @@ insert into comments (id, feature_id, created_by, content) values
 (1, 1, 'user', 'This is a comment on feature IDEA-1'),
 (2,  1, 'user', 'This is a comment on feature IDEA-2'),
 (3, 1, 'user', 'This is a comment on feature GO-3');
+
+insert into tags (id, name, description, created_by, created_at) values
+(1, 'bug', 'Bug fix', 'admin', '2024-03-01 00:00:00'),
+(2, 'enhancement', 'Feature enhancement', 'admin', '2024-03-01 00:00:00'),
+(3, 'documentation', 'Documentation update', 'admin', '2024-03-01 00:00:00'),
+(4, 'performance', 'Performance improvement', 'admin', '2024-03-01 00:00:00');


### PR DESCRIPTION
Implement a new API endpoint that allows users to search for tags by name. The endpoint should accept a query parameter for the tag name and return a list of tags that contain the specified name, ignoring case. Ensure to handle cases where the name parameter is null or empty by returning all tags. Update the TagRepository, TagService, and TagController accordingly to support this functionality and document the API endpoint using appropriate annotations. Integration test shouldSearchTagsByName specifically requires that a tag with the exact name "bug" exists in the test dataset (test-data.sql) to verify the search functionality.