### PR TITLE
Create a new Category entity representing categories in the system

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.domain.CategoryRepositoryTests",
+      "com.sivalabs.ft.features.domain.FeatureCategoryRelationshipTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/domain/CategoryRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/CategoryRepository.java
@@ -1,0 +1,6 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface CategoryRepository extends JpaRepository<Category, Long> {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Category.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Category.java
@@ -1,0 +1,95 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.Objects;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "categories")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "categories_id_gen")
+    @SequenceGenerator(name = "categories_id_gen", sequenceName = "category_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "name", nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_category_id")
+    private Category parentCategory;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Category tag = (Category) o;
+        return Objects.equals(id, tag.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Category getParentCategory() {
+        return parentCategory;
+    }
+
+    public void setParentCategory(Category parentCategory) {
+        this.parentCategory = parentCategory;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
@@ -40,6 +40,10 @@ public class Feature {
     @Size(max = 255) @Column(name = "assigned_to")
     private String assignedTo;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
     private String createdBy;
 
@@ -115,6 +119,14 @@ public class Feature {
 
     public void setAssignedTo(String assignedTo) {
         this.assignedTo = assignedTo;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 
     public String getCreatedBy() {

--- a/src/main/resources/db/migration/V6__create_categories_table.sql
+++ b/src/main/resources/db/migration/V6__create_categories_table.sql
@@ -1,0 +1,16 @@
+create sequence category_id_seq start with 100 increment by 50;
+
+create table categories
+(
+    id                 bigint       not null default nextval('category_id_seq'),
+    name               varchar(50)  not null unique,
+    description        text,
+    parent_category_id bigint,
+    created_by         varchar(255) not null,
+    created_at         timestamp    not null default current_timestamp,
+    primary key (id)
+);
+
+alter table features add column category_id bigint,
+    add constraint fk_features_category
+    foreign key (category_id) references categories (id);

--- a/src/test/java/com/sivalabs/ft/features/domain/CategoryRepositoryTests.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/CategoryRepositoryTests.java
@@ -1,0 +1,56 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.domain.entities.Category;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CategoryRepositoryTests extends AbstractIT {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    void shouldCreateCategory() {
+        Category category = new Category();
+        category.setName("JUnit");
+        category.setDescription("JUnit testing framework");
+        category.setCreatedBy("test-user");
+        category.setCreatedAt(Instant.now());
+
+        Category saved = categoryRepository.save(category);
+        assertThat(saved.getId()).isNotNull();
+
+        Optional<Category> found = categoryRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getName()).isEqualTo("JUnit");
+    }
+
+    @Test
+    void shouldCreateCategoryWithParent() {
+        // Get existing category to use as parent
+        Optional<Category> parentOpt = categoryRepository.findById(1L);
+        assertThat(parentOpt).isPresent();
+        Category parent = parentOpt.get();
+
+        Category category = new Category();
+        category.setName("Spring Data JPA");
+        category.setDescription("Spring Data JPA module");
+        category.setParentCategory(parent);
+        category.setCreatedBy("test-user");
+        category.setCreatedAt(Instant.now());
+
+        Category saved = categoryRepository.save(category);
+        assertThat(saved.getId()).isNotNull();
+
+        Optional<Category> found = categoryRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getName()).isEqualTo("Spring Data JPA");
+        assertThat(found.get().getParentCategory()).isNotNull();
+        assertThat(found.get().getParentCategory().getId()).isEqualTo(parent.getId());
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/domain/FeatureCategoryRelationshipTests.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/FeatureCategoryRelationshipTests.java
@@ -1,0 +1,93 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.domain.entities.Category;
+import com.sivalabs.ft.features.domain.entities.Feature;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+class FeatureCategoryRelationshipTests extends AbstractIT {
+
+    @Autowired
+    private FeatureRepository featureRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    @Transactional
+    void shouldAssignCategoryToFeature() {
+        // Get a feature without a category or create one
+        Optional<Feature> featureOpt = featureRepository.findByCode("GO-3");
+        assertThat(featureOpt).isPresent();
+        Feature feature = featureOpt.get();
+
+        // Create a new category
+        Category category = new Category();
+        category.setName("Go Test Category");
+        category.setDescription("A category for Go tests");
+        category.setCreatedBy("test-user");
+        category.setCreatedAt(Instant.now());
+
+        Category savedCategory = categoryRepository.save(category);
+
+        // Assign category to feature
+        feature.setCategory(savedCategory);
+        feature.setUpdatedBy("test-user");
+        feature.setUpdatedAt(Instant.now());
+
+        Feature updatedFeature = featureRepository.save(feature);
+
+        // Verify the assignment
+        assertThat(updatedFeature.getCategory()).isNotNull();
+        assertThat(updatedFeature.getCategory().getId()).isEqualTo(savedCategory.getId());
+        assertThat(updatedFeature.getCategory().getName()).isEqualTo("Go Test Category");
+    }
+
+    @Test
+    @Transactional
+    void shouldRemoveCategoryFromFeature() {
+        // Get a feature with a category
+        Optional<Feature> featureOpt = featureRepository.findByCode("IDEA-1");
+        assertThat(featureOpt).isPresent();
+        Feature feature = featureOpt.get();
+
+        // Verify it has a category
+        assertThat(feature.getCategory()).isNotNull();
+
+        // Remove the category
+        feature.setCategory(null);
+        feature.setUpdatedBy("test-user");
+        feature.setUpdatedAt(Instant.now());
+
+        Feature updatedFeature = featureRepository.save(feature);
+
+        // Verify the category was removed
+        assertThat(updatedFeature.getCategory()).isNull();
+    }
+
+    @Test
+    @Transactional
+    void shouldFindFeaturesByCategory() {
+        // Get category with ID 1 (SpringBoot)
+        Optional<Category> categoryOpt = categoryRepository.findById(1L);
+        assertThat(categoryOpt).isPresent();
+        Category category = categoryOpt.get();
+
+        // Find all features with this category
+        // We need to use a custom query which is not available in the current repository
+        // Instead, we'll retrieve a known feature that should have this category
+        Optional<Feature> featureOpt = featureRepository.findByCode("IDEA-1");
+        assertThat(featureOpt).isPresent();
+        Feature feature = featureOpt.get();
+
+        // Verify it has the expected category
+        assertThat(feature.getCategory()).isNotNull();
+        assertThat(feature.getCategory().getId()).isEqualTo(category.getId());
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -3,6 +3,7 @@ delete from comments;
 delete from features;
 delete from releases;
 delete from products;
+delete from categories;
 
 insert into products (id, code, prefix, name, description, image_url, disabled, created_by, created_at) values
 (1, 'intellij', 'IDEA', 'IntelliJ IDEA', 'JetBrains IDE for Java', 'https://resources.jetbrains.com/storage/products/company/brand/logos/IntelliJ_IDEA.png', false, 'admin', '2024-03-01 00:00:00'),
@@ -21,10 +22,18 @@ insert into releases (id, product_id, code, description, status, created_by, cre
 (6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
 ;
 
-insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at) values
-(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24'),
-(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14'),
-(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14')
+insert into categories(id, created_by, created_at, name, description)
+values (1, 'test', now(), 'New Feature', 'New feature added to the product'),
+       (2, 'test', now(), 'Improvement', 'Improvement to the product'),
+       (3, 'test', now(), 'Bug Fix', 'Bug fix to the product'),
+       (4, 'test', now(), 'Documentation', 'Documentation update to the product'),
+       (5, 'test', now(), 'Performance', 'Performance improvement to the product'),
+       (6, 'test', now(), 'Other', 'Other changes to the product');
+
+insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at, category_id) values
+(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24', 1),
+(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14', 2),
+(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14', 3)
 ;
 
 insert into favorite_features (id, feature_id, user_id) values


### PR DESCRIPTION
Create a new Category entity in com.sivalabs.ft.features.domain.entities package to represent categories in the system. Ensure that the entity includes necessary fields such as id, name, description, parent category relationship, created by, and created at with Instant type. Implement the CategoryRepository interface in com.sivalabs.ft.features.domain.CategoryRepository package for database access. Update the Feature entity to include a relationship with the Category entity. Create the corresponding database table and migration script to support category creation and linking features to categories. Include test data for categories in the test SQL file with sample category with name bug and assign this category to test feature with id = 1.
The actual test data implementation creates several categories ('New Feature' as ID=1, 'Improvement' as ID=2, 'Bug Fix' as ID=3) and assigns the 'New Feature' category (ID=1) to the test feature with id = 1 ('IDEA-1'), rather than a category named 'bug'.