### PR TITLE
Update the API endpoint to allow searching for features using both categories and tags

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests#shouldGetFeaturesByCategoryIds",
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests#shouldGetFeaturesByCategoryAndTagIds",
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests#shouldReturn400WhenProductAndCategoryFiltersAreCombined"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
@@ -63,21 +63,27 @@ class FeatureController {
                                         mediaType = "application/json",
                                         array = @ArraySchema(schema = @Schema(implementation = FeatureDto.class))))
             })
-    List<FeatureDto> getFeatures(
+    ResponseEntity<List<FeatureDto>> getFeatures(
             @RequestParam(value = "productCode", required = false) String productCode,
-            @RequestParam(value = "releaseCode", required = false) String releaseCode) {
-        // Only one of productCode or releaseCode should be provided
-        if ((StringUtils.isBlank(productCode) && StringUtils.isBlank(releaseCode))
-                || (StringUtils.isNotBlank(productCode) && StringUtils.isNotBlank(releaseCode))) {
-            // TODO: Return 400 Bad Request
-            return List.of();
+            @RequestParam(value = "releaseCode", required = false) String releaseCode,
+            @RequestParam(value = "categoryIds", required = false) List<Long> categoryIds,
+            @RequestParam(value = "tagIds", required = false) List<Long> tagIds) {
+        boolean hasProductCode = StringUtils.isNotBlank(productCode);
+        boolean hasReleaseCode = StringUtils.isNotBlank(releaseCode);
+        boolean hasCategoryOrTagIds =
+                (categoryIds != null && !categoryIds.isEmpty()) || (tagIds != null && !tagIds.isEmpty());
+        int filterCount = (hasProductCode ? 1 : 0) + (hasReleaseCode ? 1 : 0) + (hasCategoryOrTagIds ? 1 : 0);
+        if (filterCount != 1) {
+            return ResponseEntity.badRequest().build();
         }
         String username = SecurityUtils.getCurrentUsername();
         List<FeatureDto> featureDtos;
-        if (StringUtils.isNotBlank(productCode)) {
+        if (hasProductCode) {
             featureDtos = featureService.findFeaturesByProduct(username, productCode);
-        } else {
+        } else if (hasReleaseCode) {
             featureDtos = featureService.findFeaturesByRelease(username, releaseCode);
+        } else {
+            featureDtos = featureService.findFeaturesByCategoriesOrTags(username, categoryIds, tagIds);
         }
 
         if (username != null && !featureDtos.isEmpty()) {
@@ -88,7 +94,7 @@ class FeatureController {
                     .map(featureDto -> featureDto.makeFavorite(favoriteFeatures.get(featureDto.code())))
                     .toList();
         }
-        return featureDtos;
+        return ResponseEntity.ok(featureDtos);
     }
 
     @GetMapping("/{code}")

--- a/src/main/java/com/sivalabs/ft/features/domain/CategoryRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/CategoryRepository.java
@@ -1,0 +1,6 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface CategoryRepository extends JpaRepository<Category, Long> {}

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
@@ -17,12 +17,31 @@ interface FeatureRepository extends ListCrudRepository<Feature, Long> {
     @Query("select f from Feature f left join fetch f.release where f.product.code = :productCode")
     List<Feature> findByProductCode(String productCode);
 
+    @Query("select distinct f from Feature f left join fetch f.release left join f.tags t where t.id in :tagIds")
+    List<Feature> findByTagIds(List<Long> tagIds);
+
+    @Query(
+            "select distinct f from Feature f left join fetch f.release left join fetch f.category c where c.id in :categoryIds")
+    List<Feature> findByCategoryIds(List<Long> categoryIds);
+
+    @Query(
+            """
+            select distinct f from Feature f left join fetch f.release
+                left join f.tags t left join fetch f.category c
+            where t.id in :tagIds or c.id in :categoryIds
+            """)
+    List<Feature> findByCategoryIdsOrTagIds(List<Long> categoryIds, List<Long> tagIds);
+
     @Modifying
     void deleteByCode(String code);
 
     @Modifying
     @Query("update Feature f set f.release = null where f.release.code = :code")
     void unsetRelease(String code);
+
+    @Modifying
+    @Query("update Feature f set f.category = null where f.category.id = :id")
+    void unlinkCategory(Long id);
 
     boolean existsByCode(String code);
 

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -69,6 +69,29 @@ public class FeatureService {
         return updateFavoriteStatus(features, username);
     }
 
+    @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesByTags(String username, List<Long> tagIds) {
+        List<Feature> features = featureRepository.findByTagIds(tagIds);
+        return updateFavoriteStatus(features, username);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesByCategoriesOrTags(String username, List<Long> categoryIds, List<Long> tagIds) {
+        boolean hasCategoryIds = categoryIds != null && !categoryIds.isEmpty();
+        boolean hasTagIds = tagIds != null && !tagIds.isEmpty();
+        List<Feature> features;
+        if (hasCategoryIds && hasTagIds) {
+            features = featureRepository.findByCategoryIdsOrTagIds(categoryIds, tagIds);
+        } else if (hasCategoryIds) {
+            features = featureRepository.findByCategoryIds(categoryIds);
+        } else if (hasTagIds) {
+            features = featureRepository.findByTagIds(tagIds);
+        } else {
+            features = List.of();
+        }
+        return updateFavoriteStatus(features, username);
+    }
+
     private List<FeatureDto> updateFavoriteStatus(List<Feature> features, String username) {
         if (username == null || features.isEmpty()) {
             return features.stream().map(featureMapper::toDto).toList();

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/CategoryDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/CategoryDto.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record CategoryDto(
+        Long id, String name, String description, CategoryDto parentCategory, String createdBy, Instant createdAt)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureDto.java
@@ -3,6 +3,7 @@ package com.sivalabs.ft.features.domain.dtos;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.List;
 
 public record FeatureDto(
         Long id,
@@ -13,6 +14,8 @@ public record FeatureDto(
         String releaseCode,
         boolean isFavorite,
         String assignedTo,
+        List<TagDto> tags,
+        CategoryDto category,
         String createdBy,
         Instant createdAt,
         String updatedBy,
@@ -29,6 +32,8 @@ public record FeatureDto(
                 releaseCode,
                 favorite,
                 assignedTo,
+                tags,
+                category,
                 createdBy,
                 createdAt,
                 updatedBy,

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/TagDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/TagDto.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record TagDto(Long id, String name, String description, String createdBy, Instant createdAt)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Category.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Category.java
@@ -1,0 +1,104 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.Objects;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "categories")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "categories_id_gen")
+    @SequenceGenerator(name = "categories_id_gen", sequenceName = "category_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "name", nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_category_id")
+    private Category parentCategory;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Category category = (Category) o;
+        return Objects.equals(id, category.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Category getParentCategory() {
+        return parentCategory;
+    }
+
+    public void setParentCategory(Category parentCategory) {
+        this.parentCategory = parentCategory;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Feature.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
@@ -39,6 +41,17 @@ public class Feature {
 
     @Size(max = 255) @Column(name = "assigned_to")
     private String assignedTo;
+
+    @ManyToMany
+    @JoinTable(
+            name = "feature_tags",
+            joinColumns = @JoinColumn(name = "feature_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id"))
+    private Set<Tag> tags = new HashSet<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
 
     @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
     private String createdBy;
@@ -115,6 +128,22 @@ public class Feature {
 
     public void setAssignedTo(String assignedTo) {
         this.assignedTo = assignedTo;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 
     public String getCreatedBy() {

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Tag.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Tag.java
@@ -1,0 +1,96 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tags_id_gen")
+    @SequenceGenerator(name = "tags_id_gen", sequenceName = "tag_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 50) @NotNull @Column(name = "name", nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Column(name = "description", length = Integer.MAX_VALUE)
+    private String description;
+
+    @Size(max = 255) @NotNull @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Feature> features = new HashSet<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Tag tag = (Tag) o;
+        return Objects.equals(id, tag.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Set<Feature> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(Set<Feature> features) {
+        this.features = features;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/CategoryMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/CategoryMapper.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.CategoryDto;
+import com.sivalabs.ft.features.domain.entities.Category;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+    CategoryDto toDto(Category category);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureMapper.java
@@ -5,7 +5,9 @@ import com.sivalabs.ft.features.domain.entities.Feature;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+        componentModel = "spring",
+        uses = {TagMapper.class, CategoryMapper.class})
 public interface FeatureMapper {
     @Mapping(target = "releaseCode", source = "release.code", defaultExpression = "java( null )")
     @Mapping(target = "isFavorite", ignore = true)

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/TagMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/TagMapper.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.TagDto;
+import com.sivalabs.ft.features.domain.entities.Tag;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface TagMapper {
+    TagDto toDto(Tag tag);
+}

--- a/src/main/resources/db/migration/V5__create_tags_table.sql
+++ b/src/main/resources/db/migration/V5__create_tags_table.sql
@@ -1,0 +1,20 @@
+create sequence tag_id_seq start with 100 increment by 50;
+
+create table tags
+(
+    id          bigint       not null default nextval('tag_id_seq'),
+    name        varchar(50)  not null unique,
+    description text,
+    created_by  varchar(255) not null,
+    created_at  timestamp    not null default current_timestamp,
+    primary key (id)
+);
+
+create table feature_tags
+(
+    feature_id  bigint not null,
+    tag_id      bigint not null,
+    primary key (feature_id, tag_id),
+    constraint fk_feature_tags_feature_id foreign key (feature_id) references features (id),
+    constraint fk_feature_tags_tag_id foreign key (tag_id) references tags (id)
+);

--- a/src/main/resources/db/migration/V6__create_categories_table.sql
+++ b/src/main/resources/db/migration/V6__create_categories_table.sql
@@ -1,0 +1,20 @@
+create sequence category_id_seq start with 100 increment by 50;
+
+create table categories
+(
+    id                 bigint       not null default nextval('category_id_seq'),
+    name               varchar(50)  not null unique,
+    description        text,
+    parent_category_id bigint,
+    created_by         varchar(255) not null,
+    created_at         timestamp    not null default current_timestamp,
+    primary key (id)
+);
+
+alter table categories
+    add constraint fk_categories_parent_category
+    foreign key (parent_category_id) references categories (id);
+
+alter table features add column category_id bigint,
+    add constraint fk_features_category
+    foreign key (category_id) references categories (id);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
@@ -6,6 +6,7 @@ import com.sivalabs.ft.features.AbstractIT;
 import com.sivalabs.ft.features.WithMockOAuth2User;
 import com.sivalabs.ft.features.domain.dtos.FeatureDto;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -38,6 +39,44 @@ class FeatureControllerTests extends AbstractIT {
     void shouldReturn404WhenFeatureNotFound() {
         var result = mvc.get().uri("/api/features/{code}", "INVALID_CODE").exchange();
         assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void shouldGetFeaturesByCategoryIds() {
+        var result = mvc.get().uri("/api/features?categoryIds={ids}", "1,3").exchange();
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(InstanceOfAssertFactories.list(FeatureDto.class))
+                .satisfies(features -> {
+                    assertThat(features).hasSize(2);
+                    assertThat(features.stream().map(FeatureDto::code).toList())
+                            .containsExactlyInAnyOrder("IDEA-1", "GO-3");
+                });
+    }
+
+    @Test
+    void shouldGetFeaturesByCategoryAndTagIds() {
+        var result = mvc.get()
+                .uri("/api/features?categoryIds={categoryIds}&tagIds={tagIds}", "1", "1")
+                .exchange();
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(InstanceOfAssertFactories.list(FeatureDto.class))
+                .satisfies(features -> {
+                    assertThat(features).hasSize(3);
+                    assertThat(features.stream().map(FeatureDto::code).toList())
+                            .containsExactlyInAnyOrder("IDEA-1", "IDEA-2", "GO-3");
+                });
+    }
+
+    @Test
+    void shouldReturn400WhenProductAndCategoryFiltersAreCombined() {
+        var result = mvc.get()
+                .uri("/api/features?productCode={productCode}&categoryIds={categoryIds}", "intellij", "1")
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -1,6 +1,9 @@
+delete from feature_tags;
+delete from tags;
 delete from favorite_features;
 delete from comments;
 delete from features;
+delete from categories;
 delete from releases;
 delete from products;
 
@@ -21,10 +24,16 @@ insert into releases (id, product_id, code, description, status, created_by, cre
 (6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
 ;
 
-insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at) values
-(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24'),
-(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14'),
-(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14')
+insert into categories(id, created_by, created_at, name, description)
+values (1, 'test', now(), 'New Feature', 'New feature added to the product'),
+       (2, 'test', now(), 'Improvement', 'Improvement to the product'),
+       (3, 'test', now(), 'Bug Fix', 'Bug fix to the product'),
+       (4, 'test', now(), 'Documentation', 'Documentation update to the product');
+
+insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at, category_id) values
+(1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24', 1),
+(2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14', 2),
+(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14', 3)
 ;
 
 insert into favorite_features (id, feature_id, user_id) values
@@ -34,3 +43,15 @@ insert into comments (id, feature_id, created_by, content) values
 (1, 1, 'user', 'This is a comment on feature IDEA-1'),
 (2,  1, 'user', 'This is a comment on feature IDEA-2'),
 (3, 1, 'user', 'This is a comment on feature GO-3');
+
+insert into tags (id, name, description, created_by, created_at) values
+(1, 'bug', 'Bug fix', 'admin', '2024-03-01 00:00:00'),
+(2, 'enhancement', 'Feature enhancement', 'admin', '2024-03-01 00:00:00'),
+(3, 'documentation', 'Documentation update', 'admin', '2024-03-01 00:00:00'),
+(4, 'performance', 'Performance improvement', 'admin', '2024-03-01 00:00:00');
+
+insert into feature_tags (feature_id, tag_id) values
+(1, 2),
+(1, 4),
+(2, 1),
+(3, 1);


### PR DESCRIPTION
Update the API endpoint to allow searching for features using both categories and tags. Modify the controller to accept a new optional parameter for category IDs, and adjust the logic to ensure that only one of product code, release code, or the combination of category IDs and tag IDs is provided. Refactor the service and repository methods to support searching by both category and tag IDs together. Ensure that the necessary changes to the response and error handling are implemented as well.