### PR TITLE
Release Chains: update FeatureService and FeatureRepository using @Query for direct DB access (SQL or JPQL)

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.domain.FeatureRepositoryTest",
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests#shouldGetFeaturesFromReleaseAndParentReleasesWithNativeQuery"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureController.java
@@ -197,4 +197,28 @@ class FeatureController {
         featureService.deleteFeature(cmd);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/all-features")
+    @Operation(
+            summary = "Find features by release including parent releases",
+            description =
+                    "Find features by release including all parent releases, with optional parent release restriction",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = FeatureDto.class))))
+            })
+    List<FeatureDto> getAllFeatures(
+            @RequestParam(value = "releaseCode") String releaseCode,
+            @RequestParam(value = "fromParentRelease", required = false) String fromParentRelease) {
+        if (StringUtils.isBlank(releaseCode)) {
+            return List.of();
+        }
+        String username = SecurityUtils.getCurrentUsername();
+        return featureService.findFeaturesByReleaseAndParents(username, releaseCode, fromParentRelease);
+    }
 }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
@@ -99,7 +99,8 @@ class ReleaseController {
             })
     ResponseEntity<Void> createRelease(@RequestBody @Valid CreateReleasePayload payload) {
         var username = SecurityUtils.getCurrentUsername();
-        var cmd = new CreateReleaseCommand(payload.productCode(), payload.code(), payload.description(), username);
+        var cmd = new CreateReleaseCommand(
+                payload.productCode(), payload.code(), payload.description(), payload.parentCode(), username);
         String code = releaseService.createRelease(cmd);
         log.info("Created release with code {}", code);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -121,8 +122,8 @@ class ReleaseController {
             })
     void updateRelease(@PathVariable String code, @RequestBody UpdateReleasePayload payload) {
         var username = SecurityUtils.getCurrentUsername();
-        var cmd =
-                new UpdateReleaseCommand(code, payload.description(), payload.status(), payload.releasedAt(), username);
+        var cmd = new UpdateReleaseCommand(
+                code, payload.description(), payload.status(), payload.releasedAt(), payload.parentCode(), username);
         releaseService.updateRelease(cmd);
     }
 

--- a/src/main/java/com/sivalabs/ft/features/api/models/CreateReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/CreateReleasePayload.java
@@ -6,4 +6,5 @@ import jakarta.validation.constraints.Size;
 public record CreateReleasePayload(
         @NotEmpty(message = "Product code is required") String productCode,
         @Size(max = 50, message = "Release code cannot exceed 50 characters") @NotEmpty(message = "Release code is required") String code,
-        String description) {}
+        String description,
+        String parentCode) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
@@ -3,4 +3,4 @@ package com.sivalabs.ft.features.api.models;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
 import java.time.Instant;
 
-public record UpdateReleasePayload(String description, ReleaseStatus status, Instant releasedAt) {}
+public record UpdateReleasePayload(String description, ReleaseStatus status, Instant releasedAt, String parentCode) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/Commands.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/Commands.java
@@ -15,10 +15,16 @@ public class Commands {
             String code, String prefix, String name, String description, String imageUrl, String updatedBy) {}
 
     /* Release Commands */
