### PR TITLE
Invalid `date` query parameter on email failures endpoint fails with 500

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "EmailDeliveryFailureAdminApiTest#shouldReturn400ForInvalidDateFormat"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -6,7 +6,11 @@
   "build_system": "maven",
   "expected": {
     "fail_to_pass": [
-      "EmailDeliveryFailureAdminApiTest#shouldReturn400ForInvalidDateFormat"
+      "com.sivalabs.ft.features.api.controllers.EmailDeliveryFailureAdminApiTest.shouldReturn400ForInvalidDateFormat(String)[1]",
+      "com.sivalabs.ft.features.api.controllers.EmailDeliveryFailureAdminApiTest.shouldReturn400ForInvalidDateFormat(String)[2]",
+      "com.sivalabs.ft.features.api.controllers.EmailDeliveryFailureAdminApiTest.shouldReturn400ForInvalidDateFormat(String)[3]",
+      "com.sivalabs.ft.features.api.controllers.EmailDeliveryFailureAdminApiTest.shouldReturn400ForInvalidDateFormat(String)[4]",
+      "com.sivalabs.ft.features.api.controllers.EmailDeliveryFailureAdminApiTest.shouldReturn400ForInvalidDateFormat(String)[5]"
     ],
     "pass_to_pass": []
   },

--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -38,6 +39,16 @@ class GlobalExceptionHandler {
     ProblemDetail handle(BadRequestException e) {
         log.error("Bad Request", e);
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    ProblemDetail handle(MethodArgumentTypeMismatchException e) {
+        log.error("Bad Request", e);
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                BAD_REQUEST, "Invalid value for request parameter '" + e.getName() + "'");
         problemDetail.setTitle("Bad Request");
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureController.java
@@ -37,6 +37,7 @@ class EmailDeliveryFailureController {
             responses = {
                 @ApiResponse(responseCode = "200", description = "Successful response"),
                 @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "400", description = "Invalid date format"),
                 @ApiResponse(responseCode = "403", description = "Forbidden - ADMIN role required")
             })
     ResponseEntity<Page<EmailDeliveryFailureDto>> getFailures(

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureAdminApiTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureAdminApiTest.java
@@ -15,6 +15,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -169,6 +171,18 @@ class EmailDeliveryFailureAdminApiTest extends AbstractIT {
         // Only today's failure should be returned, not the 2020 one
         assertThat(content).hasSize(1);
         assertThat(content.get(0).get("recipientEmail")).isEqualTo("user1@example.com");
+    }
+
+    @ParameterizedTest(name = "should reject malformed date query param: {0}")
+    @ValueSource(strings = {"invalid-date", "2026-13-01", "2026-02-30", "2026/01/12", "2026-01-12T00:00:00Z"})
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400ForInvalidDateFormat(String invalidDate) throws Exception {
+        var response =
+                mvc.get().uri("/api/admin/email-failures?date=" + invalidDate).exchange();
+
+        assertThat(response).hasStatus(HttpStatus.BAD_REQUEST);
     }
 
     // ========== GET /api/admin/email-failures/{id} ==========


### PR DESCRIPTION
## Description

Calling `GET /api/admin/email-failures` with a malformed `date` query parameter results in a 500 Internal Server Error.

## Steps to Reproduce
Anything that isn't a proper `yyyy-MM-dd` date breaks the same way:
- `GET /api/admin/email-failures?date=invalid-date`
- `GET /api/admin/email-failures?date=2026/01/12`
- `GET /api/admin/email-failures?date=2026-01-12T00:00:00Z`

All return: `500 Internal Server Error`
Expected: `400 Bad Request`
