### PR TITLE
Fix `FeatureServiceTest` test fails in `eval/debugger-demo` branch

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "FeatureServiceTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -10,6 +10,11 @@
     ],
     "pass_to_pass": []
   },
+  "patch": {
+    "source_patterns": [
+      "src/test/java/com/sivalabs/ft/features/domain/feature/FeatureServiceTest.java"
+    ]
+  },
   "environment": {
     "project_root": "/repo",
     "docker": {

--- a/src/test/java/com/sivalabs/ft/features/domain/feature/FeatureServiceTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/feature/FeatureServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(DatabaseConfiguration.class)
@@ -24,10 +25,10 @@ import org.springframework.test.context.TestPropertySource;
 class FeatureServiceTest {
 
     @Autowired
-    FeatureService featureService;
+    private FeatureService featureService;
 
-    @Autowired
-    EventPublisher eventPublisher;
+    @MockitoBean
+    private EventPublisher eventPublisher;
 
     @BeforeEach
     void resetMocks() {


### PR DESCRIPTION
Tests in test class `FeatureServiceTest` fail with error
```
org.mockito.exceptions.misusing.NotAMockException: Argument should be a mock, but is: class com.sivalabs.ft.features.integration.LogEventPublisher

    at com.sivalabs.ft.features.domain.feature.FeatureServiceTest.resetMocks(FeatureServiceTest.java:34)
    at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
```
Fix the test.