### PR TITLE
Update the FeatureController to allow fetching features by product code in addition to release code.

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.FeatureControllerTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/api/dtos/FeatureDto.java
+++ b/src/main/java/com/sivalabs/ft/features/api/dtos/FeatureDto.java
@@ -1,5 +1,6 @@
 package com.sivalabs.ft.features.api.dtos;
 
+import com.sivalabs.ft.features.domain.FeatureStatus;
 import java.io.Serializable;
 import java.time.Instant;
 
@@ -8,7 +9,7 @@ public record FeatureDto(
         String code,
         String title,
         String description,
-        String status,
+        FeatureStatus status,
         String assignedTo,
         String createdBy,
         Instant createdAt,

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
@@ -11,6 +11,8 @@ interface FeatureRepository extends ListCrudRepository<Feature, Long> {
 
     List<Feature> findByReleaseCode(String releaseCode);
 
+    List<Feature> findByProductCode(String productCode);
+
     @Modifying
     void deleteByCode(String code);
 

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureService.java
@@ -29,8 +29,12 @@ public class FeatureService {
         return featureRepository.findByCode(code);
     }
 
-    public List<Feature> findFeatures(String releaseCode) {
+    public List<Feature> findFeaturesByRelease(String releaseCode) {
         return featureRepository.findByReleaseCode(releaseCode);
+    }
+
+    public List<Feature> findFeaturesByProduct(String productCode) {
+        return featureRepository.findByProductCode(productCode);
     }
 
     public boolean isFeatureExists(String code) {

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureStatus.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureStatus.java
@@ -2,7 +2,7 @@ package com.sivalabs.ft.features.domain;
 
 public enum FeatureStatus {
     NEW,
-    IN_DEVELOPMENT,
+    IN_PROGRESS,
     ON_HOLD,
     RELEASED
 }

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureControllerTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.sivalabs.ft.features.AbstractIT;
 import com.sivalabs.ft.features.WithMockOAuth2User;
 import com.sivalabs.ft.features.api.dtos.FeatureDto;
+import com.sivalabs.ft.features.domain.FeatureStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -81,7 +82,7 @@ class FeatureControllerTests extends AbstractIT {
                 "title": "Updated Feature",
                 "description": "Updated description",
                 "assignedTo": "jane.doe",
-                "status": "IN_DEVELOPMENT"
+                "status": "IN_PROGRESS"
             }
             """;
 
@@ -101,7 +102,7 @@ class FeatureControllerTests extends AbstractIT {
                     assertThat(dto.title()).isEqualTo("Updated Feature");
                     assertThat(dto.description()).isEqualTo("Updated description");
                     assertThat(dto.assignedTo()).isEqualTo("jane.doe");
-                    assertThat(dto.status()).isEqualTo("IN_DEVELOPMENT");
+                    assertThat(dto.status()).isEqualTo(FeatureStatus.IN_PROGRESS);
                 });
     }
 


### PR DESCRIPTION
Update the FeatureController to allow fetching features by product code in addition to release code. Ensure that the API requires either a product code or a release code, but not both. Implement the necessary service and repository methods to support this functionality. Change the FeatureDto to use the FeatureStatus enum instead of a String for status. Also, adjust the FeatureStatus enum to rename "IN_DEVELOPMENT" to "IN_PROGRESS".