### PR TITLE
Add functionality to the feature API endpoint to filter features by tags

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests#shouldGetFeaturesByTags"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
@@ -65,19 +65,24 @@ class FeatureController {
             })
     List<FeatureDto> getFeatures(
             @RequestParam(value = "productCode", required = false) String productCode,
-            @RequestParam(value = "releaseCode", required = false) String releaseCode) {
-        // Only one of productCode or releaseCode should be provided
-        if ((StringUtils.isBlank(productCode) && StringUtils.isBlank(releaseCode))
-                || (StringUtils.isNotBlank(productCode) && StringUtils.isNotBlank(releaseCode))) {
+            @RequestParam(value = "releaseCode", required = false) String releaseCode,
+            @RequestParam(value = "tagIds", required = false) List<Long> tagIds) {
+        boolean hasProductCode = StringUtils.isNotBlank(productCode);
+        boolean hasReleaseCode = StringUtils.isNotBlank(releaseCode);
+        boolean hasTagIds = tagIds != null && !tagIds.isEmpty();
+        int filterCount = (hasProductCode ? 1 : 0) + (hasReleaseCode ? 1 : 0) + (hasTagIds ? 1 : 0);
+        if (filterCount != 1) {
             // TODO: Return 400 Bad Request
             return List.of();
         }
         String username = SecurityUtils.getCurrentUsername();
         List<FeatureDto> featureDtos;
-        if (StringUtils.isNotBlank(productCode)) {
+        if (hasProductCode) {
             featureDtos = featureService.findFeaturesByProduct(username, productCode);
-        } else {
+        } else if (hasReleaseCode) {
             featureDtos = featureService.findFeaturesByRelease(username, releaseCode);
+        } else {
+            featureDtos = featureService.findFeaturesByTags(username, tagIds);
         }
 
         if (username != null && !featureDtos.isEmpty()) {

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
@@ -17,6 +17,9 @@ interface FeatureRepository extends ListCrudRepository<Feature, Long> {
     @Query("select f from Feature f left join fetch f.release where f.product.code = :productCode")
     List<Feature> findByProductCode(String productCode);
 
+    @Query("select distinct f from Feature f left join fetch f.release left join f.tags t where t.id in :tagIds")
+    List<Feature> findByTagIds(List<Long> tagIds);
+
     @Modifying
     void deleteByCode(String code);
 

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -69,6 +69,12 @@ public class FeatureService {
         return updateFavoriteStatus(features, username);
     }
 
+    @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesByTags(String username, List<Long> tagIds) {
+        List<Feature> features = featureRepository.findByTagIds(tagIds);
+        return updateFavoriteStatus(features, username);
+    }
+
     private List<FeatureDto> updateFavoriteStatus(List<Feature> features, String username) {
         if (username == null || features.isEmpty()) {
             return features.stream().map(featureMapper::toDto).toList();

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
@@ -3,6 +3,7 @@ package com.sivalabs.ft.features.domain.dtos;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.List;
 
 public record FeatureDto(
         Long id,
@@ -13,6 +14,7 @@ public record FeatureDto(
         String releaseCode,
         boolean isFavorite,
         String assignedTo,
+        List<TagDto> tags,
         String createdBy,
         Instant createdAt,
         String updatedBy,
@@ -29,6 +31,7 @@ public record FeatureDto(
                 releaseCode,
                 favorite,
                 assignedTo,
+                tags,
                 createdBy,
                 createdAt,
                 updatedBy,

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/TagDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/TagDto.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record TagDto(Long id, String name, String description, String createdBy, Instant createdAt)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
@@ -39,6 +41,13 @@ public class Feature {
 
     @Size(max = 255) @Column(name = "assigned_to")
     private String assignedTo;
+
+    @ManyToMany
+    @JoinTable(
+            name = "feature_tags",
+            joinColumns = @JoinColumn(name = "feature_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id"))
+    private Set<Tag> tags = new HashSet<>();
 
     @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
     private String createdBy;
@@ -115,6 +124,14 @@ public class Feature {
 
     public void setAssignedTo(String assignedTo) {
         this.assignedTo = assignedTo;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
     }
 
     public String getCreatedBy() {

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Tag.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Tag.java
@@ -1,0 +1,96 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tags_id_gen")
+    @SequenceGenerator(name = "tags_id_gen", sequenceName = "tag_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "name", nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Feature> features = new HashSet<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Tag tag = (Tag) o;
+        return Objects.equals(id, tag.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Set<Feature> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(Set<Feature> features) {
+        this.features = features;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureMapper.java
@@ -5,7 +5,9 @@ import com.sivalabs.ft.features.domain.entities.Feature;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+        componentModel = "spring",
+        uses = {TagMapper.class})
 public interface FeatureMapper {
     @Mapping(target = "releaseCode", source = "release.code", defaultExpression = "java( null )")
     @Mapping(target = "isFavorite", ignore = true)

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/TagMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/TagMapper.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.TagDto;
+import com.sivalabs.ft.features.domain.entities.Tag;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface TagMapper {
+    TagDto toDto(Tag tag);
+}

--- a/src/main/resources/db/migration/V5__create_tags_table.sql
+++ b/src/main/resources/db/migration/V5__create_tags_table.sql
@@ -1,0 +1,20 @@
+create sequence tag_id_seq start with 100 increment by 50;
+
+create table tags
+(
+    id          bigint       not null default nextval('tag_id_seq'),
+    name        varchar(50)  not null unique,
+    description text,
+    created_by  varchar(255) not null,
+    created_at  timestamp    not null default current_timestamp,
+    primary key (id)
+);
+
+create table feature_tags
+(
+    feature_id  bigint not null,
+    tag_id      bigint not null,
+    primary key (feature_id, tag_id),
+    constraint fk_feature_tags_feature_id foreign key (feature_id) references features (id),
+    constraint fk_feature_tags_tag_id foreign key (tag_id) references tags (id)
+);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
@@ -6,6 +6,7 @@ import com.sivalabs.ft.features.AbstractIT;
 import com.sivalabs.ft.features.WithMockOAuth2User;
 import com.sivalabs.ft.features.domain.dtos.FeatureDto;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -38,6 +39,21 @@ class FeatureControllerTests extends AbstractIT {
     void shouldReturn404WhenFeatureNotFound() {
         var result = mvc.get().uri("/api/features/{code}", "INVALID_CODE").exchange();
         assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldGetFeaturesByTags() {
+        var result = mvc.get().uri("/api/features?tagIds={tagIds}", "1,2").exchange();
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(InstanceOfAssertFactories.list(FeatureDto.class))
+                .satisfies(features -> {
+                    assertThat(features).hasSize(3);
+                    assertThat(features.stream().map(FeatureDto::code).toList())
+                            .containsExactlyInAnyOrder("IDEA-1", "IDEA-2", "GO-3");
+                });
     }
 
     @Test

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -1,3 +1,5 @@
+delete from feature_tags;
+delete from tags;
 delete from favorite_features;
 delete from comments;
 delete from features;
@@ -34,3 +36,15 @@ insert into comments (id, feature_id, created_by, content) values
 (1, 1, 'user', 'This is a comment on feature IDEA-1'),
 (2,  1, 'user', 'This is a comment on feature IDEA-2'),
 (3, 1, 'user', 'This is a comment on feature GO-3');
+
+insert into tags (id, name, description, created_by, created_at) values
+(1, 'bug', 'Bug fix', 'admin', '2024-03-01 00:00:00'),
+(2, 'enhancement', 'Feature enhancement', 'admin', '2024-03-01 00:00:00'),
+(3, 'documentation', 'Documentation update', 'admin', '2024-03-01 00:00:00'),
+(4, 'performance', 'Performance improvement', 'admin', '2024-03-01 00:00:00');
+
+insert into feature_tags (feature_id, tag_id) values
+(1, 2),
+(1, 4),
+(2, 1),
+(3, 1);


### PR DESCRIPTION
Add functionality to the feature API endpoint to filter features by tags. Update the controller to accept a list of tag IDs as a request parameter. Modify the service and repository layers to support retrieving features based on the provided tag IDs. Ensure that the validation logic allows for filtering using either product codes, release codes, or tag IDs, but not combinations of them. Also, update the test data to include examples of features associated with tags. The test-data.sql file must be modified to include the mapping (feature_id=2, tag_id=1) in the feature_tags table. This specific entry is required for the new integration test shouldGetFeaturesByTags, which asserts that a query for tagIds=1,2 must return exactly three distinct features ('IDEA-1', 'IDEA-2', and 'GO-3').