### PR TITLE
Comments and Reactions subsystem: add comments entities and service methods

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.domain.CommentRepositoryTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/domain/CommentRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/CommentRepository.java
@@ -1,20 +1,27 @@
 package com.sivalabs.ft.features.domain;
 
 import com.sivalabs.ft.features.domain.entities.Comment;
+import com.sivalabs.ft.features.domain.entities.Feature;
+import com.sivalabs.ft.features.domain.entities.Release;
 import java.util.List;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
 
-interface CommentRepository extends JpaRepository<Comment, Long> {
+interface CommentRepository extends ListCrudRepository<Comment, Long> {
+    List<Comment> findByFeature(Feature feature);
+
+    List<Comment> findByRelease(Release release);
+
+    List<Comment> findByAuthor(String author);
 
     @Modifying
-    @Query("delete from Comment c where c.createdBy = :userId and c.id = :commentId")
+    @Query("delete from Comment c where c.author = :userId and c.id = :commentId")
     int deleteComment(Long commentId, String userId);
 
     @Query("""
             select c from Comment c where c.feature.code = :featureCode
             """)
-    List<Comment> findCommentsByFeatureCode(String featureCode, PageRequest pageRequest);
+    List<Comment> findCommentsByFeatureCode(String featureCode, Pageable pageable);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Comment.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Comment.java
@@ -3,6 +3,8 @@ package com.sivalabs.ft.features.domain.entities;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
@@ -15,26 +17,39 @@ public class Comment {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "feature_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feature_id")
     private Feature feature;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "release_id")
+    private Release release;
+
     @Column(name = "created_by", nullable = false)
-    private String createdBy;
+    private String author;
 
     @Column(name = "content", nullable = false)
-    private String content;
+    private String text;
 
     @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @OneToMany(
+            mappedBy = "parentComment",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private Set<Comment> replies = new LinkedHashSet<>();
+
     public Comment() {}
 
     public Comment(Feature feature, String createdBy, String content) {
         this.feature = feature;
-        this.createdBy = createdBy;
-        this.content = content;
+        this.author = createdBy;
+        this.text = content;
         this.createdAt = Instant.now();
     }
 
@@ -54,20 +69,44 @@ public class Comment {
         this.feature = feature;
     }
 
+    public Release getRelease() {
+        return release;
+    }
+
+    public void setRelease(Release release) {
+        this.release = release;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
     public String getCreatedBy() {
-        return createdBy;
+        return author;
     }
 
     public void setCreatedBy(String createdBy) {
-        this.createdBy = createdBy;
+        this.author = createdBy;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
     }
 
     public String getContent() {
-        return content;
+        return text;
     }
 
     public void setContent(String content) {
-        this.content = content;
+        this.text = content;
     }
 
     public Instant getCreatedAt() {
@@ -76,5 +115,31 @@ public class Comment {
 
     public void setCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public Comment getParentComment() {
+        return parentComment;
+    }
+
+    public void setParentComment(Comment parentComment) {
+        this.parentComment = parentComment;
+    }
+
+    public Set<Comment> getReplies() {
+        return replies;
+    }
+
+    public void setReplies(Set<Comment> replies) {
+        this.replies = replies;
+    }
+
+    public void addReply(Comment reply) {
+        replies.add(reply);
+        reply.setParentComment(this);
+    }
+
+    public void removeReply(Comment reply) {
+        replies.remove(reply);
+        reply.setParentComment(null);
     }
 }

--- a/src/main/resources/db/migration/V4__create_comment_table.sql
+++ b/src/main/resources/db/migration/V4__create_comment_table.sql
@@ -2,10 +2,12 @@ create sequence comment_id_seq start with 100 increment by 50;
 
 create table comments
 (
-    id         bigint       not null default nextval('comment_id_seq'),
-    feature_id bigint       not null references features (id),
-    created_by varchar(255) not null,
-    content    text         not null,
-    created_at timestamp    not null default current_timestamp,
+    id                bigint       not null default nextval('comment_id_seq'),
+    feature_id        bigint references features (id),
+    release_id        bigint references releases (id),
+    parent_comment_id bigint references comments (id),
+    created_by        varchar(255) not null,
+    content           text         not null,
+    created_at        timestamp    not null default current_timestamp,
     primary key (id)
 );

--- a/src/test/java/com/sivalabs/ft/features/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/CommentRepositoryTest.java
@@ -1,0 +1,133 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import com.sivalabs.ft.features.domain.entities.Comment;
+import com.sivalabs.ft.features.domain.entities.Feature;
+import com.sivalabs.ft.features.domain.entities.Product;
+import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestcontainersConfiguration.class)
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private FeatureRepository featureRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ReleaseRepository releaseRepository;
+
+    private Feature feature;
+    private Release release;
+
+    @BeforeEach
+    void setUp() {
+        Product product = new Product();
+        product.setCode("comment-product");
+        product.setPrefix("CMT");
+        product.setName("Comment Product");
+        product.setImageUrl("https://example.com/comment-product.png");
+        product.setCreatedBy("tester");
+        product.setCreatedAt(Instant.now());
+        product = productRepository.save(product);
+
+        release = new Release();
+        release.setProduct(product);
+        release.setCode("CMT-2026.1");
+        release.setDescription("Comment release");
+        release.setStatus(ReleaseStatus.DRAFT);
+        release.setCreatedBy("tester");
+        release.setCreatedAt(Instant.now());
+        release = releaseRepository.save(release);
+
+        feature = new Feature();
+        feature.setProduct(product);
+        feature.setRelease(release);
+        feature.setCode("CMT-1");
+        feature.setTitle("Comment feature");
+        feature.setStatus(FeatureStatus.NEW);
+        feature.setCreatedBy("tester");
+        feature.setCreatedAt(Instant.now());
+        feature = featureRepository.save(feature);
+    }
+
+    @Test
+    void shouldFindFeatureCommentsIncludingReplies() {
+        Comment topLevel = createFeatureComment("Top-level feature discussion", "alice");
+        Comment reply = createFeatureComment("Reply in the same discussion", "bob");
+        topLevel.addReply(reply);
+
+        commentRepository.save(topLevel);
+
+        assertThat(commentRepository.findByFeature(feature))
+                .extracting(Comment::getText)
+                .containsExactlyInAnyOrder("Top-level feature discussion", "Reply in the same discussion");
+        assertThat(reply.getParentComment()).isEqualTo(topLevel);
+        assertThat(topLevel.getReplies()).containsExactly(reply);
+    }
+
+    @Test
+    void shouldFindReleaseCommentsAndCommentsByAuthor() {
+        Comment releaseComment = new Comment();
+        releaseComment.setRelease(release);
+        releaseComment.setText("Release-level discussion");
+        releaseComment.setAuthor("carol");
+        releaseComment.setCreatedAt(Instant.now());
+
+        Comment otherAuthorComment = createFeatureComment("Feature-level discussion", "dave");
+
+        commentRepository.save(releaseComment);
+        commentRepository.save(otherAuthorComment);
+
+        assertThat(commentRepository.findByRelease(release))
+                .extracting(Comment::getText)
+                .containsExactly("Release-level discussion");
+        assertThat(commentRepository.findByAuthor("carol"))
+                .extracting(Comment::getRelease, Comment::getFeature)
+                .containsExactly(tuple(release, null));
+    }
+
+    @Test
+    void shouldRemoveReplyWithoutDeletingReply() {
+        Comment topLevel = createFeatureComment("Parent", "alice");
+        Comment reply = createFeatureComment("Reply", "bob");
+        topLevel.addReply(reply);
+
+        commentRepository.save(topLevel);
+        Long replyId = reply.getId();
+
+        topLevel.removeReply(reply);
+        commentRepository.save(reply);
+
+        assertThat(topLevel.getReplies()).isEmpty();
+        assertThat(commentRepository.findById(replyId))
+                .get()
+                .extracting(Comment::getParentComment)
+                .isNull();
+    }
+
+    private Comment createFeatureComment(String text, String author) {
+        Comment comment = new Comment();
+        comment.setFeature(feature);
+        comment.setText(text);
+        comment.setAuthor(author);
+        comment.setCreatedAt(Instant.now());
+        return comment;
+    }
+}


### PR DESCRIPTION
Implement a model layer of the collaborative commenting and discussion feature.

Add a `Comment` entity with fields:
- `id` of type Long, generated
- `text` of type String
- `createdAt` of type Instant
- `author` of type String
- `feature` (optional) - a relationship to a Feature entity
- `release` (optional) - a relationship to a Release entity

Support hierarchical (threaded) comments using a self-referencing `parentComment` field and a collection of replies. Along with the getter and setter, add the next methods to the Comment entity for the replies field:
- `addReply(Comment reply)` - adds a reply to this comment and sets the bidirectional relationship
- `removeReply(Comment reply)` - removes a reply from this comment and clears the bidirectional relationship. The reply itself should not be deleted.

Add a `CommentRepository` interface inherited from the `ListCrudRepository` with the following methods:
- `List<Comment> findByFeature(Feature feature)` - returns all comments associated with a feature (including both top-level and replies)
- `List<Comment> findByRelease(Release release)` - returns all comments associated with a release (including both top-level and replies)
- `List<Comment> findByAuthor(String author)` - returns all comments by a specific author