### PR TITLE
Add error handling for the case where a product is not found during the update process.

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.ProductApiTest",
+      "com.sivalabs.ft.features.domain.ProductRepositoryTest",
+      "com.sivalabs.ft.features.domain.ProductServiceTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/domain/ProductService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ProductService.java
@@ -1,5 +1,6 @@
 package com.sivalabs.ft.features.domain;
 
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,9 @@ public class ProductService {
 
     @Transactional
     public void updateProduct(UpdateProductCommand cmd) {
-        var product = productRepository.findByCode(cmd.code()).orElseThrow();
+        var product = productRepository
+                .findByCode(cmd.code())
+                .orElseThrow(() -> new EntityNotFoundException("Product %s not found".formatted(cmd)));
         product.setName(cmd.name());
         product.setDescription(cmd.description());
         product.setImageUrl(cmd.imageUrl());

--- a/src/test/java/com/sivalabs/ft/features/TestcontainersConfiguration.java
+++ b/src/test/java/com/sivalabs/ft/features/TestcontainersConfiguration.java
@@ -10,7 +10,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 @Testcontainers
-class TestcontainersConfiguration {
+public class TestcontainersConfiguration {
 
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(DockerImageName.parse("postgres:17"));

--- a/src/test/java/com/sivalabs/ft/features/api/ProductApiTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/ProductApiTest.java
@@ -1,0 +1,129 @@
+package com.sivalabs.ft.features.api;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@AutoConfigureMockMvc
+public class ProductApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testGetProducts() throws Exception {
+        mockMvc.perform(get("/api/products"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").isNotEmpty());
+    }
+
+    @Test
+    void testCreateProduct() throws Exception {
+        String productJson =
+                """
+                    {
+                        "code": "new-product",
+                        "name": "New Product",
+                        "description": "A newly created product",
+                        "imageUrl": "http://example.com/image.png"
+                    }
+                """
+                        .stripIndent();
+
+        mockMvc.perform(post("/api/products")
+                        .with(jwt().jwt(builder -> builder.claim("preferred_username", "testuser")
+                                .claim("realm_access", Map.of("roles", List.of("USER")))))
+                        .contentType("application/json")
+                        .content(productJson))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(header().string("Location", "http://localhost/api/products/new-product"));
+    }
+
+    @Test
+    void testCreateProductUnauthorized() throws Exception {
+        String productJson =
+                """
+                    {
+                        "code": "new-product",
+                        "name": "New Product",
+                        "description": "A newly created product",
+                        "imageUrl": "http://example.com/image.png"
+                    }
+                """
+                        .stripIndent();
+
+        mockMvc.perform(post("/api/products").contentType("application/json").content(productJson))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testUpdateProduct() throws Exception {
+        String updatedProductJson =
+                """
+                    {
+                        "name": "Updated Product",
+                        "description": "This is an updated product description",
+                        "imageUrl": "http://example.com/updated-image.png"
+                    }
+                """
+                        .stripIndent();
+
+        String productCode = "intellij";
+
+        mockMvc.perform(put("/api/products/{code}", productCode)
+                        .with(jwt().jwt(builder -> builder.claim("preferred_username", "testuser")
+                                .claim("realm_access", Map.of("roles", List.of("USER")))))
+                        .contentType("application/json")
+                        .content(updatedProductJson))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testUpdateProductUnauthorized() throws Exception {
+        String updatedProductJson =
+                """
+                    {
+                        "name": "Updated Product",
+                        "description": "This is an updated product description",
+                        "imageUrl": "http://example.com/updated-image.png"
+                    }
+                """
+                        .stripIndent();
+
+        String productCode = "intellij";
+
+        mockMvc.perform(put("/api/products/{code}", productCode)
+                        .contentType("application/json")
+                        .content(updatedProductJson))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testGetNonExistingProduct() throws Exception {
+        String nonExistingProductCode = "nonexistent-code";
+        mockMvc.perform(get("/api/products/{code}", nonExistingProductCode)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testGetProduct() throws Exception {
+        String productCode = "intellij";
+        mockMvc.perform(get("/api/products/{code}", productCode))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(productCode))
+                .andExpect(jsonPath("$.name").isNotEmpty());
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/domain/ProductRepositoryTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/ProductRepositoryTest.java
@@ -1,0 +1,26 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestcontainersConfiguration.class)
+public class ProductRepositoryTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void testFindByCode() {
+        Product productByCode = productRepository
+                .findByCode("intellij")
+                .orElseThrow(() -> new EntityNotFoundException("Product not found"));
+        assertEquals("intellij", productByCode.getCode(), "Product code does not match condition");
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/domain/ProductServiceTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/ProductServiceTest.java
@@ -1,0 +1,86 @@
+package com.sivalabs.ft.features.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+public class ProductServiceTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void testFindProductByCode() {
+        Optional<Product> result = productService.findProductByCode("intellij");
+        assertTrue(result.isPresent(), "Product with code 'intellij' should be present");
+        assertEquals("intellij", result.get().getCode(), "Product code does not match the expected value");
+    }
+
+    @Test
+    void testFindAllProducts() {
+        var products = productService.findAllProducts();
+        assertNotNull(products, "The product list should not be null");
+        assertFalse(products.isEmpty(), "There must be sample data in the database");
+    }
+
+    @Test
+    void testCreateProduct() {
+        var command = new CreateProductCommand("new-code", "New Product", "Description", "image-url", "user");
+        long prev = productRepository.findAll().size();
+        Long productId = productService.createProduct(command);
+        assertNotNull(productId, "Product ID should not be null after creation");
+        var createdProduct = productRepository
+                .findById(productId)
+                .orElseThrow(() -> new EntityNotFoundException("Product not found"));
+        assertEquals(command.code(), createdProduct.getCode(), "Product code should match the command");
+        assertEquals(
+                prev + 1,
+                productRepository.findAll().size(),
+                "Product repository size should increase by 1 after creation");
+    }
+
+    @Test
+    void testUpdateProduct() {
+        String productCode = "intellij";
+        var updateCommand = new UpdateProductCommand(
+                productCode, "Updated Name", "Updated Description", "updated-image-url", "updater");
+        productService.updateProduct(updateCommand);
+        var updatedProduct = productRepository
+                .findByCode(productCode)
+                .orElseThrow(() -> new EntityNotFoundException("Product not found"));
+        assertEquals(updateCommand.name(), updatedProduct.getName(), "Product name should match the updated value");
+        assertEquals(
+                updateCommand.description(),
+                updatedProduct.getDescription(),
+                "Product description should match the updated value");
+        assertEquals(
+                updateCommand.imageUrl(),
+                updatedProduct.getImageUrl(),
+                "Product image URL should match the updated value");
+        assertEquals(
+                updateCommand.updatedBy(),
+                updatedProduct.getUpdatedBy(),
+                "Product updatedBy should match the updater's value");
+    }
+
+    @Test
+    void testUpdateNonExistingProduct() {
+        String nonExistentCode = "non-existent";
+        var updateCommand =
+                new UpdateProductCommand(nonExistentCode, "Some Name", "Some Description", "some-image-url", "user");
+        EntityNotFoundException exception =
+                assertThrows(EntityNotFoundException.class, () -> productService.updateProduct(updateCommand));
+        assertTrue(exception.getMessage().contains(updateCommand.code()), "Error message must contain product code");
+    }
+}


### PR DESCRIPTION
Add error handling for the case where a product is not found during the update process. Ensure that a clear and meaningful exception message is provided when the product with the specified code does not exist. Use `EntityNotFoundException` from the `jakarta.persistence` package for this purpose. Also add a comprehensive test suite by creating new API - ProductApiTest, repository - ProductRepositoryTest, and service ProductServiceTest test files. Also, make the TestcontainersConfiguration class public so it can be accessed by the new tests.