### PR TITLE
Notification delivery status stays PENDING forever

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "EmailNotificationIntegrationTest",
+      "ReleaseCascadeNotificationIntegrationTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/domain/EmailService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/EmailService.java
@@ -2,6 +2,7 @@ package com.sivalabs.ft.features.domain;
 
 import com.sivalabs.ft.features.ApplicationProperties;
 import com.sivalabs.ft.features.domain.dtos.NotificationDto;
+import com.sivalabs.ft.features.domain.exceptions.NotificationNotDeliveredException;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,9 +24,10 @@ public class EmailService {
 
     /**
      * Send a notification email with a tracking pixel.
-     * Failures are logged but do not propagate to prevent notification creation from being blocked.
+     * Throws {@link NotificationNotDeliveredException} on failure so the caller can update delivery status.
      */
-    public void sendNotificationEmail(NotificationDto notification, String recipientEmail) {
+    public void sendNotificationEmail(NotificationDto notification, String recipientEmail)
+            throws NotificationNotDeliveredException {
         try {
             var message = mailSender.createMimeMessage();
             var helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -46,6 +48,8 @@ public class EmailService {
                     notification.eventType(),
                     Instant.now(),
                     e.getMessage());
+            throw new NotificationNotDeliveredException(
+                    "Failure happened during sending notification with id {}".formatted(notification.id()));
         }
     }
 

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
@@ -34,6 +34,22 @@ interface NotificationRepository extends ListCrudRepository<Notification, UUID> 
     int markAsUnread(UUID id, String recipientUserId);
 
     /**
+     * Mark notification as delivered
+     */
+    @Modifying
+    @Query(
+            "UPDATE Notification n SET n.deliveryStatus = 'DELIVERED' WHERE n.id = :id AND n.recipientUserId = :recipientUserId")
+    int markAsDelivered(UUID id, String recipientUserId);
+
+    /**
+     * Mark notification as failed
+     */
+    @Modifying
+    @Query(
+            "UPDATE Notification n SET n.deliveryStatus = 'FAILED' WHERE n.id = :id AND n.recipientUserId = :recipientUserId")
+    int markAsFailed(UUID id, String recipientUserId);
+
+    /**
      * Mark notification as read by ID only (for tracking pixel - no recipient check).
      * Idempotent: only updates if not already read.
      */

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
@@ -2,6 +2,7 @@ package com.sivalabs.ft.features.domain;
 
 import com.sivalabs.ft.features.domain.dtos.NotificationDto;
 import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.exceptions.NotificationNotDeliveredException;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.NotificationMapper;
 import com.sivalabs.ft.features.domain.models.DeliveryStatus;
@@ -66,7 +67,12 @@ public class NotificationService {
         NotificationDto dto = notificationMapper.toDto(notification);
 
         if (recipientEmail != null) {
-            emailService.sendNotificationEmail(dto, recipientEmail);
+            try {
+                emailService.sendNotificationEmail(dto, recipientEmail);
+                notificationRepository.markAsDelivered(notification.getId(), recipientUserId);
+            } catch (NotificationNotDeliveredException exception) {
+                notificationRepository.markAsFailed(notification.getId(), recipientUserId);
+            }
         } else {
             log.debug("No email address found for user {}, skipping email delivery", recipientUserId);
         }
@@ -113,7 +119,12 @@ public class NotificationService {
 
         for (NotificationDto dto : dtos) {
             if (dto.recipientEmail() != null) {
-                emailService.sendNotificationEmail(dto, dto.recipientEmail());
+                try {
+                    emailService.sendNotificationEmail(dto, dto.recipientEmail());
+                    notificationRepository.markAsDelivered(dto.id(), dto.recipientUserId());
+                } catch (NotificationNotDeliveredException exception) {
+                    notificationRepository.markAsFailed(dto.id(), dto.recipientUserId());
+                }
             } else {
                 log.debug("No email address found for user {}, skipping email delivery", dto.recipientUserId());
             }

--- a/src/main/java/com/sivalabs/ft/features/domain/exceptions/NotificationNotDeliveredException.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/exceptions/NotificationNotDeliveredException.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.exceptions;
+
+public class NotificationNotDeliveredException extends Exception {
+    public NotificationNotDeliveredException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/EmailNotificationIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/EmailNotificationIntegrationTest.java
@@ -1,0 +1,210 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
+import com.sivalabs.ft.features.api.models.UpdateReleasePayload;
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Integration tests for the email notification system.
+ * Tests email sending and delivery failure handling.
+ */
+@Sql("/test-data.sql")
+@Import(MockJavaMailSenderConfig.class)
+class EmailNotificationIntegrationTest extends AbstractIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM notifications");
+        reset(javaMailSender);
+        // Return new MimeMessage for each call so we can inspect content
+        when(javaMailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldCreateNotificationEvenWhenEmailSendingFails() throws Exception {
+        // Given - Configure mail sender to throw exception
+        doThrow(new MailSendException("SMTP server unavailable"))
+                .when(javaMailSender)
+                .send(any(MimeMessage.class));
+
+        CreateFeaturePayload payload = new CreateFeaturePayload(
+                "intellij", "Email Failure Test", "Test notification despite email failure", null, "user1");
+
+        // When - Create feature (email sending will fail)
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Then - Feature should still be created
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Notification should be saved in the database
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "user1");
+        assertThat(count).isEqualTo(1);
+
+        // Verify email send was attempted (will fail due to mock configuration)
+        verify(javaMailSender, timeout(2000).times(1)).send(any(MimeMessage.class));
+
+        // Verify delivery_status is updated to FAILED
+        String deliveryStatus = jdbcTemplate.queryForObject(
+                "SELECT delivery_status FROM notifications WHERE recipient_user_id = ?", String.class, "user1");
+        assertThat(deliveryStatus)
+                .as("delivery_status should be FAILED after email send failure")
+                .isEqualTo("FAILED");
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "creator")
+    void shouldStoreRecipientEmailInNotification() throws Exception {
+        // Given
+        CreateFeaturePayload payload = new CreateFeaturePayload(
+                "intellij", "Recipient Email Test", "Test recipient email storage", null, "user1");
+
+        // When - Create feature
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Then - Verify recipient_email column is populated
+        String recipientEmail = jdbcTemplate.queryForObject(
+                "SELECT recipient_email FROM notifications WHERE recipient_user_id = ?", String.class, "user1");
+
+        assertThat(recipientEmail)
+                .as("recipient_email should match email from users table")
+                .isEqualTo("user1@example.com");
+
+        // Verify delivery_status is updated to DELIVERED after successful email send
+        String deliveryStatus = jdbcTemplate.queryForObject(
+                "SELECT delivery_status FROM notifications WHERE recipient_user_id = ?", String.class, "user1");
+        assertThat(deliveryStatus)
+                .as("delivery_status should be DELIVERED after successful email send")
+                .isEqualTo("DELIVERED");
+    }
+
+    /**
+     * Prepares a release with a feature assigned to user1, advanced to IN_PROGRESS,
+     * with notifications cleared and mail sender mock reset — ready for the final
+     * status transition that triggers batch notifications.
+     */
+    private void prepareReleaseForBatchNotifications() throws Exception {
+        CreateFeaturePayload featurePayload = new CreateFeaturePayload(
+                "intellij", "Batch Test Feature", "Test batch notifications", "IDEA-2025.1-DRAFT", "user1");
+
+        var createResult = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(featurePayload))
+                .exchange();
+        assertThat(createResult).hasStatus(HttpStatus.CREATED);
+
+        // Advance release through valid transitions: DRAFT -> PLANNED -> IN_PROGRESS
+        for (ReleaseStatus status : List.of(ReleaseStatus.PLANNED, ReleaseStatus.IN_PROGRESS)) {
+            var transitionResult = mvc.put()
+                    .uri("/api/releases/{code}", "IDEA-2025.1-DRAFT")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(new UpdateReleasePayload(null, status, null)))
+                    .exchange();
+            assertThat(transitionResult).hasStatus2xxSuccessful();
+        }
+
+        // Clear notifications from feature creation and status transitions
+        jdbcTemplate.execute("DELETE FROM notifications");
+        reset(javaMailSender);
+        when(javaMailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+    }
+
+    private List<Map<String, Object>> releaseAndGetBatchNotifications() throws Exception {
+        UpdateReleasePayload releasePayload = new UpdateReleasePayload(null, ReleaseStatus.RELEASED, null);
+
+        var updateResult = mvc.put()
+                .uri("/api/releases/{code}", "IDEA-2025.1-DRAFT")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(releasePayload))
+                .exchange();
+        assertThat(updateResult).hasStatus2xxSuccessful();
+
+        List<Map<String, Object>> notifications =
+                jdbcTemplate.queryForList("SELECT delivery_status, recipient_user_id FROM notifications");
+        assertThat(notifications).isNotEmpty();
+        return notifications;
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "admin")
+    void shouldMarkBatchNotificationsAsDeliveredWhenEmailSendingSucceeds() throws Exception {
+        prepareReleaseForBatchNotifications();
+
+        List<Map<String, Object>> notifications = releaseAndGetBatchNotifications();
+
+        for (Map<String, Object> notification : notifications) {
+            assertThat(notification.get("delivery_status"))
+                    .as(
+                            "delivery_status for recipient %s should be DELIVERED after successful batch email",
+                            notification.get("recipient_user_id"))
+                    .isEqualTo("DELIVERED");
+        }
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "admin")
+    void shouldMarkBatchNotificationsAsFailedWhenEmailSendingFails() throws Exception {
+        prepareReleaseForBatchNotifications();
+
+        doThrow(new MailSendException("SMTP server unavailable"))
+                .when(javaMailSender)
+                .send(any(MimeMessage.class));
+
+        List<Map<String, Object>> notifications = releaseAndGetBatchNotifications();
+
+        for (Map<String, Object> notification : notifications) {
+            assertThat(notification.get("delivery_status"))
+                    .as(
+                            "delivery_status for recipient %s should be FAILED after batch email failure",
+                            notification.get("recipient_user_id"))
+                    .isEqualTo("FAILED");
+        }
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseCascadeNotificationIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/ReleaseCascadeNotificationIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.sivalabs.ft.features.api.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sivalabs.ft.features.AbstractIT;
@@ -8,6 +10,9 @@ import com.sivalabs.ft.features.MockOAuth2UserContextFactory;
 import com.sivalabs.ft.features.WithMockOAuth2User;
 import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
 import com.sivalabs.ft.features.api.models.CreateReleasePayload;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -18,9 +23,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -29,6 +36,7 @@ import org.springframework.test.context.jdbc.Sql;
  * Tests that notifications are created when release status changes to significant states
  */
 @Sql("/test-data.sql")
+@Import(MockJavaMailSenderConfig.class)
 class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
 
     @Autowired
@@ -36,6 +44,9 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
 
     private final MockOAuth2UserContextFactory contextFactory = new MockOAuth2UserContextFactory();
 
@@ -45,6 +56,8 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
         jdbcTemplate.execute("DELETE FROM notifications");
         jdbcTemplate.execute("DELETE FROM features WHERE code LIKE 'TEST-%'");
         jdbcTemplate.execute("DELETE FROM releases WHERE code LIKE 'TEST-%'");
+        reset(javaMailSender);
+        when(javaMailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
     }
 
     @AfterEach
@@ -53,6 +66,20 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
         jdbcTemplate.execute("DELETE FROM notifications");
         jdbcTemplate.execute("DELETE FROM features WHERE code LIKE 'TEST-%'");
         jdbcTemplate.execute("DELETE FROM releases WHERE code LIKE 'TEST-%'");
+    }
+
+    private List<Map<String, Object>> getNotificationsForUser(String userId) {
+        return jdbcTemplate.queryForList(
+                "SELECT * FROM notifications WHERE recipient_user_id = ? ORDER BY created_at", userId);
+    }
+
+    private void verifyNotificationDeliveredForUser(String userId) {
+        List<Map<String, Object>> notifications = getNotificationsForUser(userId);
+        assertThat(notifications).hasSize(1);
+        Map<String, Object> notification = notifications.getFirst();
+        assertThat(notification.get("delivery_status")).isEqualTo("DELIVERED");
+        assertThat(notification.get("read")).isEqualTo(false);
+        assertThat(notification.get("recipient_email")).isNotNull();
     }
 
     private void setAuthenticationContext(String username) {
@@ -182,7 +209,7 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
             assertThat(notification.get("event_type")).isEqualTo("RELEASE_UPDATED");
             assertThat(notification.get("link")).isEqualTo("/releases/IDEA-TEST-REL-100");
             assertThat(notification.get("read")).isEqualTo(false);
-            assertThat(notification.get("delivery_status")).isEqualTo("PENDING");
+            assertThat(notification.get("delivery_status")).isEqualTo("DELIVERED");
 
             // Verify event details contain key information (format-agnostic)
             String eventDetails = (String) notification.get("event_details");
@@ -246,19 +273,11 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
                 .content(updatePayload)
                 .exchange();
 
-        // Then - Verify notifications created
-        Integer totalNotifications = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
-        assertThat(totalNotifications).isEqualTo(1); // only developer (releaseManager excluded as updater)
-
-        // Verify developer received notification
-        Integer developerNotifications = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "developer");
-        assertThat(developerNotifications).isEqualTo(1);
+        // Then - Verify developer received exactly one delivered notification
+        verifyNotificationDeliveredForUser("developer");
 
         // Verify releaseManager (updater) did NOT receive notification
-        Integer updaterNotifications = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "releaseManager");
-        assertThat(updaterNotifications).isEqualTo(0);
+        assertThat(getNotificationsForUser("releaseManager")).isEmpty();
     }
 
     @Test
@@ -326,9 +345,8 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
                 .content(updatePayload)
                 .exchange();
 
-        // Then - Verify notifications created
-        Integer totalNotifications = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
-        assertThat(totalNotifications).isEqualTo(1);
+        // Then - Verify developer received exactly one delivered notification
+        verifyNotificationDeliveredForUser("developer");
     }
 
     @Test
@@ -458,14 +476,8 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
                 .content(updatePayload)
                 .exchange();
 
-        // Then - Verify only 1 notification created (deduplicated)
-        Integer totalNotifications = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
-        assertThat(totalNotifications).isEqualTo(1);
-
-        // Verify developer gets exactly one notification (deduplicated across multiple features)
-        Integer developerNotifications = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "developer");
-        assertThat(developerNotifications).isEqualTo(1);
+        // Then - Verify developer gets exactly one delivered notification (deduplicated across multiple features)
+        verifyNotificationDeliveredForUser("developer");
     }
 
     @Test