-    public record CreateReleaseCommand(String productCode, String code, String description, String createdBy) {}
+    public record CreateReleaseCommand(
+            String productCode, String code, String description, String parentCode, String createdBy) {}
 
     public record UpdateReleaseCommand(
-            String code, String description, ReleaseStatus status, Instant releasedAt, String updatedBy) {}
+            String code,
+            String description,
+            ReleaseStatus status,
+            Instant releasedAt,
+            String parentCode,
+            String updatedBy) {}
 
     /* Feature Commands */
     public record CreateFeatureCommand(

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
@@ -14,6 +14,24 @@ interface FeatureRepository extends ListCrudRepository<Feature, Long> {
     @Query("select f from Feature f left join fetch f.release where f.release.code = :releaseCode")
     List<Feature> findByReleaseCode(String releaseCode);
 
+    @Query(
+            value =
+                    """
+            WITH RECURSIVE release_hierarchy AS (
+                SELECT r.id, r.parent_id
+                FROM releases r
+                WHERE r.code = :releaseCode
+                UNION ALL
+                SELECT parent.id, parent.parent_id
+                FROM releases parent
+                JOIN release_hierarchy child ON parent.id = child.parent_id
+            )
+            SELECT f.* FROM features f
+            JOIN release_hierarchy rh ON f.release_id = rh.id
+            """,
+            nativeQuery = true)
+    List<Feature> findByReleaseCodeWithParents(String releaseCode);
+
     @Query("select f from Feature f left join fetch f.release where f.product.code = :productCode")
     List<Feature> findByProductCode(String productCode);
 

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -64,6 +64,31 @@ public class FeatureService {
     }
 
     @Transactional(readOnly = true)
+    public List<FeatureDto> findFeaturesByReleaseAndParents(
+            String username, String releaseCode, String fromParentReleaseCode) {
+        List<Feature> features;
+        if (fromParentReleaseCode == null || fromParentReleaseCode.isBlank()) {
+            features = featureRepository.findByReleaseCodeWithParents(releaseCode);
+        } else {
+            Optional<Release> releaseOptional = releaseRepository.findByCode(releaseCode);
+            if (releaseOptional.isEmpty()) {
+                return List.of();
+            }
+            features = new java.util.ArrayList<>();
+            Release currentRelease = releaseOptional.get();
+            features.addAll(featureRepository.findByReleaseCode(currentRelease.getCode()));
+            while (currentRelease.getParent() != null) {
+                currentRelease = currentRelease.getParent();
+                features.addAll(featureRepository.findByReleaseCode(currentRelease.getCode()));
+                if (currentRelease.getCode().equals(fromParentReleaseCode)) {
+                    break;
+                }
+            }
+        }
+        return updateFavoriteStatus(features, username);
+    }
+
+    @Transactional(readOnly = true)
     public List<FeatureDto> findFeaturesByProduct(String username, String productCode) {
         List<Feature> features = featureRepository.findByProductCode(productCode);
         return updateFavoriteStatus(features, username);

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
@@ -64,6 +64,13 @@ public class ReleaseService {
         release.setStatus(ReleaseStatus.DRAFT);
         release.setCreatedBy(cmd.createdBy());
         release.setCreatedAt(Instant.now());
+        if (cmd.parentCode() != null && !cmd.parentCode().isBlank()) {
+            Release parent = releaseRepository
+                    .findByCode(cmd.parentCode())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Parent release with code " + cmd.parentCode() + " not found"));
+            release.setParent(parent);
+        }
         releaseRepository.save(release);
         return code;
     }
@@ -76,6 +83,19 @@ public class ReleaseService {
         release.setReleasedAt(cmd.releasedAt());
         release.setUpdatedBy(cmd.updatedBy());
         release.setUpdatedAt(Instant.now());
+        if (cmd.parentCode() != null) {
+            if (cmd.parentCode().isBlank()) {
+                release.setParent(null);
+            } else if (cmd.code().equals(cmd.parentCode())) {
+                throw new IllegalArgumentException("A release cannot be its own parent");
+            } else {
+                Release parent = releaseRepository
+                        .findByCode(cmd.parentCode())
+                        .orElseThrow(() -> new ResourceNotFoundException(
+                                "Parent release with code " + cmd.parentCode() + " not found"));
+                release.setParent(parent);
+            }
+        }
         releaseRepository.save(release);
     }
 

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/ReleaseDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/ReleaseDto.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 public record ReleaseDto(
         Long id,
         String code,
+        String parentCode,
         String description,
         ReleaseStatus status,
         Instant releasedAt,

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
@@ -60,6 +60,13 @@ public class Release {
     @Column(name = "updated_at")
     private Instant updatedAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Release parent;
+
+    @OneToMany(mappedBy = "parent")
+    private Set<Release> children = new LinkedHashSet<>();
+
     @OneToMany(mappedBy = "release")
     private Set<Feature> features = new LinkedHashSet<>();
 
@@ -141,6 +148,22 @@ public class Release {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public Release getParent() {
+        return parent;
+    }
+
+    public void setParent(Release parent) {
+        this.parent = parent;
+    }
+
+    public Set<Release> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Set<Release> children) {
+        this.children = children;
     }
 
     public Set<Feature> getFeatures() {

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
@@ -3,8 +3,10 @@ package com.sivalabs.ft.features.domain.mappers;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Release;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ReleaseMapper {
+    @Mapping(target = "parentCode", source = "parent.code", defaultExpression = "java( null )")
     ReleaseDto toDto(Release release);
 }

--- a/src/main/resources/db/migration/V1__create_feature_tables.sql
+++ b/src/main/resources/db/migration/V1__create_feature_tables.sql
@@ -22,6 +22,7 @@ create table releases
 (
     id          bigint       not null default nextval('release_id_seq'),
     product_id  bigint       not null,
+    parent_id   bigint,
     code        varchar(50)  not null unique,
     description text,
     status      varchar(50)  not null,
@@ -31,7 +32,8 @@ create table releases
     updated_by  varchar(255),
     updated_at  timestamp,
     primary key (id),
-    constraint fk_releases_product_id foreign key (product_id) references products (id)
+    constraint fk_releases_product_id foreign key (product_id) references products (id),
+    constraint fk_releases_parent_id foreign key (parent_id) references releases (id)
 );
 
 create sequence feature_id_seq start with 100 increment by 50;

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
@@ -123,4 +123,67 @@ class FeatureControllerTests extends AbstractIT {
         var getResult = mvc.get().uri("/api/features/{code}", "IDEA-2").exchange();
         assertThat(getResult).hasStatus(HttpStatus.NOT_FOUND);
     }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldGetFeaturesFromReleaseAndParentReleasesWithNativeQuery() {
+        createRelease("IDEA-2026.1", null);
+        createRelease("IDEA-2026.1.1", "IDEA-2026.1");
+        createFeature("IDEA-2026.1", "Parent release feature");
+        createFeature("IDEA-2026.1.1", "Child release feature");
+
+        var result = mvc.get()
+                .uri("/api/features/all-features?releaseCode={code}", "IDEA-2026.1.1")
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.size()")
+                .asNumber()
+                .isEqualTo(2);
+    }
+
+    private void createRelease(String code, String parentCode) {
+        var parentField = parentCode == null ? "" : ", \"parentCode\": \"%s\"".formatted(parentCode);
+        var payload =
+                """
+            {
+                "productCode": "intellij",
+                "code": "%s",
+                "description": "%s"%s
+            }
+            """
+                        .formatted(code, code, parentField);
+
+        var result = mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+    }
+
+    private void createFeature(String releaseCode, String title) {
+        var payload =
+                """
+            {
+                "productCode": "intellij",
+                "releaseCode": "%s",
+                "title": "%s",
+                "description": "%s description",
+                "assignedTo": "user"
+            }
+            """
+                        .formatted(releaseCode, title, title);
+
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+    }
 }

--- a/src/test/java/com/sivalabs/ft/features/domain/FeatureRepositoryTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/FeatureRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import com.sivalabs.ft.features.domain.entities.Feature;
+import com.sivalabs.ft.features.domain.entities.Product;
+import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestcontainersConfiguration.class)
+class FeatureRepositoryTest {
+
+    @Autowired
+    private FeatureRepository featureRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ReleaseRepository releaseRepository;
+
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        product = new Product();
+        product.setCode("release-chain-product");
+        product.setPrefix("RCP");
+        product.setName("Release Chain Product");
+        product.setImageUrl("https://example.com/release-chain-product.png");
+        product.setCreatedBy("tester");
+        product.setCreatedAt(Instant.now());
+        product = productRepository.save(product);
+    }
+
+    @Test
+    void shouldFindFeaturesByReleaseCodeWithParentsUsingNativeQuery() {
+        Release root = createRelease("RCP-2026.1", null);
+        Release minor = createRelease("RCP-2026.1.1", root);
+        Release patch = createRelease("RCP-2026.1.2", minor);
+        Release unrelated = createRelease("RCP-2027.1", null);
+
+        createFeature("RCP-1", root);
+        createFeature("RCP-2", minor);
+        createFeature("RCP-3", patch);
+        createFeature("RCP-4", unrelated);
+
+        assertThat(featureRepository.findByReleaseCodeWithParents("RCP-2026.1.2"))
+                .extracting(Feature::getCode)
+                .containsExactlyInAnyOrder("RCP-1", "RCP-2", "RCP-3");
+    }
+
+    private Release createRelease(String code, Release parent) {
+        Release release = new Release();
+        release.setProduct(product);
+        release.setParent(parent);
+        release.setCode(code);
+        release.setDescription(code);
+        release.setStatus(ReleaseStatus.DRAFT);
+        release.setCreatedBy("tester");
+        release.setCreatedAt(Instant.now());
+        return releaseRepository.save(release);
+    }
+
+    private void createFeature(String code, Release release) {
+        Feature feature = new Feature();
+        feature.setProduct(product);
+        feature.setRelease(release);
+        feature.setCode(code);
+        feature.setTitle(code);
+        feature.setStatus(FeatureStatus.NEW);
+        feature.setCreatedBy("tester");
+        feature.setCreatedAt(Instant.now());
+        featureRepository.save(feature);
+    }
+}


### PR DESCRIPTION
Update findFeaturesByReleaseAndParents in FeatureService. If fromParentReleaseCode is empty, call a new method findByReleaseCodeWithParents from featureRepository. Implement findByReleaseCodeWithParents using @Query for direct DB access (SQL or JPQL)