### PR TITLE
Implement CRUD API endpoints for managing categories in the application

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.CategoryControllerTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/CategoryController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/CategoryController.java
@@ -1,0 +1,172 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.api.models.CreateCategoryPayload;
+import com.sivalabs.ft.features.api.models.UpdateCategoryPayload;
+import com.sivalabs.ft.features.api.utils.SecurityUtils;
+import com.sivalabs.ft.features.domain.CategoryService;
+import com.sivalabs.ft.features.domain.Commands.CreateCategoryCommand;
+import com.sivalabs.ft.features.domain.Commands.DeleteCategoryCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateCategoryCommand;
+import com.sivalabs.ft.features.domain.dtos.CategoryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/categories")
+@Tag(name = "Categories API")
+class CategoryController {
+    private static final Logger log = LoggerFactory.getLogger(CategoryController.class);
+    private final CategoryService categoryService;
+
+    CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping("")
+    @Operation(
+            summary = "Get all categories",
+            description = "Get all categories",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = CategoryDto.class))))
+            })
+    List<CategoryDto> getAllCategories() {
+        return categoryService.getAllCategories();
+    }
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "Search categories by name",
+            description = "Search categories by name",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = CategoryDto.class))))
+            })
+    List<CategoryDto> searchCategories(@RequestParam String name) {
+        return categoryService.searchCategories(name);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Find category by ID",
+            description = "Find category by ID",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = CategoryDto.class))),
+                @ApiResponse(responseCode = "404", description = "Category not found")
+            })
+    ResponseEntity<CategoryDto> getCategory(@PathVariable Long id) {
+        return categoryService
+                .getCategoryById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("")
+    @Operation(
+            summary = "Create a new category",
+            description = "Create a new category",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Successful response",
+                        headers =
+                                @Header(
+                                        name = "Location",
+                                        required = true,
+                                        description = "URI of the created category")),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+            })
+    ResponseEntity<Void> createCategory(@RequestBody @Valid CreateCategoryPayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        var cmd =
+                new CreateCategoryCommand(payload.name(), payload.description(), payload.parentCategoryId(), username);
+        Long id = categoryService.createCategory(cmd);
+        log.info("Created category with id {}", id);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(id)
+                .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+    @PutMapping("/{id}")
+    @Operation(
+            summary = "Update an existing category",
+            description = "Update an existing category",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Successful response"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Category not found")
+            })
+    ResponseEntity<Void> updateCategory(@PathVariable Long id, @RequestBody @Valid UpdateCategoryPayload payload) {
+        var username = SecurityUtils.getCurrentUsername();
+        if (!categoryService.isCategoryExists(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        var cmd = new UpdateCategoryCommand(
+                id, payload.name(), payload.description(), payload.parentCategoryId(), username);
+        categoryService.updateCategory(cmd);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Delete an existing category",
+            description = "Delete an existing category",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Successful response"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden"),
+                @ApiResponse(responseCode = "404", description = "Category not found")
+            })
+    ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
+        var username = SecurityUtils.getCurrentUsername();
+        if (!categoryService.isCategoryExists(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        categoryService.deleteCategory(new DeleteCategoryCommand(id, username));
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/api/models/CreateCategoryPayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/CreateCategoryPayload.java
@@ -1,0 +1,9 @@
+package com.sivalabs.ft.features.api.models;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+public record CreateCategoryPayload(
+        @NotEmpty(message = "Name is required") @Size(max = 50, message = "Name cannot exceed 50 characters") String name,
+        String description,
+        Long parentCategoryId) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateCategoryPayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateCategoryPayload.java
@@ -1,0 +1,9 @@
+package com.sivalabs.ft.features.api.models;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCategoryPayload(
+        @NotEmpty(message = "Name is required") @Size(max = 50, message = "Name cannot exceed 50 characters") String name,
+        String description,
+        Long parentCategoryId) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/CategoryRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/CategoryRepository.java
@@ -1,0 +1,21 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Category;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
+
+    boolean existsByName(String name);
+
+    List<Category> findByNameContainingIgnoreCase(String name);
+
+    @Modifying
+    @Query("update Category c set c.parentCategory = null where c.parentCategory.id = :categoryId")
+    void clearParentCategoryReference(@Param("categoryId") Long categoryId);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/CategoryService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/CategoryService.java
@@ -1,0 +1,97 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.Commands.CreateCategoryCommand;
+import com.sivalabs.ft.features.domain.Commands.DeleteCategoryCommand;
+import com.sivalabs.ft.features.domain.Commands.UpdateCategoryCommand;
+import com.sivalabs.ft.features.domain.dtos.CategoryDto;
+import com.sivalabs.ft.features.domain.entities.Category;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import com.sivalabs.ft.features.domain.mappers.CategoryMapper;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+    private final FeatureRepository featureRepository;
+
+    public CategoryService(
+            CategoryRepository categoryRepository, CategoryMapper categoryMapper, FeatureRepository featureRepository) {
+        this.categoryRepository = categoryRepository;
+        this.categoryMapper = categoryMapper;
+        this.featureRepository = featureRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryDto> getAllCategories() {
+        return categoryRepository.findAll().stream().map(categoryMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<CategoryDto> getCategoryById(Long id) {
+        return categoryRepository.findById(id).map(categoryMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryDto> searchCategories(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return getAllCategories();
+        }
+        return categoryRepository.findByNameContainingIgnoreCase(name.trim()).stream()
+                .map(categoryMapper::toDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isCategoryExists(Long id) {
+        return categoryRepository.existsById(id);
+    }
+
+    @Transactional
+    public Long createCategory(CreateCategoryCommand cmd) {
+        Category category = new Category();
+        category.setName(cmd.name());
+        category.setDescription(cmd.description());
+        if (cmd.parentCategoryId() != null) {
+            category.setParentCategory(categoryRepository
+                    .findById(cmd.parentCategoryId())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Parent category not found with id: " + cmd.parentCategoryId())));
+        }
+        category.setCreatedBy(cmd.createdBy());
+        category.setCreatedAt(Instant.now());
+        return categoryRepository.save(category).getId();
+    }
+
+    @Transactional
+    public void updateCategory(UpdateCategoryCommand cmd) {
+        Category category = categoryRepository
+                .findById(cmd.id())
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + cmd.id()));
+        category.setName(cmd.name());
+        category.setDescription(cmd.description());
+        if (cmd.parentCategoryId() == null) {
+            category.setParentCategory(null);
+        } else if (!cmd.parentCategoryId().equals(category.getId())) {
+            category.setParentCategory(categoryRepository
+                    .findById(cmd.parentCategoryId())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Parent category not found with id: " + cmd.parentCategoryId())));
+        }
+        categoryRepository.save(category);
+    }
+
+    @Transactional
+    public void deleteCategory(DeleteCategoryCommand cmd) {
+        if (!categoryRepository.existsById(cmd.id())) {
+            throw new ResourceNotFoundException("Category not found with id: " + cmd.id());
+        }
+        categoryRepository.clearParentCategoryReference(cmd.id());
+        featureRepository.unlinkCategory(cmd.id());
+        categoryRepository.deleteById(cmd.id());
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/Commands.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/Commands.java
@@ -42,4 +42,12 @@ public class Commands {
 
     /* Comment Commands */
     public record CreateCommentCommand(String featureCode, String content, String createdBy) {}
+
+    /* Category Commands */
+    public record CreateCategoryCommand(String name, String description, Long parentCategoryId, String createdBy) {}
+
+    public record UpdateCategoryCommand(
+            Long id, String name, String description, Long parentCategoryId, String updatedBy) {}
+
+    public record DeleteCategoryCommand(Long id, String deletedBy) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
@@ -24,6 +24,10 @@ interface FeatureRepository extends ListCrudRepository<Feature, Long> {
     @Query("update Feature f set f.release = null where f.release.code = :code")
     void unsetRelease(String code);
 
+    @Modifying
+    @Query("update Feature f set f.category = null where f.category.id = :id")
+    void unlinkCategory(Long id);
+
     boolean existsByCode(String code);
 
     @Query(value = "select nextval('feature_code_seq')", nativeQuery = true)

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/CategoryDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/CategoryDto.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record CategoryDto(
+        Long id, String name, String description, CategoryDto parentCategory, String createdBy, Instant createdAt)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Category.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Category.java
@@ -1,0 +1,95 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.Objects;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "categories")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "categories_id_gen")
+    @SequenceGenerator(name = "categories_id_gen", sequenceName = "category_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "name", nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_category_id")
+    private Category parentCategory;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Category tag = (Category) o;
+        return Objects.equals(id, tag.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Category getParentCategory() {
+        return parentCategory;
+    }
+
+    public void setParentCategory(Category parentCategory) {
+        this.parentCategory = parentCategory;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
@@ -40,6 +40,10 @@ public class Feature {
     @Size(max = 255) @Column(name = "assigned_to")
     private String assignedTo;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
     private String createdBy;
 
@@ -115,6 +119,14 @@ public class Feature {
 
     public void setAssignedTo(String assignedTo) {
         this.assignedTo = assignedTo;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 
     public String getCreatedBy() {

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/CategoryMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/CategoryMapper.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.CategoryDto;
+import com.sivalabs.ft.features.domain.entities.Category;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+    CategoryDto toDto(Category category);
+}

--- a/src/main/resources/db/migration/V6__create_categories_table.sql
+++ b/src/main/resources/db/migration/V6__create_categories_table.sql
@@ -1,0 +1,16 @@
+create sequence category_id_seq start with 100 increment by 50;
+
+create table categories
+(
+    id                 bigint       not null default nextval('category_id_seq'),
+    name               varchar(50)  not null unique,
+    description        text,
+    parent_category_id bigint,
+    created_by         varchar(255) not null,
+    created_at         timestamp    not null default current_timestamp,
+    primary key (id)
+);
+
+alter table features add column category_id bigint,
+    add constraint fk_features_category
+    foreign key (category_id) references categories (id);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/CategoryControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/CategoryControllerTests.java
@@ -1,0 +1,167 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.domain.dtos.CategoryDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class CategoryControllerTests extends AbstractIT {
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldGetAllCategories() {
+        var result = mvc.get().uri("/api/categories").exchange();
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.size()")
+                .asNumber()
+                .isEqualTo(6);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldSearchCategoriesByName() {
+        var result = mvc.get().uri("/api/categories/search?name=bug").exchange();
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.size()")
+                .asNumber()
+                .isEqualTo(1);
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$[0].name")
+                .asString()
+                .isEqualTo("Bug Fix");
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldGetCategoryById() {
+        var result = mvc.get().uri("/api/categories/{id}", 1).exchange();
+        assertThat(result).hasStatusOk().bodyJson().convertTo(CategoryDto.class).satisfies(dto -> {
+            assertThat(dto.id()).isEqualTo(1);
+            assertThat(dto.name()).isEqualTo("New Feature");
+            assertThat(dto.description()).isEqualTo("New feature added to the product");
+        });
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldReturn404WhenCategoryNotFound() {
+        var result = mvc.get().uri("/api/categories/{id}", 999L).exchange();
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldCreateNewCategory() {
+        var payload =
+                """
+            {
+                "name": "Security",
+                "description": "Security related work",
+                "parentCategoryId": null
+            }
+            """;
+
+        var result = mvc.post()
+                .uri("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+        String location = result.getMvcResult().getResponse().getHeader("Location");
+        assertThat(location).isNotNull();
+
+        var getResult = mvc.get().uri(location).exchange();
+        assertThat(getResult)
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(CategoryDto.class)
+                .satisfies(dto -> {
+                    assertThat(dto.name()).isEqualTo("Security");
+                    assertThat(dto.description()).isEqualTo("Security related work");
+                });
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldCreateCategoryWithParent() {
+        var payload =
+                """
+            {
+                "name": "Regression",
+                "description": "Regression fixes",
+                "parentCategoryId": 3
+            }
+            """;
+
+        var result = mvc.post()
+                .uri("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+        String location = result.getMvcResult().getResponse().getHeader("Location");
+        assertThat(location).isNotNull();
+
+        var getResult = mvc.get().uri(location).exchange();
+        assertThat(getResult)
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(CategoryDto.class)
+                .satisfies(dto -> {
+                    assertThat(dto.name()).isEqualTo("Regression");
+                    assertThat(dto.parentCategory()).isNotNull();
+                    assertThat(dto.parentCategory().id()).isEqualTo(3L);
+                    assertThat(dto.parentCategory().name()).isEqualTo("Bug Fix");
+                });
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldUpdateCategory() {
+        var payload =
+                """
+            {
+                "name": "Updated Category",
+                "description": "Updated Category Description",
+                "parentCategoryId": null
+            }
+            """;
+
+        var result = mvc.put()
+                .uri("/api/categories/{id}", 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatusOk();
+
+        var updatedCategory = mvc.get().uri("/api/categories/{id}", 1).exchange();
+        assertThat(updatedCategory)
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(CategoryDto.class)
+                .satisfies(dto -> {
+                    assertThat(dto.name()).isEqualTo("Updated Category");
+                    assertThat(dto.description()).isEqualTo("Updated Category Description");
+                });
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldDeleteCategory() {
+        var result = mvc.delete().uri("/api/categories/{id}", 1).exchange();
+        assertThat(result).hasStatusOk();
+
+        var getResult = mvc.get().uri("/api/categories/{id}", 1).exchange();
+        assertThat(getResult).hasStatus(HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -3,6 +3,7 @@ delete from comments;
 delete from features;
 delete from releases;
 delete from products;
+delete from categories;
 
 insert into products (id, code, prefix, name, description, image_url, disabled, created_by, created_at) values
 (1, 'intellij', 'IDEA', 'IntelliJ IDEA', 'JetBrains IDE for Java', 'https://resources.jetbrains.com/storage/products/company/brand/logos/IntelliJ_IDEA.png', false, 'admin', '2024-03-01 00:00:00'),
@@ -21,10 +22,18 @@ insert into releases (id, product_id, code, description, status, created_by, cre
 (6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
 ;
 
-insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at) values
-(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24'),
-(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14'),
-(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14')
+insert into categories(id, created_by, created_at, name, description)
+values (1, 'test', now(), 'New Feature', 'New feature added to the product'),
+       (2, 'test', now(), 'Improvement', 'Improvement to the product'),
+       (3, 'test', now(), 'Bug Fix', 'Bug fix to the product'),
+       (4, 'test', now(), 'Documentation', 'Documentation update to the product'),
+       (5, 'test', now(), 'Performance', 'Performance improvement to the product'),
+       (6, 'test', now(), 'Other', 'Other changes to the product');
+
+insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at, category_id) values
+(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24', 1),
+(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14', 2),
+(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14', 3)
 ;
 
 insert into favorite_features (id, feature_id, user_id) values


### PR DESCRIPTION
Implement CRUD API endpoints for managing categories in the application. Create a CategoryController to handle requests for creating, updating, retrieving, and deleting categories. Use appropriate data transfer objects for creating and updating categories. Ensure that all endpoints are secured and validate input data. Update the CategoryService to include methods for these operations and ensure that categories can be categorized under parent categories as needed. Add necessary repository methods to fetch categories by name and handle parent category references. Critically, the deletion logic must handle dependencies to prevent database constraint violations before removing a category: ensure that any child categories referencing the category to be deleted have their parent reference set to null, and similarly, ensure that any Feature entities referencing this category also have their category reference set to null.