@@ -632,12 +644,11 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
         // Then - Verify success and notifications created
         assertThat(result).hasStatus2xxSuccessful();
 
-        Integer totalNotifications = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
-        assertThat(totalNotifications).isEqualTo(1); // developer only (releaseManager excluded)
+        verifyNotificationDeliveredForUser("developer");
 
-        // Verify notification details
-        String eventDetails = jdbcTemplate.queryForObject(
-                "SELECT event_details FROM notifications WHERE recipient_user_id = ?", String.class, "developer");
+        // Verify notification contains RELEASED in event details
+        String eventDetails =
+                (String) getNotificationsForUser("developer").getFirst().get("event_details");
         assertThat(eventDetails).contains("RELEASED");
     }
 
@@ -833,12 +844,11 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
         // Then - Verify success and notifications created
         assertThat(result).hasStatus2xxSuccessful();
 
-        Integer totalNotifications = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
-        assertThat(totalNotifications).isEqualTo(1); // developer only (releaseManager excluded)
+        verifyNotificationDeliveredForUser("developer");
 
-        // Verify notification contains CANCELLED status
-        String eventDetails = jdbcTemplate.queryForObject(
-                "SELECT event_details FROM notifications WHERE recipient_user_id = ?", String.class, "developer");
+        // Verify notification contains CANCELLED in event details
+        String eventDetails =
+                (String) getNotificationsForUser("developer").getFirst().get("event_details");
         assertThat(eventDetails).contains("CANCELLED");
     }
 
