### PR TITLE
Implement User Notification System: Email Notifications (with Read Tracking)

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.EmailNotificationIntegrationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -1,9 +1,13 @@
 package com.sivalabs.ft.features;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "ft")
-public record ApplicationProperties(EventsProperties events) {
+@Validated
+public record ApplicationProperties(
+        EventsProperties events, @NotBlank(message = "ft.publicBaseUrl property is required") String publicBaseUrl) {
 
     public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationTrackingController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationTrackingController.java
@@ -1,0 +1,71 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.domain.NotificationRepository;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Public endpoint for tracking email opens via tracking pixel.
+ * This endpoint is accessible without authentication.
+ */
+@RestController
+class NotificationTrackingController {
+    private static final Logger log = LoggerFactory.getLogger(NotificationTrackingController.class);
+
+    // 1x1 transparent GIF (base64 encoded)
+    private static final byte[] TRANSPARENT_GIF =
+            Base64.getDecoder().decode("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+
+    private final NotificationRepository notificationRepository;
+
+    NotificationTrackingController(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    @GetMapping("/notifications/{id}/read")
+    @Transactional
+    public ResponseEntity<byte[]> trackRead(@PathVariable String id) {
+        UUID notificationId;
+        try {
+            notificationId = UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid notification ID format");
+        }
+
+        Notification notification = notificationRepository
+                .findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        // Idempotent: only update if not already read
+        if (!Boolean.TRUE.equals(notification.getRead())) {
+            notification.setRead(true);
+            notification.setReadAt(Instant.now());
+            notificationRepository.save(notification);
+            log.info("Notification {} marked as read via tracking pixel", notificationId);
+        } else {
+            log.debug("Notification {} already read, skipping update", notificationId);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_GIF);
+        headers.setCacheControl("no-cache, no-store, must-revalidate");
+        headers.setPragma("no-cache");
+        headers.setExpires(0);
+
+        return new ResponseEntity<>(TRANSPARENT_GIF, headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
@@ -34,6 +34,8 @@ class SecurityConfig {
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/comments/**")
                         .permitAll()
+                        .requestMatchers(HttpMethod.GET, "/notifications/*/read")
+                        .permitAll()
                         .anyRequest()
                         .authenticated())
                 .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -10,6 +10,7 @@ import com.sivalabs.ft.features.domain.entities.Release;
 import com.sivalabs.ft.features.domain.events.EventPublisher;
 import com.sivalabs.ft.features.domain.mappers.FeatureMapper;
 import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,9 @@ public class FeatureService {
     private final FavoriteFeatureRepository favoriteFeatureRepository;
     private final EventPublisher eventPublisher;
     private final FeatureMapper featureMapper;
+    private final NotificationService notificationService;
+    private final NotificationRecipientService notificationRecipientService;
+    private final UserRepository userRepository;
 
     FeatureService(
             FavoriteFeatureService favoriteFeatureService,
@@ -37,7 +41,10 @@ public class FeatureService {
             ProductRepository productRepository,
             FavoriteFeatureRepository favoriteFeatureRepository,
             EventPublisher eventPublisher,
-            FeatureMapper featureMapper) {
+            FeatureMapper featureMapper,
+            NotificationService notificationService,
+            NotificationRecipientService notificationRecipientService,
+            UserRepository userRepository) {
         this.favoriteFeatureService = favoriteFeatureService;
         this.releaseRepository = releaseRepository;
         this.featureRepository = featureRepository;
@@ -45,6 +52,9 @@ public class FeatureService {
         this.eventPublisher = eventPublisher;
         this.favoriteFeatureRepository = favoriteFeatureRepository;
         this.featureMapper = featureMapper;
+        this.notificationService = notificationService;
+        this.notificationRecipientService = notificationRecipientService;
+        this.userRepository = userRepository;
     }
 
     @Transactional(readOnly = true)
@@ -106,6 +116,7 @@ public class FeatureService {
         feature.setCreatedAt(Instant.now());
         featureRepository.save(feature);
         eventPublisher.publishFeatureCreatedEvent(feature);
+        createFeatureNotifications(feature, cmd.createdBy(), NotificationEventType.FEATURE_CREATED);
         return code;
     }
 
@@ -134,5 +145,22 @@ public class FeatureService {
         favoriteFeatureRepository.deleteByFeatureCode(cmd.code());
         featureRepository.deleteByCode(cmd.code());
         eventPublisher.publishFeatureDeletedEvent(feature, cmd.deletedBy(), Instant.now());
+    }
+
+    private void createFeatureNotifications(
+            Feature feature, String actor, NotificationEventType notificationEventType) {
+        var featureDto = featureMapper.toDto(feature);
+        var recipients = notificationRecipientService.getFeatureNotificationRecipients(featureDto, actor);
+        for (String recipient : recipients) {
+            userRepository
+                    .findByUsername(recipient)
+                    .ifPresent(user -> notificationService.createNotification(
+                            recipient,
+                            user.getEmail(),
+                            notificationEventType,
+                            "Summary: Feature %s was created. Actor: %s. Link: /api/features/%s"
+                                    .formatted(feature.getCode(), actor, feature.getCode()),
+                            "/api/features/" + feature.getCode()));
+        }
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationEmailService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationEmailService.java
@@ -1,0 +1,152 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.ApplicationProperties;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import jakarta.mail.internet.MimeMessage;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.HtmlUtils;
+
+/**
+ * Service for sending email notifications.
+ * Handles email rendering, error handling, and logging.
+ * Email delivery failures are logged but do not throw exceptions.
+ */
+@Service
+public class NotificationEmailService {
+    private static final Logger log = LoggerFactory.getLogger(NotificationEmailService.class);
+
+    private final JavaMailSender mailSender;
+    private final ApplicationProperties applicationProperties;
+    private final NotificationRepository notificationRepository;
+
+    public NotificationEmailService(
+            JavaMailSender mailSender,
+            ApplicationProperties applicationProperties,
+            NotificationRepository notificationRepository) {
+        this.mailSender = mailSender;
+        this.applicationProperties = applicationProperties;
+        this.notificationRepository = notificationRepository;
+    }
+
+    /**
+     * Send email notification for a saved notification.
+     * On error: logs recipient, eventType, timestamp, and error details, and updates delivery_status to FAILED.
+     * Does NOT throw exception to avoid affecting notification creation.
+     * Uses REQUIRES_NEW to create a new transaction (notification entity is detached after original commit).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendNotificationEmail(Notification notification) {
+        if (notification.getRecipientEmail() == null
+                || notification.getRecipientEmail().isBlank()) {
+            log.debug("Skipping email send for notification {} - no recipient email", notification.getId());
+            return;
+        }
+
+        try {
+            String subject = buildSubject(notification);
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(notification.getRecipientEmail());
+            helper.setSubject(subject);
+            helper.setText(buildHtmlContent(notification, subject), true);
+            helper.setFrom("noreply@feature-service.local");
+
+            mailSender.send(message);
+            log.info(
+                    "Email sent successfully to {} for notification {}",
+                    notification.getRecipientEmail(),
+                    notification.getId());
+
+        } catch (Exception e) {
+            logEmailFailure(notification, e);
+            updateDeliveryStatusToFailed(notification);
+        }
+    }
+
+    private void updateDeliveryStatusToFailed(Notification notification) {
+        try {
+            notificationRepository.updateDeliveryStatus(notification.getId(), DeliveryStatus.FAILED);
+            log.debug("Updated delivery_status to FAILED for notification {}", notification.getId());
+        } catch (Exception e) {
+            log.warn("Failed to update delivery_status for notification {}", notification.getId(), e);
+        }
+    }
+
+    private String buildSubject(Notification notification) {
+        return switch (notification.getEventType()) {
+            case FEATURE_CREATED -> "New Feature Created";
+            case FEATURE_UPDATED -> "Feature Updated";
+            case FEATURE_DELETED -> "Feature Deleted";
+            case RELEASE_CREATED -> "New Release Created";
+            case RELEASE_UPDATED -> "Release Updated";
+            case RELEASE_DELETED -> "Release Deleted";
+        };
+    }
+
+    private String buildHtmlContent(Notification notification, String subject) {
+        String trackingPixelUrl = buildTrackingPixelUrl(notification);
+        String linkHtml = notification.getLink() != null
+                ? "<p><a href=\"" + HtmlUtils.htmlEscape(notification.getLink()) + "\">View Details</a></p>"
+                : "";
+
+        String eventDetails = notification.getEventDetails() != null
+                ? HtmlUtils.htmlEscape(notification.getEventDetails())
+                : "No details available";
+
+        return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset="UTF-8">
+                </head>
+                <body>
+                    <h2>%s</h2>
+                    <p>%s</p>
+                    %s
+                    <hr>
+                    <p style="color: #666; font-size: 12px;">
+                        Recipient: %s<br>
+                        Event triggered at: %s
+                    </p>
+                    <img src="%s" width="1" height="1" alt="" style="display:none;">
+                </body>
+                </html>
+                """
+                .formatted(
+                        subject,
+                        eventDetails,
+                        linkHtml,
+                        HtmlUtils.htmlEscape(notification.getRecipientUserId()),
+                        HtmlUtils.htmlEscape(String.valueOf(notification.getCreatedAt())),
+                        HtmlUtils.htmlEscape(trackingPixelUrl));
+    }
+
+    private String buildTrackingPixelUrl(Notification notification) {
+        String baseUrl = applicationProperties.publicBaseUrl();
+        // Remove trailing slash if present
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return baseUrl + "/notifications/" + notification.getId() + "/read";
+    }
+
+    private void logEmailFailure(Notification notification, Exception e) {
+        log.error(
+                "Email delivery failed - recipient: {}, eventType: {}, timestamp: {}, error: {}",
+                notification.getRecipientEmail(),
+                notification.getEventType(),
+                Instant.now(),
+                e.getMessage(),
+                e);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationRecipientService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationRecipientService.java
@@ -1,0 +1,38 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.FeatureDto;
+import java.util.HashSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service to determine notification recipients based on business rules
+ * Returns all potential recipients (createdBy + assignedTo), filtering via excludeUser parameter
+ */
+@Service
+public class NotificationRecipientService {
+    private static final Logger log = LoggerFactory.getLogger(NotificationRecipientService.class);
+    /**
+     * Get notification recipients for feature events from DTO
+     * Returns createdBy and assignedTo users
+     * Use excludeUser parameter to filter out the user who triggered the action
+     */
+    public Set<String> getFeatureNotificationRecipients(FeatureDto featureDto, String excludeUser) {
+        Set<String> recipients = new HashSet<>();
+
+        // Add creator if not excluded
+        if (featureDto.createdBy() != null && !featureDto.createdBy().equals(excludeUser)) {
+            recipients.add(featureDto.createdBy());
+        }
+
+        // Add assignee if not excluded
+        if (featureDto.assignedTo() != null && !featureDto.assignedTo().equals(excludeUser)) {
+            recipients.add(featureDto.assignedTo());
+        }
+
+        log.debug("Feature {} notification recipients (excluding {}): {}", featureDto.code(), excludeUser, recipients);
+        return recipients;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
@@ -1,0 +1,43 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface NotificationRepository extends ListCrudRepository<Notification, UUID> {
+
+    /**
+     * Find all notifications for a specific user with pagination, ordered by creation date (newest first)
+     */
+    @Query("SELECT n FROM Notification n WHERE n.recipientUserId = :recipientUserId ORDER BY n.createdAt DESC")
+    Page<Notification> findByRecipientUserIdOrderByCreatedAtDesc(String recipientUserId, Pageable pageable);
+
+    /**
+     * Mark notification as read
+     */
+    @Modifying
+    @Query(
+            "UPDATE Notification n SET n.read = true, n.readAt = :readAt WHERE n.id = :id AND n.recipientUserId = :recipientUserId")
+    int markAsRead(UUID id, String recipientUserId, Instant readAt);
+
+    /**
+     * Mark notification as unread
+     */
+    @Modifying
+    @Query(
+            "UPDATE Notification n SET n.read = false, n.readAt = null WHERE n.id = :id AND n.recipientUserId = :recipientUserId")
+    int markAsUnread(UUID id, String recipientUserId);
+
+    /**
+     * Update delivery status (used for FAILED status when email sending fails)
+     */
+    @Modifying
+    @Query("UPDATE Notification n SET n.deliveryStatus = :deliveryStatus WHERE n.id = :id")
+    int updateDeliveryStatus(UUID id, DeliveryStatus deliveryStatus);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
@@ -1,0 +1,182 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.NotificationDto;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
+import com.sivalabs.ft.features.domain.mappers.NotificationMapper;
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Service
+public class NotificationService {
+    private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
+    private final NotificationEmailService notificationEmailService;
+
+    public NotificationService(
+            NotificationRepository notificationRepository,
+            NotificationMapper notificationMapper,
+            NotificationEmailService notificationEmailService) {
+        this.notificationRepository = notificationRepository;
+        this.notificationMapper = notificationMapper;
+        this.notificationEmailService = notificationEmailService;
+    }
+
+    /**
+     * Create a new notification
+     */
+    @Transactional
+    public NotificationDto createNotification(
+            String recipientUserId,
+            String recipientEmail,
+            NotificationEventType eventType,
+            String eventDetails,
+            String link) {
+
+        var notification = new Notification();
+        notification.setRecipientUserId(recipientUserId);
+        notification.setRecipientEmail(recipientEmail);
+        notification.setEventType(eventType);
+        notification.setEventDetails(eventDetails);
+        notification.setLink(link);
+        notification.setCreatedAt(Instant.now());
+        notification.setRead(false);
+        notification.setDeliveryStatus(DeliveryStatus.PENDING);
+
+        notification = notificationRepository.save(notification);
+
+        log.info("Created notification {} for user {}", notification.getId(), recipientUserId);
+
+        // Send email after transaction commits to avoid sending if rollback occurs
+        Notification savedNotification = notification;
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                notificationEmailService.sendNotificationEmail(savedNotification);
+            }
+        });
+
+        return notificationMapper.toDto(notification);
+    }
+
+    /**
+     * Create multiple notifications in a single batch operation.
+     */
+    @Transactional
+    public List<NotificationDto> createNotificationsBatch(List<NotificationData> notificationsData) {
+        if (notificationsData == null || notificationsData.isEmpty()) {
+            return List.of();
+        }
+
+        List<Notification> notifications = new ArrayList<>();
+        Instant now = Instant.now();
+
+        for (NotificationData data : notificationsData) {
+            var notification = new Notification();
+            notification.setRecipientUserId(data.recipientUserId());
+            notification.setRecipientEmail(data.recipientEmail());
+            notification.setEventType(data.eventType());
+            notification.setEventDetails(data.eventDetails());
+            notification.setLink(data.link());
+            notification.setCreatedAt(now);
+            notification.setRead(false);
+            notification.setDeliveryStatus(DeliveryStatus.PENDING);
+            notifications.add(notification);
+        }
+
+        List<Notification> savedNotifications = notificationRepository.saveAll(notifications);
+
+        log.info("Created {} notifications in batch", savedNotifications.size());
+
+        // Send emails after transaction commits to avoid sending if rollback occurs
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (Notification savedNotification : savedNotifications) {
+                    notificationEmailService.sendNotificationEmail(savedNotification);
+                }
+            }
+        });
+
+        return savedNotifications.stream().map(notificationMapper::toDto).toList();
+    }
+
+    /**
+     * Data class for batch notification creation
+     */
+    public record NotificationData(
+            String recipientUserId,
+            String recipientEmail,
+            NotificationEventType eventType,
+            String eventDetails,
+            String link) {}
+
+    /**
+     * Get notifications for a user with pagination
+     */
+    @Transactional(readOnly = true)
+    public Page<NotificationDto> getNotificationsForUser(String recipientUserId, Pageable pageable) {
+        Page<Notification> notifications =
+                notificationRepository.findByRecipientUserIdOrderByCreatedAtDesc(recipientUserId, pageable);
+        return notifications.map(notificationMapper::toDto);
+    }
+
+    /**
+     * Mark notification as read
+     * Only the recipient can mark their own notifications as read
+     */
+    @Transactional
+    public NotificationDto markAsRead(UUID notificationId, String recipientUserId) {
+        Instant readAt = Instant.now();
+        int updated = notificationRepository.markAsRead(notificationId, recipientUserId, readAt);
+
+        if (updated == 0) {
+            throw new ResourceNotFoundException("Notification not found or access denied");
+        }
+
+        // Fetch updated notification
+        Notification notification = notificationRepository
+                .findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        log.info("Marked notification {} as read for user {}", notificationId, recipientUserId);
+
+        return notificationMapper.toDto(notification);
+    }
+
+    /**
+     * Mark notification as unread
+     * Only the recipient can mark their own notifications as unread
+     */
+    @Transactional
+    public NotificationDto markAsUnread(UUID notificationId, String recipientUserId) {
+        int updated = notificationRepository.markAsUnread(notificationId, recipientUserId);
+
+        if (updated == 0) {
+            throw new ResourceNotFoundException("Notification not found or access denied");
+        }
+
+        // Fetch updated notification
+        Notification notification = notificationRepository
+                .findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        log.info("Marked notification {} as unread for user {}", notificationId, recipientUserId);
+
+        return notificationMapper.toDto(notification);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReleaseService.java
@@ -5,8 +5,10 @@ import com.sivalabs.ft.features.domain.Commands.UpdateReleaseCommand;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Product;
 import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.entities.User;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.ReleaseMapper;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
 import java.time.Instant;
 import java.util.List;
@@ -21,16 +23,22 @@ public class ReleaseService {
     private final ProductRepository productRepository;
     private final FeatureRepository featureRepository;
     private final ReleaseMapper releaseMapper;
+    private final NotificationService notificationService;
+    private final UserRepository userRepository;
 
     ReleaseService(
             ReleaseRepository releaseRepository,
             ProductRepository productRepository,
             FeatureRepository featureRepository,
-            ReleaseMapper releaseMapper) {
+            ReleaseMapper releaseMapper,
+            NotificationService notificationService,
+            UserRepository userRepository) {
         this.releaseRepository = releaseRepository;
         this.productRepository = productRepository;
         this.featureRepository = featureRepository;
         this.releaseMapper = releaseMapper;
+        this.notificationService = notificationService;
+        this.userRepository = userRepository;
     }
 
     @Transactional(readOnly = true)
@@ -65,6 +73,7 @@ public class ReleaseService {
         release.setCreatedBy(cmd.createdBy());
         release.setCreatedAt(Instant.now());
         releaseRepository.save(release);
+        createReleaseNotifications(release, cmd.createdBy());
         return code;
     }
 
@@ -86,5 +95,20 @@ public class ReleaseService {
         }
         featureRepository.unsetRelease(code);
         releaseRepository.deleteByCode(code);
+    }
+
+    private void createReleaseNotifications(Release release, String actor) {
+        for (User user : userRepository.findAll()) {
+            if (user.getUsername().equals(actor)) {
+                continue;
+            }
+            notificationService.createNotification(
+                    user.getUsername(),
+                    user.getEmail(),
+                    NotificationEventType.RELEASE_CREATED,
+                    "Summary: Release %s was created. Actor: %s. Link: /api/releases/%s"
+                            .formatted(release.getCode(), actor, release.getCode()),
+                    "/api/releases/" + release.getCode());
+        }
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/UserRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/UserRepository.java
@@ -1,0 +1,10 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.User;
+import java.util.Optional;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface UserRepository extends ListCrudRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/NotificationDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/NotificationDto.java
@@ -1,0 +1,63 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+        UUID id,
+        String recipientUserId,
+        String recipientEmail,
+        NotificationEventType eventType,
+        String eventDetails,
+        String link,
+        Instant createdAt,
+        boolean read,
+        Instant readAt,
+        DeliveryStatus deliveryStatus)
+        implements Serializable {
+
+    /**
+     * Create a copy with read status updated
+     */
+    public NotificationDto markAsRead(Instant readAt) {
+        return new NotificationDto(
+                id,
+                recipientUserId,
+                recipientEmail,
+                eventType,
+                eventDetails,
+                link,
+                createdAt,
+                true,
+                readAt,
+                deliveryStatus);
+    }
+
+    /**
+     * Create a copy with unread status
+     */
+    public NotificationDto markAsUnread() {
+        return new NotificationDto(
+                id,
+                recipientUserId,
+                recipientEmail,
+                eventType,
+                eventDetails,
+                link,
+                createdAt,
+                false,
+                null,
+                deliveryStatus);
+    }
+
+    /**
+     * Create a copy with updated delivery status
+     */
+    public NotificationDto withDeliveryStatus(DeliveryStatus status) {
+        return new NotificationDto(
+                id, recipientUserId, recipientEmail, eventType, eventDetails, link, createdAt, read, readAt, status);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Notification.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Notification.java
@@ -1,0 +1,154 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import com.sivalabs.ft.features.domain.models.DeliveryStatus;
+import com.sivalabs.ft.features.domain.models.NotificationEventType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Size(max = 255) @NotNull @Column(name = "recipient_user_id", nullable = false)
+    private String recipientUserId;
+
+    @Size(max = 255) @Column(name = "recipient_email")
+    private String recipientEmail;
+
+    @NotNull @Column(name = "event_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private NotificationEventType eventType;
+
+    @Column(name = "event_details", length = Integer.MAX_VALUE)
+    private String eventDetails;
+
+    @Size(max = 500) @Column(name = "link", length = 500)
+    private String link;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @NotNull @ColumnDefault("false")
+    @Column(name = "read", nullable = false)
+    private Boolean read;
+
+    @Column(name = "read_at")
+    private Instant readAt;
+
+    @NotNull @Column(name = "delivery_status", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'PENDING'")
+    private DeliveryStatus deliveryStatus;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getRecipientUserId() {
+        return recipientUserId;
+    }
+
+    public void setRecipientUserId(String recipientUserId) {
+        this.recipientUserId = recipientUserId;
+    }
+
+    public String getRecipientEmail() {
+        return recipientEmail;
+    }
+
+    public void setRecipientEmail(String recipientEmail) {
+        this.recipientEmail = recipientEmail;
+    }
+
+    public NotificationEventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(NotificationEventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getEventDetails() {
+        return eventDetails;
+    }
+
+    public void setEventDetails(String eventDetails) {
+        this.eventDetails = eventDetails;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Boolean getRead() {
+        return read;
+    }
+
+    public void setRead(Boolean read) {
+        this.read = read;
+    }
+
+    public Instant getReadAt() {
+        return readAt;
+    }
+
+    public void setReadAt(Instant readAt) {
+        this.readAt = readAt;
+    }
+
+    public DeliveryStatus getDeliveryStatus() {
+        return deliveryStatus;
+    }
+
+    public void setDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+    }
+
+    /**
+     * Mark notification as read and set readAt timestamp
+     */
+    public void markAsRead() {
+        this.read = true;
+        this.readAt = Instant.now();
+    }
+
+    /**
+     * Mark notification as unread and clear readAt timestamp
+     */
+    public void markAsUnread() {
+        this.read = false;
+        this.readAt = null;
+    }
+
+    /**
+     * Update delivery status
+     */
+    public void updateDeliveryStatus(DeliveryStatus status) {
+        this.deliveryStatus = status;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/User.java
@@ -1,0 +1,51 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Size(max = 255) @NotNull @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Size(max = 255) @NotNull @Column(name = "email", nullable = false)
+    private String email;
+
+    public User() {}
+
+    public User(String username, String email) {
+        this.username = username;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/NotificationMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/NotificationMapper.java
@@ -1,0 +1,12 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.NotificationDto;
+import com.sivalabs.ft.features.domain.entities.Notification;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+    NotificationDto toDto(Notification notification);
+
+    Notification toEntity(NotificationDto notificationDto);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/DeliveryStatus.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/DeliveryStatus.java
@@ -1,0 +1,22 @@
+package com.sivalabs.ft.features.domain.models;
+
+/**
+ * Delivery status for notifications
+ * Tracks the delivery state of email notifications
+ */
+public enum DeliveryStatus {
+    /**
+     * Notification is pending delivery
+     */
+    PENDING,
+
+    /**
+     * Notification was successfully delivered
+     */
+    DELIVERED,
+
+    /**
+     * Notification delivery failed
+     */
+    FAILED
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/NotificationEventType.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/NotificationEventType.java
@@ -1,0 +1,14 @@
+package com.sivalabs.ft.features.domain.models;
+
+/**
+ * Event types for notifications
+ * Defines what kind of events trigger notifications
+ */
+public enum NotificationEventType {
+    FEATURE_CREATED,
+    FEATURE_UPDATED,
+    FEATURE_DELETED,
+    RELEASE_CREATED,
+    RELEASE_UPDATED,
+    RELEASE_DELETED
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,7 @@ ft.openapi.contact.email=support@sivalabs.in
 ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
+ft.publicBaseUrl=http://localhost:8081
 
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}
@@ -26,6 +27,14 @@ spring.jpa.show-sql=true
 OAUTH2_SERVER_URL=http://localhost:9191
 REALM_URL=${OAUTH2_SERVER_URL}/realms/feature-tracker
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${REALM_URL}
+
+######## Mail Configuration  #########
+spring.mail.host=${MAIL_HOST:localhost}
+spring.mail.port=${MAIL_PORT:1025}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
 
 ######## Kafka Configuration  #########
 KAFKA_BROKER=localhost:9092

--- a/src/main/resources/db/migration/V5__create_notification_tables.sql
+++ b/src/main/resources/db/migration/V5__create_notification_tables.sql
@@ -1,0 +1,28 @@
+create table users
+(
+    id       bigserial primary key,
+    username varchar(255) not null unique,
+    email    varchar(255) not null
+);
+
+create index idx_users_username on users(username);
+
+create table notifications
+(
+    id                uuid primary key default gen_random_uuid(),
+    recipient_user_id varchar(255) not null,
+    recipient_email   varchar(255),
+    event_type        varchar(50)  not null check (event_type in ('FEATURE_CREATED', 'FEATURE_UPDATED', 'FEATURE_DELETED', 'RELEASE_CREATED', 'RELEASE_UPDATED', 'RELEASE_DELETED')),
+    event_details     text,
+    link              varchar(500),
+    created_at        timestamp    not null default current_timestamp,
+    read              boolean      not null default false,
+    read_at           timestamp,
+    delivery_status   varchar(50)  not null default 'PENDING' check (delivery_status in ('PENDING', 'DELIVERED', 'FAILED'))
+);
+
+create index idx_notifications_recipient_user_id on notifications(recipient_user_id);
+create index idx_notifications_created_at on notifications(created_at);
+create index idx_notifications_read on notifications(read);
+create index idx_notifications_delivery_status on notifications(delivery_status);
+create index idx_notifications_recipient_unread on notifications(recipient_user_id, read, created_at desc);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/EmailNotificationIntegrationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/EmailNotificationIntegrationTests.java
@@ -1,0 +1,242 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.util.Properties;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Import(MockJavaMailSenderConfig.class)
+@ExtendWith(OutputCaptureExtension.class)
+class EmailNotificationIntegrationTests extends AbstractIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void configureMailSender() {
+        reset(javaMailSender);
+        when(javaMailSender.createMimeMessage())
+                .thenAnswer(invocation -> new MimeMessage(Session.getInstance(new Properties())));
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldSendEmailWhenFeatureNotificationIsCreated() throws Exception {
+        var payload =
+                """
+                {
+                    "productCode": "intellij",
+                    "releaseCode": "IDEA-2023.3.8",
+                    "title": "New Feature",
+                    "description": "New feature description",
+                    "assignedTo": "bob"
+                }
+                """;
+
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+        String notificationId = jdbcTemplate.queryForObject(
+                "select id::text from notifications where recipient_user_id = ?", String.class, "bob");
+        assertThat(notificationId).isNotBlank();
+        assertThat(jdbcTemplate.queryForObject(
+                        "select recipient_email from notifications where id = ?::uuid", String.class, notificationId))
+                .isEqualTo("bob@example.com");
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(javaMailSender, timeout(2000)).send(captor.capture());
+
+        MimeMessage message = captor.getValue();
+        assertThat(message.getAllRecipients()[0].toString()).isEqualTo("bob@example.com");
+        assertThat(message.getSubject()).isEqualTo("New Feature Created");
+        assertThat(extractContent(message))
+                .contains("Summary: Feature")
+                .contains("Actor: alice")
+                .contains("/api/features/")
+                .contains("http://localhost:8081/notifications/" + notificationId + "/read");
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "admin")
+    void shouldSendEmailsWhenReleaseNotificationIsCreated() {
+        var payload =
+                """
+                {
+                    "productCode": "intellij",
+                    "code": "2025.1",
+                    "description": "IntelliJ IDEA 2025.1"
+                }
+                """;
+
+        var result = mvc.post()
+                .uri("/api/releases")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+        Integer notifications = jdbcTemplate.queryForObject(
+                "select count(*) from notifications where event_type = 'RELEASE_CREATED'", Integer.class);
+        assertThat(notifications).isEqualTo(7);
+        Integer selfNotifications = jdbcTemplate.queryForObject(
+                "select count(*) from notifications where recipient_user_id = 'admin'", Integer.class);
+        assertThat(selfNotifications).isZero();
+        verify(javaMailSender, timeout(2000).times(7)).send(any(MimeMessage.class));
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldCreateNotificationWhenEmailSendingFails(CapturedOutput output) {
+        doThrow(new MailSendException("smtp unavailable")).when(javaMailSender).send(any(MimeMessage.class));
+        var payload =
+                """
+                {
+                    "productCode": "intellij",
+                    "releaseCode": "IDEA-2023.3.8",
+                    "title": "Failure Still Creates Notification",
+                    "description": "Email failure must not block creation",
+                    "assignedTo": "bob"
+                }
+                """;
+
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+        await().untilAsserted(() -> assertThat(jdbcTemplate.queryForObject(
+                        "select delivery_status from notifications where recipient_user_id = ?", String.class, "bob"))
+                .isEqualTo("FAILED"));
+        assertThat(output)
+                .contains("Email delivery failed - recipient: bob@example.com")
+                .contains("eventType: FEATURE_CREATED")
+                .contains("smtp unavailable");
+    }
+
+    @Test
+    void shouldMarkNotificationAsReadWithTrackingPixel() {
+        UUID notificationId = insertNotification(false);
+
+        var result = mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+
+        assertThat(result).hasStatusOk();
+        var response = result.getMvcResult().getResponse();
+        assertThat(response.getContentType()).isEqualTo(MediaType.IMAGE_GIF_VALUE);
+        assertThat(new String(response.getContentAsByteArray(), 0, 3, StandardCharsets.US_ASCII))
+                .isEqualTo("GIF");
+        assertThat(jdbcTemplate.queryForObject(
+                        "select read from notifications where id = ?", Boolean.class, notificationId))
+                .isTrue();
+        assertThat(jdbcTemplate.queryForObject(
+                        "select read_at from notifications where id = ?", Timestamp.class, notificationId))
+                .isNotNull();
+    }
+
+    @Test
+    void shouldReturn404WhenTrackingNotificationDoesNotExist() throws Exception {
+        var result =
+                mvc.get().uri("/notifications/{id}/read", UUID.randomUUID()).exchange();
+
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+        assertThat(result.getMvcResult().getResponse().getContentAsString()).contains("Notification not found");
+    }
+
+    @Test
+    void shouldReturn400ForInvalidTrackingNotificationId() throws Exception {
+        var result = mvc.get().uri("/notifications/not-a-uuid/read").exchange();
+
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+        assertThat(result.getMvcResult().getResponse().getContentAsString())
+                .contains("Invalid notification ID format")
+                .doesNotContain("IllegalArgumentException")
+                .doesNotContain("java.lang");
+    }
+
+    @Test
+    void shouldNotChangeReadTimestampOnRepeatedTrackingPixelCalls() {
+        UUID notificationId = insertNotification(false);
+
+        mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+        Timestamp firstReadAt = jdbcTemplate.queryForObject(
+                "select read_at from notifications where id = ?", Timestamp.class, notificationId);
+
+        mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+        Timestamp secondReadAt = jdbcTemplate.queryForObject(
+                "select read_at from notifications where id = ?", Timestamp.class, notificationId);
+
+        assertThat(secondReadAt).isEqualTo(firstReadAt);
+    }
+
+    private UUID insertNotification(boolean read) {
+        UUID notificationId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                insert into notifications
+                    (id, recipient_user_id, recipient_email, event_type, event_details, link, created_at, read, delivery_status)
+                values (?, ?, ?, ?, ?, ?, current_timestamp, ?, ?)
+                """,
+                notificationId,
+                "bob",
+                "bob@example.com",
+                "FEATURE_CREATED",
+                "Summary: Feature was created. Actor: alice. Link: /api/features/IDEA-999",
+                "/api/features/IDEA-999",
+                read,
+                "PENDING");
+        return notificationId;
+    }
+
+    private String extractContent(MimeMessage message) throws Exception {
+        return extractContent(message.getContent());
+    }
+
+    private String extractContent(Object content) throws Exception {
+        if (content instanceof MimeMultipart multipart) {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < multipart.getCount(); i++) {
+                BodyPart bodyPart = multipart.getBodyPart(i);
+                builder.append(extractContent(bodyPart.getContent()));
+            }
+            return builder.toString();
+        }
+        return String.valueOf(content);
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/testsupport/MockJavaMailSenderConfig.java
+++ b/src/test/java/com/sivalabs/ft/features/testsupport/MockJavaMailSenderConfig.java
@@ -1,0 +1,18 @@
+package com.sivalabs.ft.features.testsupport;
+
+import static org.mockito.Mockito.mock;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@TestConfiguration
+public class MockJavaMailSenderConfig {
+
+    @Bean
+    @Primary
+    public JavaMailSender mockJavaMailSender() {
+        return mock(JavaMailSender.class);
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -1,7 +1,9 @@
+delete from notifications;
 delete from favorite_features;
 delete from comments;
 delete from features;
 delete from releases;
+delete from users;
 delete from products;
 
 insert into products (id, code, prefix, name, description, image_url, disabled, created_by, created_at) values
@@ -34,3 +36,13 @@ insert into comments (id, feature_id, created_by, content) values
 (1, 1, 'user', 'This is a comment on feature IDEA-1'),
 (2,  1, 'user', 'This is a comment on feature IDEA-2'),
 (3, 1, 'user', 'This is a comment on feature GO-3');
+
+insert into users (id, username, email) values
+(1, 'admin', 'admin@example.com'),
+(2, 'user', 'user@example.com'),
+(3, 'alice', 'alice@example.com'),
+(4, 'bob', 'bob@example.com'),
+(5, 'marcobehler', 'marcobehler@example.com'),
+(6, 'daniiltsarev', 'daniiltsarev@example.com'),
+(7, 'antonarhipov', 'antonarhipov@example.com'),
+(8, 'andreybelyaev', 'andreybelyaev@example.com');


### PR DESCRIPTION
### Objective
Implement email notifications for feature/release events, including read tracking.

### Requirements

#### Email Delivery

Send emails when in-app notifications are created.

Email recipients must match the recipients of the corresponding in-app Notification.

Email content must include:
- Event summary
- Actor (who triggered the event)
- Links to affected entities

#### Database Schema

A `users` table must be created with columns: `id`, `username`, `email`. This table is the source of email addresses for notifications.

The `notifications` table must include a column named `recipient_email`.

The email must be sent to the address stored in `recipient_email`, which is retrieved from the `users` table by `username`.

#### Delivery Logging

Log email delivery failures with:
- Recipient email
- Event type
- Timestamp
- Error details

Email delivery failure must not prevent notification creation.

#### Email Read Tracking

- Embed a tracking pixel in each email (unique link with notification ID)
- When email is opened, the system calls `GET /notifications/{id}/read`
- Update the notification's status in DB

#### Configuration

The application must be configured with a public base URL via a property named `publicBaseUrl` defined in `application.properties`.

---

### Public API

#### GET /notifications/{id}/read

**Authentication:** None required (must be publicly accessible for email clients)

**Path Parameters:**
- `id` (UUID) — notification ID

**Response:**

| HTTP Status | Condition | Body |
|-------------|-----------|------|
| 200 OK | Notification exists | 1x1 transparent GIF image (Content-Type: `image/gif`) |
| 400 Bad Request | Invalid UUID format | Error message (must not expose stack traces or internal details) |
| 404 Not Found | Notification does not exist | Error message |

**Behavior:**
- Marks notification as read and records the timestamp
- Idempotent: subsequent calls return 200 OK but do not update the timestamp

---

### Test Coverage

- Unit/integration tests for email service
- Tests for read tracking (pixel invocation)
- Security tests to ensure tracking cannot be spoofed:
  - Non-existent notification ID must return 404
  - Invalid UUID format must return 400 without exposing internals
  - Multiple calls must be idempotent

---

### Acceptance Criteria

- Emails are sent when in-app notifications are created
- Delivery failures are logged
- Notifications are marked as read when the tracking pixel is triggered
- Tracking endpoint is secure against spoofing attempts