@@ -898,22 +908,11 @@ class ReleaseCascadeNotificationIntegrationTest extends AbstractIT {
         // Then - Verify both creator and assignee receive notifications
         assertThat(result).hasStatus2xxSuccessful();
 
-        Integer totalNotifications = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM notifications", Integer.class);
-        assertThat(totalNotifications).isEqualTo(2); // creator + assignee
-
-        // Verify creator received notification
-        Integer creatorNotifications = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "creator");
-        assertThat(creatorNotifications).isEqualTo(1);
-
-        // Verify assignee received notification
-        Integer assigneeNotifications = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "assignee");
-        assertThat(assigneeNotifications).isEqualTo(1);
+        // Verify both creator and assignee received delivered notifications
+        verifyNotificationDeliveredForUser("creator");
+        verifyNotificationDeliveredForUser("assignee");
 
         // Verify releaseManager (updater) did NOT receive notification
-        Integer updaterNotifications = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "releaseManager");
-        assertThat(updaterNotifications).isEqualTo(0);
+        assertThat(getNotificationsForUser("releaseManager")).isEmpty();
     }
 }

--- a/src/test/java/com/sivalabs/ft/features/domain/EmailServiceTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/EmailServiceTest.java
@@ -1,13 +1,11 @@
 package com.sivalabs.ft.features.domain;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.sivalabs.ft.features.ApplicationProperties;
 import com.sivalabs.ft.features.domain.dtos.NotificationDto;
 import com.sivalabs.ft.features.domain.models.DeliveryStatus;
 import com.sivalabs.ft.features.domain.models.NotificationEventType;
-import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import java.time.Instant;
 import java.util.UUID;
@@ -38,7 +36,7 @@ class EmailServiceTest {
     }
 
     @Test
-    void shouldSendEmailWithTrackingPixel() throws MessagingException {
+    void shouldSendEmailWithTrackingPixel() throws Exception {
         // Given
         UUID notificationId = UUID.randomUUID();
         NotificationDto notification = new NotificationDto(
@@ -64,35 +62,7 @@ class EmailServiceTest {
     }
 
     @Test
-    void shouldLogFailureAndNotThrowWhenSendFails() {
-        // Given
-        UUID notificationId = UUID.randomUUID();
-        NotificationDto notification = new NotificationDto(
-                notificationId,
-                "testuser",
-                "testuser@example.com",
-                NotificationEventType.FEATURE_UPDATED,
-                "{\"action\":\"updated\",\"actor\":\"admin\"}",
-                "/features/IDEA-1",
-                Instant.now(),
-                false,
-                null,
-                DeliveryStatus.PENDING);
-
-        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
-        doThrow(new RuntimeException("SMTP connection refused"))
-                .when(mailSender)
-                .send(any(MimeMessage.class));
-
-        // When - should not throw
-        emailService.sendNotificationEmail(notification, "testuser@example.com");
-
-        // Then - failure was swallowed (logged only)
-        verify(mailSender).send(mimeMessage);
-    }
-
-    @Test
-    void shouldHandleNullEventDetails() throws MessagingException {
+    void shouldHandleNullEventDetails() throws Exception {
         // Given
         UUID notificationId = UUID.randomUUID();
         NotificationDto notification = new NotificationDto(

--- a/src/test/java/com/sivalabs/ft/features/testsupport/MockJavaMailSenderConfig.java
+++ b/src/test/java/com/sivalabs/ft/features/testsupport/MockJavaMailSenderConfig.java
@@ -1,0 +1,26 @@
+package com.sivalabs.ft.features.testsupport;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+
+/**
+ * Test configuration that provides a mock JavaMailSender.
+ * Import this config in tests that trigger email sending to avoid real SMTP connections.
+ */
+@TestConfiguration
+public class MockJavaMailSenderConfig {
+    @Bean
+    @Primary
+    public JavaMailSender mockJavaMailSender() {
+        JavaMailSender mailSender = mock(JavaMailSender.class);
+        when(mailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+        return mailSender;
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -45,7 +45,13 @@ insert into users (username, email) values
 ('user1', 'user1@example.com'),
 ('user2', 'user2@example.com'),
 ('otheruser', 'otheruser@example.com'),
-('marcobehler', 'marcobehler@example.com');
+('marcobehler', 'marcobehler@example.com'),
+('developer', 'developer@example.com'),
+('releaseManager', 'releaseManager@example.com'),
+('productOwner', 'productOwner@example.com'),
+('userA', 'userA@example.com'),
+('userB', 'userB@example.com'),
+('userC', 'userC@example.com');
 
 insert into comments (id, feature_id, created_by, content) values
 (1, 1, 'user', 'This is a comment on feature IDEA-1'),


### PR DESCRIPTION
## Description

After an email is sent, the notification `delivery_status` still remains in `PENDING`.
It is never updated to either `DELIVERED` or `FAILED` in case of errors.

## Steps to Reproduce

Create a feature assigned to an existing user:

```json
POST /api/features
{
  "productCode": "intellij",
  "title": "Delivery Status Test",
  "description": "Test notification delivery status",
  "assigneeUserId": "bob"
}
```

Look up notification in DB:

```sql
SELECT delivery_status FROM notifications WHERE recipient_user_id = 'bob';
```

**Actual:**
```
delivery_status = "PENDING"
```

**Expected:**
```
delivery_status = "DELIVERED"
```

Similarly, when we hit failure trying to send the email – is is never updated to `FAILED` and stays `PENDING` as well.
