### PR TITLE
Feature Analytics and Usage Tracking:  API Endpoints

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -6,7 +6,9 @@
   "build_system": "maven",
   "expected": {
     "fail_to_pass": [
-      "com.sivalabs.ft.features.api.controllers.FeatureUsageControllerTests"
+      "com.sivalabs.ft.features.api.controllers.FeatureUsageControllerTests$AuthenticatedUserTests.shouldCreateUsageEventWithCompleteDataAndReturn201",
+      "com.sivalabs.ft.features.api.controllers.FeatureUsageControllerTests$AdminTests.shouldGetAllEventsWithFiltersAndPreciseValidation",
+      "com.sivalabs.ft.features.api.controllers.FeatureUsageControllerTests$ForbiddenAccessTests.shouldReturn403ForUserAccessingAllEvents"
     ],
     "pass_to_pass": []
   },

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.FeatureUsageControllerTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -3,7 +3,9 @@ package com.sivalabs.ft.features;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "ft")
-public record ApplicationProperties(EventsProperties events) {
+public record ApplicationProperties(EventsProperties events, UsageTrackingProperties usageTracking) {
 
     public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
+
+    public record UsageTrackingProperties(boolean enabled, boolean captureIp, boolean captureUserAgent) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -8,6 +8,9 @@ import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -39,6 +42,42 @@ class GlobalExceptionHandler {
         log.error("Bad Request", e);
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
         problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    ProblemDetail handle(HttpMessageNotReadableException e) {
+        log.warn("Invalid JSON or enum value", e);
+        String message = "Invalid request format";
+        if (e.getMessage() != null && e.getMessage().contains("ActionType")) {
+            message = "Invalid action type. Valid values are: "
+                    + java.util.Arrays.toString(com.sivalabs.ft.features.domain.models.ActionType.values());
+        }
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, message);
+        problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ProblemDetail handle(MethodArgumentNotValidException e) {
+        log.warn("Validation error", e);
+        String message = "Validation failed";
+        if (e.getBindingResult().hasFieldErrors()) {
+            message = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+        }
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, message);
+        problemDetail.setTitle("Validation Error");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    ProblemDetail handle(AuthorizationDeniedException e) {
+        log.warn("Access denied", e);
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(FORBIDDEN, "Access denied");
+        problemDetail.setTitle("Forbidden");
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;
     }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/CommentController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/CommentController.java
@@ -4,7 +4,9 @@ import com.sivalabs.ft.features.api.models.AddCommentPayload;
 import com.sivalabs.ft.features.api.utils.SecurityUtils;
 import com.sivalabs.ft.features.domain.Commands.CreateCommentCommand;
 import com.sivalabs.ft.features.domain.CommentService;
+import com.sivalabs.ft.features.domain.FeatureUsageService;
 import com.sivalabs.ft.features.domain.dtos.CommentDto;
+import com.sivalabs.ft.features.domain.models.ActionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,9 +25,11 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 class CommentController {
     private static final Logger log = LoggerFactory.getLogger(CommentController.class);
     private final CommentService commentService;
+    private final FeatureUsageService featureUsageService;
 
-    CommentController(CommentService commentService) {
+    CommentController(CommentService commentService, FeatureUsageService featureUsageService) {
         this.commentService = commentService;
+        this.featureUsageService = featureUsageService;
     }
 
     @PostMapping
@@ -49,6 +53,11 @@ class CommentController {
         var commentId = commentService.createComment(command);
 
         log.info("Comment added with id: {}", commentId);
+
+        if (username != null) {
+            featureUsageService.logUsage(username, addCommentPayload.featureCode(), null, ActionType.COMMENT_ADDED);
+        }
+
         return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest()
                         .path("/{commentId}")
                         .buildAndExpand(commentId)

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/FavoriteFeatureController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/FavoriteFeatureController.java
@@ -2,6 +2,8 @@ package com.sivalabs.ft.features.api.controllers;
 
 import com.sivalabs.ft.features.api.utils.SecurityUtils;
 import com.sivalabs.ft.features.domain.FavoriteFeatureService;
+import com.sivalabs.ft.features.domain.FeatureUsageService;
+import com.sivalabs.ft.features.domain.models.ActionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,9 +17,11 @@ import org.springframework.web.bind.annotation.*;
 class FavoriteFeatureController {
 
     private final FavoriteFeatureService favoriteFeatureService;
+    private final FeatureUsageService featureUsageService;
 
-    FavoriteFeatureController(FavoriteFeatureService favoriteFeatureService) {
+    FavoriteFeatureController(FavoriteFeatureService favoriteFeatureService, FeatureUsageService featureUsageService) {
         this.favoriteFeatureService = favoriteFeatureService;
+        this.featureUsageService = featureUsageService;
     }
 
     @PostMapping
@@ -32,6 +36,11 @@ class FavoriteFeatureController {
     ResponseEntity<Void> addFavoriteFeature(@PathVariable String featureCode) {
         var username = SecurityUtils.getCurrentUsername();
         favoriteFeatureService.addFavoriteFeature(username, featureCode);
+
+        if (username != null) {
+            featureUsageService.logUsage(username, featureCode, null, ActionType.FAVORITE_ADDED);
+        }
+
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -46,6 +55,11 @@ class FavoriteFeatureController {
     ResponseEntity<Void> removeFavoriteFeature(@PathVariable String featureCode) {
         var username = SecurityUtils.getCurrentUsername();
         favoriteFeatureService.removeFavoriteFeature(username, featureCode);
+
+        if (username != null) {
+            featureUsageService.logUsage(username, featureCode, null, ActionType.FAVORITE_REMOVED);
+        }
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureUsageController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/FeatureUsageController.java
@@ -1,0 +1,445 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.api.models.CreateUsageEventPayload;
+import com.sivalabs.ft.features.api.utils.SecurityUtils;
+import com.sivalabs.ft.features.domain.FeatureUsageService;
+import com.sivalabs.ft.features.domain.dtos.*;
+import com.sivalabs.ft.features.domain.models.ActionType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/usage")
+@Tag(name = "Feature Usage API")
+public class FeatureUsageController {
+    private static final Logger log = LoggerFactory.getLogger(FeatureUsageController.class);
+
+    private final FeatureUsageService featureUsageService;
+
+    public FeatureUsageController(FeatureUsageService featureUsageService) {
+        this.featureUsageService = featureUsageService;
+    }
+
+    @PostMapping("")
+    @Operation(
+            summary = "Create Usage Event",
+            description = "Create a new feature usage event",
+            responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Usage event created successfully",
+                        headers = @Header(name = "Location", description = "URI of the created usage event"),
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = FeatureUsageDto.class))),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<FeatureUsageDto> createUsageEvent(
+            @RequestBody @Valid CreateUsageEventPayload payload, HttpServletRequest request) {
+
+        String username = SecurityUtils.getCurrentUsername();
+        if (username == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        String ipAddress = request.getRemoteAddr();
+        String userAgent = request.getHeader("User-Agent");
+
+        FeatureUsageDto usageEvent = featureUsageService.createUsageEvent(
+                username,
+                payload.featureCode(),
+                payload.productCode(),
+                payload.releaseCode(),
+                payload.actionType(),
+                payload.context(),
+                ipAddress,
+                userAgent);
+
+        if (usageEvent != null) {
+            URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                    .path("/{id}")
+                    .buildAndExpand(usageEvent.id())
+                    .toUri();
+            return ResponseEntity.created(location).body(usageEvent);
+        }
+
+        return ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/stats")
+    @Operation(
+            summary = "Overall Usage Statistics",
+            description = "Get overall usage statistics with optional filters",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Statistics retrieved successfully",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = UsageStatsDto.class))),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<UsageStatsDto> getOverallStats(
+            @RequestParam(required = false) ActionType actionType,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            UsageStatsDto stats = featureUsageService.getOverallStats(actionType, start, end);
+            return ResponseEntity.ok(stats);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/feature/{featureCode}/stats")
+    @Operation(
+            summary = "Feature Statistics",
+            description = "Get statistics for a specific feature",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Feature statistics retrieved successfully",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = FeatureStatsDto.class))),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<FeatureStatsDto> getFeatureStats(
+            @PathVariable String featureCode,
+            @RequestParam(required = false) ActionType actionType,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            FeatureStatsDto stats = featureUsageService.getFeatureStats(featureCode, actionType, start, end);
+            return ResponseEntity.ok(stats);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/product/{productCode}/stats")
+    @Operation(
+            summary = "Product Statistics",
+            description = "Get statistics for a specific product",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Product statistics retrieved successfully",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ProductStatsDto.class))),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<ProductStatsDto> getProductStats(
+            @PathVariable String productCode,
+            @RequestParam(required = false) ActionType actionType,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            ProductStatsDto stats = featureUsageService.getProductStats(productCode, actionType, start, end);
+            return ResponseEntity.ok(stats);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/events")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRODUCT_MANAGER')")
+    @Operation(
+            summary = "All Usage Events List",
+            description = "Get paginated usage events with optional filters (Admin/Product Manager only)",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Events retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - Admin/Product Manager role required")
+            })
+    public ResponseEntity<Page<FeatureUsageDto>> getAllEvents(
+            @RequestParam(required = false) ActionType actionType,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(required = false) String userId,
+            @RequestParam(required = false) String featureCode,
+            @RequestParam(required = false) String productCode,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            Pageable pageable = PageRequest.of(page, size);
+            Page<FeatureUsageDto> events = featureUsageService.getAllEventsPaginated(
+                    actionType, start, end, userId, featureCode, productCode, pageable);
+            return ResponseEntity.ok(events);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/feature/{featureCode}/events")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRODUCT_MANAGER')")
+    @Operation(
+            summary = "Feature Events List",
+            description = "Get paginated events for a specific feature (Admin/Product Manager only)",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Feature events retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - Admin/Product Manager role required")
+            })
+    public ResponseEntity<Page<FeatureUsageDto>> getFeatureEvents(
+            @PathVariable String featureCode,
+            @RequestParam(required = false) ActionType actionType,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            Pageable pageable = PageRequest.of(page, size);
+            Page<FeatureUsageDto> events = featureUsageService.getFeatureEventsPaginatedWithFilters(
+                    featureCode, actionType, start, end, pageable);
+            return ResponseEntity.ok(events);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/product/{productCode}/events")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRODUCT_MANAGER')")
+    @Operation(
+            summary = "Product Events List",
+            description = "Get paginated events for a specific product (Admin/Product Manager only)",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Product events retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - Admin/Product Manager role required")
+            })
+    public ResponseEntity<Page<FeatureUsageDto>> getProductEvents(
+            @PathVariable String productCode,
+            @RequestParam(required = false) ActionType actionType,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            Pageable pageable = PageRequest.of(page, size);
+            Page<FeatureUsageDto> events = featureUsageService.getProductEventsPaginatedWithFilters(
+                    productCode, actionType, start, end, pageable);
+            return ResponseEntity.ok(events);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/top-features")
+    @Operation(
+            summary = "Most Accessed Features List",
+            description = "Get list of most accessed features with usage counts",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Top features retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<List<TopItemDto>> getTopFeatures(
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(defaultValue = "10") int limit) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            List<TopItemDto> topFeatures = featureUsageService.getTopFeatures(start, end, limit);
+            return ResponseEntity.ok(topFeatures);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/top-users")
+    @Operation(
+            summary = "Most Active Users List",
+            description = "Get list of most active users with activity counts",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Top users retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<List<TopItemDto>> getTopUsers(
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(defaultValue = "10") int limit) {
+
+        try {
+            Instant start = startDate != null ? Instant.parse(startDate) : null;
+            Instant end = endDate != null ? Instant.parse(endDate) : null;
+
+            // Validate date range logic
+            if (start != null && end != null && start.isAfter(end)) {
+                log.warn("Invalid date range: startDate {} is after endDate {}", start, end);
+                return ResponseEntity.badRequest().build();
+            }
+
+            List<TopItemDto> topUsers = featureUsageService.getTopUsers(start, end, limit);
+            return ResponseEntity.ok(topUsers);
+        } catch (DateTimeParseException e) {
+            log.warn("Invalid date format: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/user/{userId}")
+    @Operation(
+            summary = "User Usage Events",
+            description = "Get paginated usage events for a specific user",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "User events retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<Page<FeatureUsageDto>> getUserEvents(
+            @PathVariable String userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FeatureUsageDto> events = featureUsageService.getUserEvents(userId, pageable);
+        return ResponseEntity.ok(events);
+    }
+
+    @GetMapping("/feature/{featureCode}")
+    @Operation(
+            summary = "Feature Usage Events",
+            description = "Get paginated usage events for a specific feature",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Feature events retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<Page<FeatureUsageDto>> getFeatureEventsPaginated(
+            @PathVariable String featureCode,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FeatureUsageDto> events = featureUsageService.getFeatureEventsPaginated(featureCode, pageable);
+        return ResponseEntity.ok(events);
+    }
+
+    @GetMapping("/product/{productCode}")
+    @Operation(
+            summary = "Product Usage Events",
+            description = "Get paginated usage events for a specific product",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Product events retrieved successfully"),
+                @ApiResponse(responseCode = "400", description = "Invalid parameters"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    public ResponseEntity<Page<FeatureUsageDto>> getProductEventsPaginated(
+            @PathVariable String productCode,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FeatureUsageDto> events = featureUsageService.getProductEventsPaginated(productCode, pageable);
+        return ResponseEntity.ok(events);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/ProductController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/ProductController.java
@@ -5,8 +5,10 @@ import com.sivalabs.ft.features.api.models.UpdateProductPayload;
 import com.sivalabs.ft.features.api.utils.SecurityUtils;
 import com.sivalabs.ft.features.domain.Commands.CreateProductCommand;
 import com.sivalabs.ft.features.domain.Commands.UpdateProductCommand;
+import com.sivalabs.ft.features.domain.FeatureUsageService;
 import com.sivalabs.ft.features.domain.ProductService;
 import com.sivalabs.ft.features.domain.dtos.ProductDto;
+import com.sivalabs.ft.features.domain.models.ActionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -14,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -35,9 +38,11 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 class ProductController {
     private static final Logger log = LoggerFactory.getLogger(ProductController.class);
     private final ProductService productService;
+    private final FeatureUsageService featureUsageService;
 
-    ProductController(ProductService productService) {
+    ProductController(ProductService productService, FeatureUsageService featureUsageService) {
         this.productService = productService;
+        this.featureUsageService = featureUsageService;
     }
 
     @GetMapping("")
@@ -71,11 +76,28 @@ class ProductController {
                                         schema = @Schema(implementation = ProductDto.class))),
                 @ApiResponse(responseCode = "404", description = "Product not found")
             })
-    ResponseEntity<ProductDto> getProduct(@PathVariable String code) {
-        return productService
+    ResponseEntity<ProductDto> getProduct(@PathVariable String code, HttpServletRequest request) {
+        var username = SecurityUtils.getCurrentUsername();
+        var result = productService
                 .findProductByCode(code)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+
+        // Log for both authorized and anonymous users
+        if (result.getStatusCode().is2xxSuccessful()) {
+            String userId = username != null ? username : "anonymous";
+            featureUsageService.logUsage(
+                    userId,
+                    null,
+                    code,
+                    null,
+                    ActionType.PRODUCT_VIEWED,
+                    null,
+                    request.getRemoteAddr(),
+                    request.getHeader("User-Agent"));
+        }
+
+        return result;
     }
 
     @PostMapping("")
@@ -101,6 +123,11 @@ class ProductController {
                 payload.code(), payload.prefix(), payload.name(), payload.description(), payload.imageUrl(), username);
         Long id = productService.createProduct(cmd);
         log.info("Created product with id {}", id);
+
+        if (username != null) {
+            featureUsageService.logUsage(username, null, payload.code(), ActionType.PRODUCT_CREATED);
+        }
+
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{code}")
                 .buildAndExpand(payload.code())
@@ -123,5 +150,9 @@ class ProductController {
         var cmd = new UpdateProductCommand(
                 code, payload.prefix(), payload.name(), payload.description(), payload.imageUrl(), username);
         productService.updateProduct(cmd);
+
+        if (username != null) {
+            featureUsageService.logUsage(username, null, code, ActionType.PRODUCT_UPDATED);
+        }
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/api/models/CreateUsageEventPayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/CreateUsageEventPayload.java
@@ -1,0 +1,12 @@
+package com.sivalabs.ft.features.api.models;
+
+import com.sivalabs.ft.features.domain.models.ActionType;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record CreateUsageEventPayload(
+        @NotNull(message = "Action type is required") ActionType actionType,
+        String featureCode,
+        String productCode,
+        String releaseCode,
+        Map<String, Object> context) {}

--- a/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
@@ -13,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 class SecurityConfig {
 
     @Bean

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageRepository.java
@@ -1,0 +1,270 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.FeatureUsage;
+import com.sivalabs.ft.features.domain.models.ActionType;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FeatureUsageRepository extends JpaRepository<FeatureUsage, Long> {
+
+    // Find by feature code (paginated)
+    Page<FeatureUsage> findByFeatureCodeOrderByTimestampDesc(String featureCode, Pageable pageable);
+
+    // Find by product code (paginated)
+    Page<FeatureUsage> findByProductCodeOrderByTimestampDesc(String productCode, Pageable pageable);
+
+    // Find by user id
+    Page<FeatureUsage> findByUserIdOrderByTimestampDesc(String userId, Pageable pageable);
+
+    // Find with filters (paginated)
+    @Query(
+            """
+            SELECT fu FROM FeatureUsage fu
+            WHERE (CAST(:userId AS string) IS NULL OR fu.userId = :userId)
+            AND (CAST(:featureCode AS string) IS NULL OR fu.featureCode = :featureCode)
+            AND (CAST(:productCode AS string) IS NULL OR fu.productCode = :productCode)
+            AND (CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType)
+            AND (CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate)
+            AND (CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)
+            ORDER BY fu.timestamp DESC
+            """)
+    Page<FeatureUsage> findWithFiltersPaginated(
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            @Param("userId") String userId,
+            @Param("featureCode") String featureCode,
+            @Param("productCode") String productCode,
+            Pageable pageable);
+    // Find feature events with filters (paginated)
+    @Query(
+            """
+            SELECT fu FROM FeatureUsage fu
+            WHERE fu.featureCode = :featureCode
+            AND (CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType)
+            AND (CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate)
+            AND (CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)
+            ORDER BY fu.timestamp DESC
+            """)
+    Page<FeatureUsage> findFeatureEventsWithFiltersPaginated(
+            @Param("featureCode") String featureCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            Pageable pageable);
+
+    // Find product events with filters (paginated)
+    @Query(
+            """
+            SELECT fu FROM FeatureUsage fu
+            WHERE fu.productCode = :productCode
+            AND (CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType)
+            AND (CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate)
+            AND (CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)
+            ORDER BY fu.timestamp DESC
+            """)
+    Page<FeatureUsage> findProductEventsWithFiltersPaginated(
+            @Param("productCode") String productCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            Pageable pageable);
+
+    // Statistics queries
+    @Query(
+            """
+            SELECT COUNT(fu) FROM FeatureUsage fu
+            WHERE (CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType)
+            AND (CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate)
+            AND (CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)
+            """)
+    long countWithFilters(
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    @Query(
+            """
+            SELECT COUNT(DISTINCT fu.userId) FROM FeatureUsage fu
+            WHERE (CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType)
+            AND (CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate)
+            AND (CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)
+            """)
+    long countUniqueUsersWithFilters(
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    @Query(
+            """
+            SELECT COUNT(DISTINCT fu.featureCode) FROM FeatureUsage fu
+            WHERE fu.featureCode IS NOT NULL
+            AND (CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType)
+            AND (CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate)
+            AND (CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)
+            """)
+    long countUniqueFeaturesWithFilters(
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    @Query(
+            """
+            SELECT COUNT(DISTINCT fu.productCode) FROM FeatureUsage fu
+            WHERE fu.productCode IS NOT NULL
+            AND (CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType)
+            AND (CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate)
+            AND (CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)
+            """)
+    long countUniqueProductsWithFilters(
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+    // Feature-specific statistics
+    @Query("SELECT COUNT(fu) FROM FeatureUsage fu WHERE fu.featureCode = :featureCode AND "
+            + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)")
+    long countByFeatureCodeWithFilters(
+            @Param("featureCode") String featureCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    @Query("SELECT COUNT(DISTINCT fu.userId) FROM FeatureUsage fu WHERE fu.featureCode = :featureCode AND "
+            + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)")
+    long countUniqueUsersByFeatureCodeWithFilters(
+            @Param("featureCode") String featureCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    // Product-specific statistics
+    @Query("SELECT COUNT(fu) FROM FeatureUsage fu WHERE fu.productCode = :productCode AND "
+            + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)")
+    long countByProductCodeWithFilters(
+            @Param("productCode") String productCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    @Query("SELECT COUNT(DISTINCT fu.userId) FROM FeatureUsage fu WHERE fu.productCode = :productCode AND "
+            + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)")
+    long countUniqueUsersByProductCodeWithFilters(
+            @Param("productCode") String productCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    @Query(
+            "SELECT COUNT(DISTINCT fu.featureCode) FROM FeatureUsage fu WHERE fu.productCode = :productCode AND fu.featureCode IS NOT NULL AND "
+                    + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+                    + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+                    + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate)")
+    long countUniqueFeaturesByProductCodeWithFilters(
+            @Param("productCode") String productCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    // Feature usage by product for feature stats
+    @Query(
+            "SELECT fu.productCode, COUNT(fu) FROM FeatureUsage fu WHERE fu.featureCode = :featureCode AND fu.productCode IS NOT NULL AND "
+                    + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+                    + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+                    + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+                    + "GROUP BY fu.productCode ORDER BY COUNT(fu) DESC")
+    List<Object[]> findFeatureUsageByProduct(
+            @Param("featureCode") String featureCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+
+    // Top users for feature
+    @Query("SELECT fu.userId, COUNT(fu) FROM FeatureUsage fu WHERE fu.featureCode = :featureCode AND "
+            + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+            + "GROUP BY fu.userId ORDER BY COUNT(fu) DESC")
+    List<Object[]> findTopUsersByFeatureCode(
+            @Param("featureCode") String featureCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            Pageable pageable);
+
+    // Top features for product
+    @Query(
+            "SELECT fu.featureCode, COUNT(fu) FROM FeatureUsage fu WHERE fu.productCode = :productCode AND fu.featureCode IS NOT NULL AND "
+                    + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+                    + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+                    + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+                    + "GROUP BY fu.featureCode ORDER BY COUNT(fu) DESC")
+    List<Object[]> findTopFeaturesByProductCode(
+            @Param("productCode") String productCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            Pageable pageable);
+
+    // Top users for product
+    @Query("SELECT fu.userId, COUNT(fu) FROM FeatureUsage fu WHERE fu.productCode = :productCode AND "
+            + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+            + "GROUP BY fu.userId ORDER BY COUNT(fu) DESC")
+    List<Object[]> findTopUsersByProductCode(
+            @Param("productCode") String productCode,
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate,
+            Pageable pageable);
+
+    // Missing methods that were accidentally removed
+
+    // Top features
+    @Query("SELECT fu.featureCode, COUNT(fu) FROM FeatureUsage fu WHERE fu.featureCode IS NOT NULL AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+            + "GROUP BY fu.featureCode ORDER BY COUNT(fu) DESC")
+    List<Object[]> findTopFeatures(
+            @Param("startDate") Instant startDate, @Param("endDate") Instant endDate, Pageable pageable);
+
+    // Top users
+    @Query("SELECT fu.userId, COUNT(fu) FROM FeatureUsage fu WHERE "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+            + "GROUP BY fu.userId ORDER BY COUNT(fu) DESC")
+    List<Object[]> findTopUsers(
+            @Param("startDate") Instant startDate, @Param("endDate") Instant endDate, Pageable pageable);
+
+    // Top products
+    @Query("SELECT fu.productCode, COUNT(fu) FROM FeatureUsage fu WHERE fu.productCode IS NOT NULL AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+            + "GROUP BY fu.productCode ORDER BY COUNT(fu) DESC")
+    List<Object[]> findTopProducts(
+            @Param("startDate") Instant startDate, @Param("endDate") Instant endDate, Pageable pageable);
+
+    // Usage by action type
+    @Query("SELECT fu.actionType, COUNT(fu) FROM FeatureUsage fu WHERE "
+            + "(CAST(:actionType AS string) IS NULL OR fu.actionType = :actionType) AND "
+            + "(CAST(:startDate AS timestamp) IS NULL OR fu.timestamp >= :startDate) AND "
+            + "(CAST(:endDate AS timestamp) IS NULL OR fu.timestamp <= :endDate) "
+            + "GROUP BY fu.actionType")
+    List<Object[]> findUsageByActionType(
+            @Param("actionType") ActionType actionType,
+            @Param("startDate") Instant startDate,
+            @Param("endDate") Instant endDate);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureUsageService.java
@@ -1,0 +1,349 @@
+package com.sivalabs.ft.features.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.domain.dtos.*;
+import com.sivalabs.ft.features.domain.entities.FeatureUsage;
+import com.sivalabs.ft.features.domain.mappers.FeatureUsageMapper;
+import com.sivalabs.ft.features.domain.models.ActionType;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FeatureUsageService {
+    private static final Logger log = LoggerFactory.getLogger(FeatureUsageService.class);
+
+    private final FeatureUsageRepository featureUsageRepository;
+    private final ObjectMapper objectMapper;
+    private final com.sivalabs.ft.features.ApplicationProperties applicationProperties;
+    private final FeatureUsageMapper featureUsageMapper;
+
+    public FeatureUsageService(
+            FeatureUsageRepository featureUsageRepository,
+            ObjectMapper objectMapper,
+            com.sivalabs.ft.features.ApplicationProperties applicationProperties,
+            FeatureUsageMapper featureUsageMapper) {
+        this.featureUsageRepository = featureUsageRepository;
+        this.objectMapper = objectMapper;
+        this.applicationProperties = applicationProperties;
+        this.featureUsageMapper = featureUsageMapper;
+    }
+
+    @Transactional
+    public void logUsage(
+            String userId,
+            String featureCode,
+            String productCode,
+            String releaseCode,
+            ActionType actionType,
+            Map<String, Object> contextData,
+            String ipAddress,
+            String userAgent) {
+        if (!applicationProperties.usageTracking().enabled()) {
+            return;
+        }
+        try {
+            // Enrich context with anonymized device fingerprint for anonymous users
+            Map<String, Object> enrichedContext = contextData != null ? new HashMap<>(contextData) : new HashMap<>();
+
+            if (ipAddress != null && userAgent != null) {
+                // Create device fingerprint: hash(device:ip)
+                String deviceFingerprint = createDeviceFingerprint(ipAddress, userAgent);
+                enrichedContext.put("deviceFingerprint", deviceFingerprint);
+
+                // Extract location from IP (placeholder - would use GeoIP service in production)
+                String location = extractLocation(ipAddress);
+                if (location != null) {
+                    enrichedContext.put("location", location);
+                }
+            }
+
+            String contextJson = null;
+            if (!enrichedContext.isEmpty()) {
+                try {
+                    contextJson = objectMapper.writeValueAsString(enrichedContext);
+                } catch (JsonProcessingException e) {
+                    log.warn("Failed to serialize context data", e);
+                }
+            }
+
+            var featureUsage = new FeatureUsage();
+            featureUsage.setUserId(userId);
+            featureUsage.setFeatureCode(featureCode);
+            featureUsage.setProductCode(productCode);
+            featureUsage.setReleaseCode(releaseCode);
+            featureUsage.setActionType(actionType);
+            featureUsage.setTimestamp(Instant.now());
+            featureUsage.setContext(contextJson);
+
+            featureUsageRepository.save(featureUsage);
+            log.debug(
+                    "Logged usage: user={}, feature={}, product={}, release={}, action={}",
+                    userId,
+                    featureCode,
+                    productCode,
+                    releaseCode,
+                    actionType);
+        } catch (Exception e) {
+            log.error("Failed to log usage event", e);
+            // Don't throw exception to avoid breaking the main flow
+        }
+    }
+
+    @Transactional
+    public void logUsage(String userId, String featureCode, String productCode, ActionType actionType) {
+        logUsage(userId, featureCode, productCode, null, actionType, null, null, null);
+    }
+
+    @Transactional
+    public void logUsage(
+            String userId, String featureCode, String productCode, ActionType actionType, Map<String, Object> context) {
+        logUsage(userId, featureCode, productCode, null, actionType, context, null, null);
+    }
+
+    @Transactional
+    public void logUsage(
+            String userId, String featureCode, String productCode, String releaseCode, ActionType actionType) {
+        logUsage(userId, featureCode, productCode, releaseCode, actionType, null, null, null);
+    }
+
+    /**
+     * Create device fingerprint using hash(device:ip) for anonymous user tracking.
+     * GDPR compliant - uses hash instead of storing actual IP.
+     */
+    private String createDeviceFingerprint(String ipAddress, String userAgent) {
+        try {
+            String combined = userAgent + ":" + ipAddress;
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(combined.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0');
+                hexString.append(hex);
+            }
+            // Return first 16 characters for shorter fingerprint
+            return hexString.substring(0, 16);
+        } catch (NoSuchAlgorithmException e) {
+            log.warn("Failed to create device fingerprint", e);
+            return null;
+        }
+    }
+
+    /**
+     * Extract location from IP address.
+     * Placeholder implementation - in production would use GeoIP service.
+     * Returns only country code for GDPR compliance (not city/precise location).
+     */
+    private String extractLocation(String ipAddress) {
+        // Placeholder: In production, use MaxMind GeoIP2 or similar service
+        // For now, return null or "UNKNOWN"
+        // Example: return geoIpService.getCountryCode(ipAddress);
+        return null;
+    }
+
+    // New API methods for programmatic usage tracking
+
+    @Transactional
+    public FeatureUsageDto createUsageEvent(
+            String userId,
+            String featureCode,
+            String productCode,
+            String releaseCode,
+            ActionType actionType,
+            Map<String, Object> context,
+            String ipAddress,
+            String userAgent) {
+
+        logUsage(userId, featureCode, productCode, releaseCode, actionType, context, ipAddress, userAgent);
+
+        // Find the most recent usage event for this user and action
+        Page<FeatureUsage> recentUsage = featureUsageRepository.findWithFiltersPaginated(
+                actionType, null, null, userId, featureCode, productCode, PageRequest.of(0, 1));
+
+        if (!recentUsage.isEmpty()) {
+            FeatureUsage usage = recentUsage.getContent().get(0);
+            return new FeatureUsageDto(
+                    usage.getId(),
+                    usage.getUserId(),
+                    usage.getFeatureCode(),
+                    usage.getProductCode(),
+                    usage.getReleaseCode(),
+                    usage.getActionType(),
+                    usage.getTimestamp(),
+                    usage.getContext(),
+                    ipAddress,
+                    userAgent);
+        }
+
+        return null;
+    }
+
+    // Statistics methods
+    public UsageStatsDto getOverallStats(ActionType actionType, Instant startDate, Instant endDate) {
+        long totalUsageCount = featureUsageRepository.countWithFilters(actionType, startDate, endDate);
+        long uniqueUserCount = featureUsageRepository.countUniqueUsersWithFilters(actionType, startDate, endDate);
+        long uniqueFeatureCount = featureUsageRepository.countUniqueFeaturesWithFilters(actionType, startDate, endDate);
+        long uniqueProductCount = featureUsageRepository.countUniqueProductsWithFilters(actionType, startDate, endDate);
+
+        Map<ActionType, Long> usageByActionType =
+                featureUsageRepository.findUsageByActionType(actionType, startDate, endDate).stream()
+                        .collect(Collectors.toMap(row -> (ActionType) row[0], row -> (Long) row[1]));
+
+        List<TopItemDto> topFeatures =
+                featureUsageRepository.findTopFeatures(startDate, endDate, PageRequest.of(0, 10)).stream()
+                        .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                        .collect(Collectors.toList());
+
+        List<TopItemDto> topProducts =
+                featureUsageRepository.findTopProducts(startDate, endDate, PageRequest.of(0, 10)).stream()
+                        .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                        .collect(Collectors.toList());
+
+        List<TopItemDto> topUsers =
+                featureUsageRepository.findTopUsers(startDate, endDate, PageRequest.of(0, 10)).stream()
+                        .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                        .collect(Collectors.toList());
+
+        return new UsageStatsDto(
+                totalUsageCount,
+                uniqueUserCount,
+                uniqueFeatureCount,
+                uniqueProductCount,
+                usageByActionType,
+                topFeatures,
+                topProducts,
+                topUsers);
+    }
+
+    public FeatureStatsDto getFeatureStats(
+            String featureCode, ActionType actionType, Instant startDate, Instant endDate) {
+        long totalUsageCount =
+                featureUsageRepository.countByFeatureCodeWithFilters(featureCode, actionType, startDate, endDate);
+        long uniqueUserCount = featureUsageRepository.countUniqueUsersByFeatureCodeWithFilters(
+                featureCode, actionType, startDate, endDate);
+
+        Map<ActionType, Long> usageByActionType =
+                featureUsageRepository.findUsageByActionType(actionType, startDate, endDate).stream()
+                        .collect(Collectors.toMap(row -> (ActionType) row[0], row -> (Long) row[1]));
+
+        List<TopItemDto> topUsers =
+                featureUsageRepository
+                        .findTopUsersByFeatureCode(featureCode, actionType, startDate, endDate, PageRequest.of(0, 10))
+                        .stream()
+                        .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                        .collect(Collectors.toList());
+
+        List<TopItemDto> usageByProduct =
+                featureUsageRepository.findFeatureUsageByProduct(featureCode, actionType, startDate, endDate).stream()
+                        .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                        .collect(Collectors.toList());
+
+        return new FeatureStatsDto(
+                featureCode, totalUsageCount, uniqueUserCount, usageByActionType, topUsers, usageByProduct);
+    }
+
+    public ProductStatsDto getProductStats(
+            String productCode, ActionType actionType, Instant startDate, Instant endDate) {
+        long totalUsageCount =
+                featureUsageRepository.countByProductCodeWithFilters(productCode, actionType, startDate, endDate);
+        long uniqueUserCount = featureUsageRepository.countUniqueUsersByProductCodeWithFilters(
+                productCode, actionType, startDate, endDate);
+        long uniqueFeatureCount = featureUsageRepository.countUniqueFeaturesByProductCodeWithFilters(
+                productCode, actionType, startDate, endDate);
+
+        Map<ActionType, Long> usageByActionType =
+                featureUsageRepository.findUsageByActionType(actionType, startDate, endDate).stream()
+                        .collect(Collectors.toMap(row -> (ActionType) row[0], row -> (Long) row[1]));
+
+        List<TopItemDto> topFeatures = featureUsageRepository
+                .findTopFeaturesByProductCode(productCode, actionType, startDate, endDate, PageRequest.of(0, 10))
+                .stream()
+                .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                .collect(Collectors.toList());
+
+        List<TopItemDto> topUsers =
+                featureUsageRepository
+                        .findTopUsersByProductCode(productCode, actionType, startDate, endDate, PageRequest.of(0, 10))
+                        .stream()
+                        .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                        .collect(Collectors.toList());
+
+        return new ProductStatsDto(
+                productCode,
+                totalUsageCount,
+                uniqueUserCount,
+                uniqueFeatureCount,
+                usageByActionType,
+                topFeatures,
+                topUsers);
+    }
+
+    // Events list methods (paginated)
+    public Page<FeatureUsageDto> getAllEventsPaginated(
+            ActionType actionType,
+            Instant startDate,
+            Instant endDate,
+            String userId,
+            String featureCode,
+            String productCode,
+            Pageable pageable) {
+        Page<FeatureUsage> events = featureUsageRepository.findWithFiltersPaginated(
+                actionType, startDate, endDate, userId, featureCode, productCode, pageable);
+        return events.map(featureUsageMapper::toDto);
+    }
+
+    public Page<FeatureUsageDto> getFeatureEventsPaginatedWithFilters(
+            String featureCode, ActionType actionType, Instant startDate, Instant endDate, Pageable pageable) {
+        Page<FeatureUsage> events = featureUsageRepository.findFeatureEventsWithFiltersPaginated(
+                featureCode, actionType, startDate, endDate, pageable);
+        return events.map(featureUsageMapper::toDto);
+    }
+
+    public Page<FeatureUsageDto> getProductEventsPaginatedWithFilters(
+            String productCode, ActionType actionType, Instant startDate, Instant endDate, Pageable pageable) {
+        Page<FeatureUsage> events = featureUsageRepository.findProductEventsWithFiltersPaginated(
+                productCode, actionType, startDate, endDate, pageable);
+        return events.map(featureUsageMapper::toDto);
+    }
+
+    // Top rankings methods
+    public List<TopItemDto> getTopFeatures(Instant startDate, Instant endDate, int limit) {
+        return featureUsageRepository.findTopFeatures(startDate, endDate, PageRequest.of(0, limit)).stream()
+                .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                .collect(Collectors.toList());
+    }
+
+    public List<TopItemDto> getTopUsers(Instant startDate, Instant endDate, int limit) {
+        return featureUsageRepository.findTopUsers(startDate, endDate, PageRequest.of(0, limit)).stream()
+                .map(row -> new TopItemDto((String) row[0], (Long) row[1]))
+                .collect(Collectors.toList());
+    }
+
+    // Paginated methods
+    public Page<FeatureUsageDto> getUserEvents(String userId, Pageable pageable) {
+        Page<FeatureUsage> events = featureUsageRepository.findByUserIdOrderByTimestampDesc(userId, pageable);
+        return events.map(featureUsageMapper::toDto);
+    }
+
+    public Page<FeatureUsageDto> getFeatureEventsPaginated(String featureCode, Pageable pageable) {
+        Page<FeatureUsage> events = featureUsageRepository.findByFeatureCodeOrderByTimestampDesc(featureCode, pageable);
+        return events.map(featureUsageMapper::toDto);
+    }
+
+    public Page<FeatureUsageDto> getProductEventsPaginated(String productCode, Pageable pageable) {
+        Page<FeatureUsage> events = featureUsageRepository.findByProductCodeOrderByTimestampDesc(productCode, pageable);
+        return events.map(featureUsageMapper::toDto);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureStatsDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureStatsDto.java
@@ -1,0 +1,13 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ActionType;
+import java.util.List;
+import java.util.Map;
+
+public record FeatureStatsDto(
+        String featureCode,
+        long totalUsageCount,
+        long uniqueUserCount,
+        Map<ActionType, Long> usageByActionType,
+        List<TopItemDto> topUsers,
+        List<TopItemDto> usageByProduct) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureUsageDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/FeatureUsageDto.java
@@ -1,0 +1,16 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ActionType;
+import java.time.Instant;
+
+public record FeatureUsageDto(
+        Long id,
+        String userId,
+        String featureCode,
+        String productCode,
+        String releaseCode,
+        ActionType actionType,
+        Instant timestamp,
+        String context,
+        String ipAddress,
+        String userAgent) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/ProductStatsDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/ProductStatsDto.java
@@ -1,0 +1,14 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ActionType;
+import java.util.List;
+import java.util.Map;
+
+public record ProductStatsDto(
+        String productCode,
+        long totalUsageCount,
+        long uniqueUserCount,
+        long uniqueFeatureCount,
+        Map<ActionType, Long> usageByActionType,
+        List<TopItemDto> topFeatures,
+        List<TopItemDto> topUsers) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/TopItemDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/TopItemDto.java
@@ -1,0 +1,3 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+public record TopItemDto(String name, Long count) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/UsageStatsDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/UsageStatsDto.java
@@ -1,0 +1,15 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import com.sivalabs.ft.features.domain.models.ActionType;
+import java.util.List;
+import java.util.Map;
+
+public record UsageStatsDto(
+        long totalUsageCount,
+        long uniqueUserCount,
+        long uniqueFeatureCount,
+        long uniqueProductCount,
+        Map<ActionType, Long> usageByActionType,
+        List<TopItemDto> topFeatures,
+        List<TopItemDto> topProducts,
+        List<TopItemDto> topUsers) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/FeatureUsage.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/FeatureUsage.java
@@ -1,0 +1,105 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import com.sivalabs.ft.features.domain.models.ActionType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "feature_usage")
+public class FeatureUsage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "feature_usage_id_gen")
+    @SequenceGenerator(name = "feature_usage_id_gen", sequenceName = "feature_usage_id_seq")
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 255) @NotNull @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Size(max = 50) @Column(name = "feature_code", length = 50)
+    private String featureCode;
+
+    @Size(max = 50) @Column(name = "product_code", length = 50)
+    private String productCode;
+
+    @Size(max = 50) @Column(name = "release_code", length = 50)
+    private String releaseCode;
+
+    @NotNull @Column(name = "action_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private ActionType actionType;
+
+    @NotNull @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "timestamp", nullable = false)
+    private Instant timestamp;
+
+    @Column(name = "context", length = Integer.MAX_VALUE)
+    private String context;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getFeatureCode() {
+        return featureCode;
+    }
+
+    public void setFeatureCode(String featureCode) {
+        this.featureCode = featureCode;
+    }
+
+    public String getProductCode() {
+        return productCode;
+    }
+
+    public void setProductCode(String productCode) {
+        this.productCode = productCode;
+    }
+
+    public String getReleaseCode() {
+        return releaseCode;
+    }
+
+    public void setReleaseCode(String releaseCode) {
+        this.releaseCode = releaseCode;
+    }
+
+    public ActionType getActionType() {
+        return actionType;
+    }
+
+    public void setActionType(ActionType actionType) {
+        this.actionType = actionType;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureUsageMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureUsageMapper.java
@@ -1,0 +1,28 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.FeatureUsageDto;
+import com.sivalabs.ft.features.domain.entities.FeatureUsage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeatureUsageMapper {
+
+    public FeatureUsageDto toDto(FeatureUsage entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return new FeatureUsageDto(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getFeatureCode(),
+                entity.getProductCode(),
+                entity.getReleaseCode(),
+                entity.getActionType(),
+                entity.getTimestamp(),
+                entity.getContext(),
+                null, // ipAddress - not stored in entity, would need to be passed separately
+                null // userAgent - not stored in entity, would need to be passed separately
+                );
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/ActionType.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/ActionType.java
@@ -1,0 +1,17 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum ActionType {
+    FEATURE_VIEWED,
+    FEATURE_CREATED,
+    FEATURE_UPDATED,
+    FEATURE_DELETED,
+    FEATURES_LISTED,
+    PRODUCT_VIEWED,
+    PRODUCT_CREATED,
+    PRODUCT_UPDATED,
+    RELEASE_VIEWED,
+    RELEASE_CREATED,
+    COMMENT_ADDED,
+    FAVORITE_ADDED,
+    FAVORITE_REMOVED
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,9 @@ ft.openapi.contact.email=support@sivalabs.in
 ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
+ft.usage-tracking.enabled=true
+ft.usage-tracking.capture-ip=true
+ft.usage-tracking.capture-user-agent=true
 
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}

--- a/src/main/resources/db/migration/V5__create_feature_usage_table.sql
+++ b/src/main/resources/db/migration/V5__create_feature_usage_table.sql
@@ -1,0 +1,22 @@
+create sequence feature_usage_id_seq start with 1 increment by 50;
+
+create table feature_usage
+(
+    id           bigint       not null default nextval('feature_usage_id_seq'),
+    user_id      varchar(255) not null,
+    feature_code varchar(50),
+    product_code varchar(50),
+    release_code varchar(50),
+    action_type  varchar(50)  not null,
+    timestamp    timestamp    not null default current_timestamp,
+    context      text,
+    primary key (id)
+);
+
+create index idx_feature_usage_user_id on feature_usage (user_id);
+create index idx_feature_usage_feature_code on feature_usage (feature_code);
+create index idx_feature_usage_product_code on feature_usage (product_code);
+create index idx_feature_usage_release_code on feature_usage (release_code);
+create index idx_feature_usage_action_type on feature_usage (action_type);
+create index idx_feature_usage_timestamp on feature_usage (timestamp);
+create index idx_feature_usage_timestamp_action on feature_usage (timestamp, action_type);

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/AnonymousUsageTrackingTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/AnonymousUsageTrackingTest.java
@@ -1,0 +1,140 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.domain.models.ActionType;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Integration tests to verify that usage events are logged for anonymous (unauthenticated) users.
+ * These tests do NOT use @WithMockOAuth2User annotation to simulate anonymous requests.
+ */
+class AnonymousUsageTrackingTest extends AbstractIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        // Clean up feature_usage table before each test
+        jdbcTemplate.execute("DELETE FROM feature_usage");
+    }
+
+    @Test
+    void shouldLogAnonymousUserViewingProduct() throws Exception {
+        // When: Anonymous user views a product
+        mockMvc.perform(get("/api/products/intellij")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged with userId="anonymous"
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND action_type = ?",
+                Integer.class,
+                "anonymous",
+                "intellij",
+                ActionType.PRODUCT_VIEWED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogAnonymousUserViewingFeature() throws Exception {
+        // When: Anonymous user views a feature
+        mockMvc.perform(get("/api/features/IDEA-1")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged with userId="anonymous"
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND feature_code = ? AND action_type = ?",
+                Integer.class,
+                "anonymous",
+                "IDEA-1",
+                ActionType.FEATURE_VIEWED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogAnonymousUserListingFeatures() throws Exception {
+        // When: Anonymous user lists features by product
+        mockMvc.perform(get("/api/features?productCode=intellij")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged with userId="anonymous"
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND action_type = ?",
+                Integer.class,
+                "anonymous",
+                "intellij",
+                ActionType.FEATURES_LISTED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogAnonymousUserViewingRelease() throws Exception {
+        // When: Anonymous user views a release
+        mockMvc.perform(get("/api/releases/IDEA-2023.3.8")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged with userId="anonymous"
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND release_code = ? AND action_type = ?",
+                Integer.class,
+                "anonymous",
+                "IDEA-2023.3.8",
+                ActionType.RELEASE_VIEWED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldStoreDeviceFingerprintInContextForAnonymousUser() throws Exception {
+        // When: Anonymous user views a product with User-Agent header
+        mockMvc.perform(get("/api/products/intellij")
+                        .header("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0")
+                        .header("X-Forwarded-For", "192.168.1.100"))
+                .andExpect(status().is2xxSuccessful());
+
+        // Then: Verify context contains device fingerprint
+        Map<String, Object> event = jdbcTemplate.queryForMap(
+                "SELECT * FROM feature_usage WHERE user_id = ? AND product_code = ?", "anonymous", "intellij");
+
+        String context = (String) event.get("context");
+        assertThat(context).isNotNull();
+
+        // Verify device fingerprint is present (16 hex characters)
+        assertThat(context).contains("deviceFingerprint");
+        assertThat(context).matches(".*\"deviceFingerprint\":\"[a-f0-9]{16}\".*");
+    }
+
+    @Test
+    void shouldNotLogAnonymousUserCreatingFeature() throws Exception {
+        // When: Anonymous user tries to create a feature (should be rejected by security)
+        mockMvc.perform(
+                        post("/api/features")
+                                .contentType("application/json")
+                                .content(
+                                        """
+                                {
+                                    "productCode": "intellij",
+                                    "title": "Test Feature",
+                                    "description": "Test"
+                                }
+                                """))
+                .andExpect(status().is4xxClientError()); // 401 Unauthorized
+
+        // Then: Verify no usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ?", Integer.class, "anonymous");
+
+        assertThat(count).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureUsageControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/FeatureUsageControllerTests.java
@@ -1,0 +1,1052 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Comprehensive tests for FeatureUsageController covering all requirements:
+ * - Authentication and authorization
+ * - API functionality with precise assertions
+ * - Proper test isolation with database cleanup
+ * - API-based test data creation instead of direct repository access
+ */
+class FeatureUsageControllerTests extends AbstractIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM feature_usage");
+    }
+
+    /**
+     * Tests for unauthenticated requests - should return 401 Unauthorized
+     */
+    @Nested
+    class UnauthenticatedTests {
+
+        @Test
+        void shouldReturn401ForUnauthenticatedPostUsageEvent() {
+            var requestBody =
+                    """
+                    {
+                        "actionType": "FEATURE_VIEWED",
+                        "featureCode": "FEAT-001"
+                    }
+                    """;
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetAllUsageEvents() {
+            var result = mvc.get().uri("/api/usage/events").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetUsageStats() {
+            var result = mvc.get().uri("/api/usage/stats").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetFeatureStats() {
+            var result = mvc.get().uri("/api/usage/feature/FEAT-001/stats").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetProductStats() {
+            var result = mvc.get().uri("/api/usage/product/PROD-001/stats").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetFeatureEvents() {
+            var result = mvc.get().uri("/api/usage/feature/FEAT-001/events").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetProductEvents() {
+            var result = mvc.get().uri("/api/usage/product/PROD-001/events").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetTopFeatures() {
+            var result = mvc.get().uri("/api/usage/top-features").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetTopUsers() {
+            var result = mvc.get().uri("/api/usage/top-users").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetUserUsage() {
+            var result = mvc.get().uri("/api/usage/user/user1").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetFeatureUsagePaginated() {
+            var result = mvc.get().uri("/api/usage/feature/FEAT-001").exchange();
+            assertThat(result).hasStatus(401);
+        }
+
+        @Test
+        void shouldReturn401ForUnauthenticatedGetProductUsagePaginated() {
+            var result = mvc.get().uri("/api/usage/product/PROD-001").exchange();
+            assertThat(result).hasStatus(401);
+        }
+    }
+
+    /**
+     * Tests for authenticated regular users (USER role)
+     * Tests only endpoints accessible to USER role
+     */
+    @Nested
+    @WithMockOAuth2User(roles = {"USER"})
+    class AuthenticatedUserTests {
+
+        @Test
+        void shouldCreateUsageEventWithCompleteDataAndReturn201() {
+            var requestBody =
+                    """
+                    {
+                        "actionType": "FEATURE_VIEWED",
+                        "featureCode": "FEAT-001",
+                        "productCode": "PROD-001",
+                        "releaseCode": "REL-001",
+                        "context": {
+                            "source": "web",
+                            "device": "desktop",
+                            "user": {
+                                "preferences": {
+                                    "theme": "dark",
+                                    "notifications": true
+                                }
+                            },
+                            "tags": ["important", "urgent"],
+                            "metadata": {
+                                "count": 42,
+                                "enabled": true,
+                                "optional": null
+                            }
+                        }
+                    }
+                    """;
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            // Verify successful creation (flexible 2xx pattern)
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify complete response structure
+            assertThat(result).bodyJson().extractingPath("$.id").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.actionType")
+                    .asString()
+                    .isEqualTo("FEATURE_VIEWED");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.featureCode")
+                    .asString()
+                    .isEqualTo("FEAT-001");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.productCode")
+                    .asString()
+                    .isEqualTo("PROD-001");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.releaseCode")
+                    .asString()
+                    .isEqualTo("REL-001");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.userId")
+                    .asString()
+                    .isNotEmpty(); // UserId is anonymized due to GDPR settings
+            assertThat(result).bodyJson().extractingPath("$.timestamp").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.context")
+                    .asString()
+                    .contains("web")
+                    .contains("desktop")
+                    .contains("dark")
+                    .contains("important")
+                    .contains("urgent");
+        }
+
+        @Test
+        void shouldCreateUsageEventWithMinimalData() {
+            var requestBody =
+                    """
+                    {
+                        "actionType": "FEATURE_CREATED"
+                    }
+                    """;
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify all required fields are present even with minimal input
+            assertThat(result).bodyJson().extractingPath("$.id").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.actionType")
+                    .asString()
+                    .isEqualTo("FEATURE_CREATED");
+            assertThat(result).bodyJson().extractingPath("$.userId").asString().isNotEmpty();
+            assertThat(result).bodyJson().extractingPath("$.timestamp").isNotNull();
+            // Optional fields should be null
+            assertThat(result).bodyJson().extractingPath("$.featureCode").isNull();
+            assertThat(result).bodyJson().extractingPath("$.productCode").isNull();
+        }
+
+        @Test
+        void shouldRejectPostUsageEventWithoutActionType() {
+            var requestBody =
+                    """
+                    {
+                        "featureCode": "FEAT-001",
+                        "productCode": "PROD-001"
+                    }
+                    """;
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            assertThat(result).hasStatus4xxClientError();
+        }
+
+        @Test
+        void shouldRejectPostUsageEventWithInvalidActionType() {
+            var requestBody =
+                    """
+                    {
+                        "actionType": "INVALID_ACTION",
+                        "featureCode": "FEAT-001"
+                    }
+                    """;
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            assertThat(result).hasStatus4xxClientError();
+        }
+
+        @Test
+        void shouldRejectPostUsageEventWithMalformedJson() {
+            var requestBody =
+                    """
+                    {
+                        "actionType": "FEATURE_VIEWED",
+                        "featureCode": "FEAT-001"
+                    """;
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            assertThat(result).hasStatus4xxClientError();
+        }
+
+        @Test
+        void shouldGetFeatureStatsWithPreciseValidation() {
+            // Create exactly 3 events with different action types
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_UPDATED", "TEST-FEATURE", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE", "TEST-PRODUCT");
+
+            var result = mvc.get().uri("/api/usage/feature/TEST-FEATURE/stats").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify exact counts
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.featureCode")
+                    .asString()
+                    .isEqualTo("TEST-FEATURE");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalUsageCount")
+                    .asNumber()
+                    .isEqualTo(3);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.uniqueUserCount")
+                    .asNumber()
+                    .isEqualTo(1);
+
+            // Verify exact action type distribution
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.usageByActionType.FEATURE_VIEWED")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.usageByActionType.FEATURE_UPDATED")
+                    .asNumber()
+                    .isEqualTo(1);
+
+            // Verify structure completeness
+            assertThat(result).bodyJson().extractingPath("$.topUsers").asList().isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.usageByProduct")
+                    .asList()
+                    .isNotNull();
+        }
+
+        @Test
+        void shouldGetProductStatsWithPreciseValidation() {
+            // Create exactly 2 events for 2 different features
+            createUsageEventViaAPI("FEATURE_VIEWED", "FEAT-A", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "FEAT-B", "TEST-PRODUCT");
+
+            var result = mvc.get().uri("/api/usage/product/TEST-PRODUCT/stats").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify exact counts
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.productCode")
+                    .asString()
+                    .isEqualTo("TEST-PRODUCT");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalUsageCount")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.uniqueUserCount")
+                    .asNumber()
+                    .isEqualTo(1);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.uniqueFeatureCount")
+                    .asNumber()
+                    .isEqualTo(2);
+
+            // Verify structure completeness
+            assertThat(result).bodyJson().extractingPath("$.usageByActionType").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.topFeatures")
+                    .asList()
+                    .isNotNull();
+            assertThat(result).bodyJson().extractingPath("$.topUsers").asList().isNotNull();
+        }
+
+        @Test
+        void shouldGetOverallStatsWithStructureValidation() {
+            // Create test data
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE", "TEST-PRODUCT");
+
+            var result = mvc.get().uri("/api/usage/stats").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify structure is correct (overall stats include all events)
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalUsageCount")
+                    .asNumber()
+                    .satisfies(count -> assertThat(count.intValue()).isGreaterThan(0));
+            assertThat(result).bodyJson().extractingPath("$.uniqueUserCount").isNotNull();
+            assertThat(result).bodyJson().extractingPath("$.uniqueFeatureCount").isNotNull();
+            assertThat(result).bodyJson().extractingPath("$.uniqueProductCount").isNotNull();
+            assertThat(result).bodyJson().extractingPath("$.usageByActionType").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.topFeatures")
+                    .asList()
+                    .isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.topProducts")
+                    .asList()
+                    .isNotNull();
+            assertThat(result).bodyJson().extractingPath("$.topUsers").asList().isNotNull();
+        }
+
+        @Test
+        void shouldHandleDateRangeFiltersCorrectly() {
+            // Create an event
+            createUsageEventViaAPI("FEATURE_VIEWED", "DATE-FILTER-FEATURE", "DATE-FILTER-PRODUCT");
+
+            // Use a date range that includes the event
+            Instant startDate = Instant.now().minusSeconds(3600); // 1 hour ago
+            Instant endDate = Instant.now().plusSeconds(3600); // 1 hour from now
+
+            var result = mvc.get()
+                    .uri("/api/usage/feature/DATE-FILTER-FEATURE/stats?startDate=" + startDate.toString() + "&endDate="
+                            + endDate.toString())
+                    .exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Should include our event
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalUsageCount")
+                    .asNumber()
+                    .isEqualTo(1);
+
+            // Test with date range that excludes the event
+            Instant pastStart = Instant.now().minusSeconds(7200); // 2 hours ago
+            Instant pastEnd = Instant.now().minusSeconds(3600); // 1 hour ago
+
+            var pastResult = mvc.get()
+                    .uri("/api/usage/feature/DATE-FILTER-FEATURE/stats?startDate=" + pastStart.toString() + "&endDate="
+                            + pastEnd.toString())
+                    .exchange();
+
+            assertThat(pastResult).hasStatus2xxSuccessful();
+
+            // Should exclude our event (exactly 0)
+            assertThat(pastResult)
+                    .bodyJson()
+                    .extractingPath("$.totalUsageCount")
+                    .asNumber()
+                    .isEqualTo(0);
+        }
+
+        @Test
+        void shouldReturnEmptyStatsForNonExistentFeature() {
+            var result = mvc.get().uri("/api/usage/feature/NON-EXISTENT/stats").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify exact zero values and correct structure
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.featureCode")
+                    .asString()
+                    .isEqualTo("NON-EXISTENT");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalUsageCount")
+                    .asNumber()
+                    .isEqualTo(0);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.uniqueUserCount")
+                    .asNumber()
+                    .isEqualTo(0);
+
+            // Verify empty maps are actually empty
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.usageByActionType")
+                    .asMap()
+                    .isEmpty();
+            assertThat(result).bodyJson().extractingPath("$.topUsers").asList().isEmpty();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.usageByProduct")
+                    .asList()
+                    .isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyStatsForNonExistentProduct() {
+            var result = mvc.get().uri("/api/usage/product/NON-EXISTENT/stats").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify exact zero values and correct structure
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.productCode")
+                    .asString()
+                    .isEqualTo("NON-EXISTENT");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalUsageCount")
+                    .asNumber()
+                    .isEqualTo(0);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.uniqueUserCount")
+                    .asNumber()
+                    .isEqualTo(0);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.uniqueFeatureCount")
+                    .asNumber()
+                    .isEqualTo(0);
+        }
+
+        @Test
+        void shouldHandleInvalidDateFormats() {
+            var result = mvc.get()
+                    .uri("/api/usage/feature/FEAT-001/stats?startDate=invalid-date")
+                    .exchange();
+            assertThat(result).hasStatus4xxClientError();
+
+            var result1 = mvc.get()
+                    .uri("/api/usage/product/PROD-001/stats?endDate=invalid-date")
+                    .exchange();
+            assertThat(result1).hasStatus4xxClientError();
+
+            var result2 = mvc.get().uri("/api/usage/stats?endDate=invalid-date").exchange();
+            assertThat(result2).hasStatus4xxClientError();
+
+            // Test top features with invalid dates
+            var result3 = mvc.get()
+                    .uri("/api/usage/top-features?startDate=invalid-date")
+                    .exchange();
+            assertThat(result3).hasStatus4xxClientError();
+
+            // Test top users with invalid dates
+            var result4 =
+                    mvc.get().uri("/api/usage/top-users?endDate=invalid-date").exchange();
+            assertThat(result4).hasStatus4xxClientError();
+        }
+
+        @Test
+        void shouldHandleInvalidDateRanges() {
+            Instant startDate = Instant.now();
+            Instant endDate = Instant.now().minusSeconds(3600); // End before start
+
+            var result = mvc.get()
+                    .uri("/api/usage/stats?startDate=" + startDate.toString() + "&endDate=" + endDate.toString())
+                    .exchange();
+
+            assertThat(result).hasStatus4xxClientError();
+        }
+
+        @Test
+        void shouldGetTopFeatures() {
+            // Create test data with different usage counts to verify sorting
+            createUsageEventViaAPI("FEATURE_VIEWED", "TOP-FEATURE-1", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "TOP-FEATURE-2", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "TOP-FEATURE-1", "TEST-PRODUCT"); // Make FEATURE-1 more popular
+
+            var result = mvc.get().uri("/api/usage/top-features").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+            assertThat(result).bodyJson().extractingPath("$").asList().isNotEmpty();
+
+            // Verify sorting: first element should be TOP-FEATURE-1 (2 usages)
+            assertThat(result).bodyJson().extractingPath("$[0].name").asString().isEqualTo("TOP-FEATURE-1");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$[0].count")
+                    .asNumber()
+                    .isEqualTo(2);
+
+            // Second element should be TOP-FEATURE-2 (1 usage)
+            assertThat(result).bodyJson().extractingPath("$[1].name").asString().isEqualTo("TOP-FEATURE-2");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$[1].count")
+                    .asNumber()
+                    .isEqualTo(1);
+        }
+
+        @Test
+        void shouldGetTopUsers() {
+            // Create test data (all events from same user due to @WithMockOAuth2User)
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE-1", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE-2", "TEST-PRODUCT");
+
+            var result = mvc.get().uri("/api/usage/top-users").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+            assertThat(result).bodyJson().extractingPath("$").asList().isNotEmpty();
+
+            // Should have exactly one user with count = 2 (first element due to sorting)
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$[0].count")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result).bodyJson().extractingPath("$[0].name").asString().isNotEmpty();
+        }
+
+        @Test
+        void shouldGetTopFeaturesWithDateRangeFilter() {
+            // Create test data
+            createUsageEventViaAPI("FEATURE_VIEWED", "DATE-FEATURE", "TEST-PRODUCT");
+
+            Instant startDate = Instant.now().minusSeconds(3600); // 1 hour ago
+            Instant endDate = Instant.now().plusSeconds(3600); // 1 hour from now
+
+            var result = mvc.get()
+                    .uri("/api/usage/top-features?startDate=" + startDate.toString() + "&endDate=" + endDate.toString())
+                    .exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+            assertThat(result).bodyJson().extractingPath("$").asList().isNotEmpty();
+        }
+
+        @Test
+        void shouldGetTopUsersWithLimitParameter() {
+            // Create test data
+            createUsageEventViaAPI("FEATURE_VIEWED", "LIMIT-FEATURE", "TEST-PRODUCT");
+
+            var result = mvc.get().uri("/api/usage/top-users?limit=5").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+            assertThat(result).bodyJson().extractingPath("$").asList().isNotEmpty();
+
+            // Should not exceed limit of 5 users (though we only have 1 user in test)
+            assertThat(result).bodyJson().extractingPath("$").asList().size().isLessThanOrEqualTo(5);
+        }
+
+        @Test
+        void shouldGetTopFeaturesWithDefaultLimit() {
+            // Create 11 different features to test default limit of 10
+            for (int i = 1; i <= 11; i++) {
+                createUsageEventViaAPI("FEATURE_VIEWED", "LIMIT-TEST-FEATURE-" + i, "TEST-PRODUCT");
+            }
+
+            // Request without limit parameter to test default
+            var result = mvc.get().uri("/api/usage/top-features").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+            assertThat(result).bodyJson().extractingPath("$").asList().isNotEmpty();
+
+            // Should return exactly 10 features (default limit)
+            assertThat(result).bodyJson().extractingPath("$.size()").asNumber().isEqualTo(10);
+        }
+
+        @Test
+        void shouldGetUserUsageWithPagination() {
+            // Create test data for specific user (current authenticated user)
+            createUsageEventViaAPI("FEATURE_VIEWED", "USER-FEATURE-1", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "USER-FEATURE-2", "TEST-PRODUCT");
+
+            // Use the raw userId "user" which will be anonymized by the endpoint
+            // The @WithMockOAuth2User annotation uses "user" as the default username
+            var result = mvc.get().uri("/api/usage/user/user?page=0&size=10").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result).bodyJson().extractingPath("$.size").asNumber().isEqualTo(10);
+            assertThat(result).bodyJson().extractingPath("$.number").asNumber().isEqualTo(0);
+        }
+
+        @Test
+        void shouldGetFeatureUsageWithPagination() {
+            // Create test data
+            createUsageEventViaAPI("FEATURE_VIEWED", "PAGINATED-FEATURE", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_UPDATED", "PAGINATED-FEATURE", "TEST-PRODUCT");
+
+            var result = mvc.get()
+                    .uri("/api/usage/feature/PAGINATED-FEATURE?page=0&size=5")
+                    .exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result).bodyJson().extractingPath("$.size").asNumber().isEqualTo(5);
+            assertThat(result).bodyJson().extractingPath("$.number").asNumber().isEqualTo(0);
+
+            // Verify content structure
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].featureCode")
+                    .asString()
+                    .isEqualTo("PAGINATED-FEATURE");
+        }
+
+        @Test
+        void shouldGetProductUsageWithPagination() {
+            // Create test data
+            createUsageEventViaAPI("FEATURE_VIEWED", "FEAT-1", "PAGINATED-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "FEAT-2", "PAGINATED-PRODUCT");
+
+            var result = mvc.get()
+                    .uri("/api/usage/product/PAGINATED-PRODUCT?page=0&size=5")
+                    .exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result).bodyJson().extractingPath("$.size").asNumber().isEqualTo(5);
+            assertThat(result).bodyJson().extractingPath("$.number").asNumber().isEqualTo(0);
+
+            // Verify content structure
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].productCode")
+                    .asString()
+                    .isEqualTo("PAGINATED-PRODUCT");
+        }
+
+        /**
+         * Helper method to create usage events via API instead of direct repository access.
+         */
+        private void createUsageEventViaAPI(String actionType, String featureCode, String productCode) {
+            var requestBody = String.format(
+                    """
+                    {
+                        "actionType": "%s",
+                        "featureCode": "%s",
+                        "productCode": "%s"
+                    }
+                    """,
+                    actionType, featureCode, productCode);
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            // Ensure the event was created successfully
+            assertThat(result).hasStatus2xxSuccessful();
+        }
+    }
+
+    /**
+     * Tests for admin-only endpoints (ADMIN role)
+     * Tests restricted endpoints that require ADMIN or PRODUCT_MANAGER role
+     */
+    @Nested
+    @WithMockOAuth2User(roles = {"ADMIN", "PRODUCT_MANAGER"})
+    class AdminTests {
+
+        @Test
+        void shouldGetFeatureEventsWithPreciseValidation() {
+            // Create exactly 2 events
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_UPDATED", "TEST-FEATURE", "TEST-PRODUCT");
+
+            var result = mvc.get().uri("/api/usage/feature/TEST-FEATURE/events").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure and content size
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content.size()")
+                    .asNumber()
+                    .isEqualTo(2);
+
+            // Verify both events have correct feature code
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].featureCode")
+                    .asString()
+                    .isEqualTo("TEST-FEATURE");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[1].featureCode")
+                    .asString()
+                    .isEqualTo("TEST-FEATURE");
+
+            // Verify event structure
+            assertThat(result).bodyJson().extractingPath("$.content[0].id").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].actionType")
+                    .isNotNull();
+            assertThat(result).bodyJson().extractingPath("$.content[0].userId").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].timestamp")
+                    .isNotNull();
+        }
+
+        @Test
+        void shouldGetProductEventsWithPreciseValidation() {
+            // Create exactly 2 events for different features
+            createUsageEventViaAPI("FEATURE_VIEWED", "FEAT-1", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "FEAT-2", "TEST-PRODUCT");
+
+            var result = mvc.get().uri("/api/usage/product/TEST-PRODUCT/events").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure and content size
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content.size()")
+                    .asNumber()
+                    .isEqualTo(2);
+
+            // Verify all events belong to the requested product
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].productCode")
+                    .asString()
+                    .isEqualTo("TEST-PRODUCT");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[1].productCode")
+                    .asString()
+                    .isEqualTo("TEST-PRODUCT");
+        }
+
+        @Test
+        void shouldGetAllEventsWithFiltersAndPreciseValidation() {
+            // Create 3 events: 2 FEATURE_VIEWED, 1 FEATURE_UPDATED
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_UPDATED", "TEST-FEATURE", "TEST-PRODUCT");
+            createUsageEventViaAPI("FEATURE_VIEWED", "TEST-FEATURE", "TEST-PRODUCT");
+
+            // Filter by FEATURE_VIEWED only
+            var result = mvc.get()
+                    .uri("/api/usage/events?actionType=FEATURE_VIEWED&featureCode=TEST-FEATURE")
+                    .exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure and content size
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(2);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content.size()")
+                    .asNumber()
+                    .isEqualTo(2);
+
+            // Verify all returned events match the filter
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].actionType")
+                    .asString()
+                    .isEqualTo("FEATURE_VIEWED");
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].featureCode")
+                    .asString()
+                    .isEqualTo("TEST-FEATURE");
+        }
+
+        @Test
+        void shouldGetAllUsageEventsWithMultipleFilters() {
+            // Create test data
+            createUsageEventViaAPI("FEATURE_VIEWED", "MULTI-FEATURE", "MULTI-PRODUCT");
+            createUsageEventViaAPI("FEATURE_UPDATED", "MULTI-FEATURE", "MULTI-PRODUCT");
+
+            var result = mvc.get()
+                    .uri(
+                            "/api/usage/events?actionType=FEATURE_VIEWED&featureCode=MULTI-FEATURE&productCode=MULTI-PRODUCT")
+                    .exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure and content size
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(1);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content.size()")
+                    .asNumber()
+                    .isEqualTo(1);
+        }
+
+        @Test
+        void shouldReturnEmptyListForNonExistentFeatureEvents() {
+            var result = mvc.get().uri("/api/usage/feature/NON-EXISTENT/events").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure with empty content
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(0);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content.size()")
+                    .asNumber()
+                    .isEqualTo(0);
+            assertThat(result).bodyJson().extractingPath("$.content").asList().isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyListForNonExistentProductEvents() {
+            var result = mvc.get().uri("/api/usage/product/NON-EXISTENT/events").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure with empty content
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(0);
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content.size()")
+                    .asNumber()
+                    .isEqualTo(0);
+            assertThat(result).bodyJson().extractingPath("$.content").asList().isEmpty();
+        }
+
+        @Test
+        void shouldGetAllEventsWithUserIdFilter() {
+            // Create test data with specific user
+            createUsageEventViaAPI("FEATURE_VIEWED", "USER-FILTER-FEATURE", "USER-FILTER-PRODUCT");
+            createUsageEventViaAPI("FEATURE_UPDATED", "USER-FILTER-FEATURE", "USER-FILTER-PRODUCT");
+
+            // Filter by userId (current authenticated user is "user")
+            var result = mvc.get().uri("/api/usage/events?userId=user").exchange();
+
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify pagination structure and content size
+            assertThat(result).bodyJson().extractingPath("$.content").isNotNull();
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.totalElements")
+                    .asNumber()
+                    .isEqualTo(2);
+
+            // Verify all returned events belong to the filtered user
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[0].userId")
+                    .asString()
+                    .isNotEmpty(); // userId is anonymized but should be present
+            assertThat(result)
+                    .bodyJson()
+                    .extractingPath("$.content[1].userId")
+                    .asString()
+                    .isNotEmpty();
+        }
+
+        /**
+         * Helper method to create usage events via API instead of direct repository access.
+         */
+        private void createUsageEventViaAPI(String actionType, String featureCode, String productCode) {
+            var requestBody = String.format(
+                    """
+                    {
+                        "actionType": "%s",
+                        "featureCode": "%s",
+                        "productCode": "%s"
+                    }
+                    """,
+                    actionType, featureCode, productCode);
+
+            var result = mvc.post()
+                    .uri("/api/usage")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .exchange();
+
+            // Ensure the event was created successfully
+            assertThat(result).hasStatus2xxSuccessful();
+        }
+    }
+
+    /**
+     * Tests for forbidden access - regular users trying to access restricted endpoints
+     */
+    @Nested
+    @WithMockOAuth2User(roles = {"USER"})
+    class ForbiddenAccessTests {
+
+        @Test
+        void shouldReturn403ForUserAccessingAllEvents() {
+            var result = mvc.get().uri("/api/usage/events").exchange();
+            assertThat(result).hasStatus(403);
+        }
+
+        @Test
+        void shouldReturn403ForUserAccessingFeatureEvents() {
+            var result = mvc.get().uri("/api/usage/feature/FEAT-001/events").exchange();
+            assertThat(result).hasStatus(403);
+        }
+
+        @Test
+        void shouldReturn403ForUserAccessingProductEvents() {
+            var result = mvc.get().uri("/api/usage/product/PROD-001/events").exchange();
+            assertThat(result).hasStatus(403);
+        }
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/UsageTrackingIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/UsageTrackingIntegrationTest.java
@@ -1,0 +1,367 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
+import com.sivalabs.ft.features.api.models.CreateProductPayload;
+import com.sivalabs.ft.features.api.models.UpdateFeaturePayload;
+import com.sivalabs.ft.features.domain.models.ActionType;
+import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Integration tests to verify that usage events are automatically logged
+ * to the feature_usage table when various API endpoints are called.
+ *
+ * These tests use direct SQL queries to verify database state without
+ * using FeatureUsageRepository or FeatureUsageController.
+ */
+@WithMockOAuth2User(username = "testuser")
+class UsageTrackingIntegrationTest extends AbstractIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        // Clean up feature_usage table before each test
+        jdbcTemplate.execute("DELETE FROM feature_usage");
+    }
+
+    @Test
+    void shouldLogUsageWhenViewingProduct() throws Exception {
+        // When: View a product
+        mockMvc.perform(get("/api/products/intellij")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged in database
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "intellij",
+                ActionType.PRODUCT_VIEWED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenCreatingProduct() throws Exception {
+        // Given: Product creation payload
+        CreateProductPayload payload = new CreateProductPayload(
+                "test-product", "TST", "Test Product", "Test Description", "https://example.com/test.png");
+
+        // When: Create a product
+        mockMvc.perform(post("/api/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isCreated());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "test-product",
+                ActionType.PRODUCT_CREATED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenUpdatingProduct() throws Exception {
+        // Given: Product update payload
+        String payload =
+                """
+                {
+                    "prefix": "IDEA-UPD",
+                    "name": "IntelliJ IDEA Updated",
+                    "description": "Updated description for IntelliJ IDEA",
+                    "imageUrl": "https://example.com/updated-intellij.png"
+                }
+                """;
+
+        // When: Update an existing product
+        mockMvc.perform(put("/api/products/intellij")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "intellij",
+                ActionType.PRODUCT_UPDATED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenViewingFeature() throws Exception {
+        // When: View a feature
+        mockMvc.perform(get("/api/features/IDEA-1")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND feature_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "IDEA-1",
+                ActionType.FEATURE_VIEWED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenCreatingFeature() throws Exception {
+        // Given: Feature creation payload
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "New Test Feature", "Test Description", null, null);
+
+        // When: Create a feature
+        mockMvc.perform(post("/api/features")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isCreated());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "intellij",
+                ActionType.FEATURE_CREATED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenUpdatingFeature() throws Exception {
+        // Given: Feature update payload
+        UpdateFeaturePayload payload =
+                new UpdateFeaturePayload("Updated Title", "Updated Description", null, null, FeatureStatus.IN_PROGRESS);
+
+        // When: Update a feature
+        mockMvc.perform(put("/api/features/IDEA-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND feature_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "IDEA-1",
+                ActionType.FEATURE_UPDATED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenDeletingFeature() throws Exception {
+        // When: Delete a feature without related records (GO-3 has no comments)
+        mockMvc.perform(delete("/api/features/GO-3")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND feature_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "GO-3",
+                ActionType.FEATURE_DELETED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenListingFeaturesByProduct() throws Exception {
+        // When: List features by product
+        mockMvc.perform(get("/api/features?productCode=intellij")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "intellij",
+                ActionType.FEATURES_LISTED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogMultipleEventsForMultipleActions() throws Exception {
+        // When: Perform multiple actions
+        mockMvc.perform(get("/api/products/intellij")).andExpect(status().is2xxSuccessful());
+        mockMvc.perform(get("/api/features/IDEA-1")).andExpect(status().is2xxSuccessful());
+        mockMvc.perform(get("/api/features/IDEA-2")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify all events were logged
+        Integer totalCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ?", Integer.class, "testuser");
+
+        assertThat(totalCount).isEqualTo(3);
+    }
+
+    @Test
+    void shouldNotLogUsageForNonExistentFeature() throws Exception {
+        // When: Try to view non-existent feature
+        mockMvc.perform(get("/api/features/NON-EXISTENT")).andExpect(status().is4xxClientError());
+
+        // Then: Verify no usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ?", Integer.class, "testuser");
+
+        assertThat(count).isEqualTo(0);
+    }
+
+    @Test
+    void shouldVerifyDatabaseSchemaForUsageTable() {
+        // Verify that feature_usage table has expected columns
+        List<Map<String, Object>> columns =
+                jdbcTemplate.queryForList("SELECT column_name, data_type FROM information_schema.columns "
+                        + "WHERE table_name = 'feature_usage' ORDER BY ordinal_position");
+
+        assertThat(columns).isNotEmpty();
+
+        // Verify key columns exist
+        List<String> columnNames =
+                columns.stream().map(col -> (String) col.get("column_name")).toList();
+
+        assertThat(columnNames)
+                .contains("id", "user_id", "feature_code", "product_code", "release_code", "action_type", "timestamp");
+    }
+
+    @Test
+    void shouldLogUsageWhenViewingRelease() throws Exception {
+        // When: View a release (using existing test data)
+        mockMvc.perform(get("/api/releases/IDEA-2023.3.8")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged with release_code
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND release_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "IDEA-2023.3.8",
+                ActionType.RELEASE_VIEWED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenCreatingRelease() throws Exception {
+        // Given: Release creation payload
+        String payload =
+                """
+                {
+                    "productCode": "intellij",
+                    "code": "IDEA-2025.1",
+                    "description": "IntelliJ IDEA 2025.1"
+                }
+                """;
+
+        // When: Create a release
+        mockMvc.perform(post("/api/releases")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated());
+
+        // Then: Verify usage event was logged with release_code
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND product_code = ? AND release_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "intellij",
+                "IDEA-2025.1",
+                ActionType.RELEASE_CREATED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenAddingComment() throws Exception {
+        // Given: Comment payload
+        String payload =
+                """
+                {
+                    "featureCode": "IDEA-1",
+                    "content": "This is a test comment"
+                }
+                """;
+
+        // When: Add a comment
+        mockMvc.perform(post("/api/comments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND feature_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "IDEA-1",
+                ActionType.COMMENT_ADDED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenAddingFavorite() throws Exception {
+        // When: Add feature to favorites
+        mockMvc.perform(post("/api/features/IDEA-1/favorites")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND feature_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "IDEA-1",
+                ActionType.FAVORITE_ADDED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldLogUsageWhenRemovingFavorite() throws Exception {
+        // Given: Feature is already in favorites (from test-data.sql: IDEA-2 is favorited by 'user')
+        // First add it for testuser
+        mockMvc.perform(post("/api/features/GO-3/favorites")).andExpect(status().is2xxSuccessful());
+
+        // Clean usage table to test only the removal
+        jdbcTemplate.execute("DELETE FROM feature_usage");
+
+        // When: Remove feature from favorites
+        mockMvc.perform(delete("/api/features/GO-3/favorites")).andExpect(status().is2xxSuccessful());
+
+        // Then: Verify usage event was logged
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feature_usage WHERE user_id = ? AND feature_code = ? AND action_type = ?",
+                Integer.class,
+                "testuser",
+                "GO-3",
+                ActionType.FAVORITE_REMOVED.name());
+
+        assertThat(count).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
# Feature Analytics and Usage Tracking REST API Endpoints

## Description

Implement REST API endpoints to programmatically post feature usage events and retrieve analytics data. This enables external systems and clients to track feature usage and query aggregated statistics for features and products.

## Objective

Expose REST API endpoints for posting usage events and retrieving analytics data programmatically.

## Requirements

### 1. POST /api/usage - Create Usage Event

- Accept authenticated POST requests to create new usage events
- **Required field**: `actionType` (ActionType enum)
- **Optional fields**: `featureCode`, `productCode`, `releaseCode`, `context` (Map<String, Object>)
- **Auto-capture**: `userId` from SecurityContext, `timestamp` (server time), `ipAddress`, `userAgent` from request
- **Return**: FeatureUsageDto with: `id`, `userId`, `featureCode`, `productCode`, `releaseCode`, `actionType`, `timestamp`, `context`
- **Responses**:
  - `201 Created` with FeatureUsageDto body and Location header
  - `4xx Client Error` for validation errors (missing actionType, invalid enum, malformed JSON)
  - `401 Unauthorized` for unauthenticated requests

### 2. GET /api/usage/feature/{featureCode}/stats - Feature Statistics

- Return FeatureStatsDto with: `featureCode`, `totalUsageCount`, `uniqueUserCount`, `usageByActionType`, `topUsers`, `usageByProduct`
- **Query parameters** (optional): `actionType`, `startDate`, `endDate` (ISO 8601 format)
- **Note**: topFeatures, topProducts, topUsers, usageByProduct fields use List\<TopItemDto\> structure: {name: String, count: Long} sorted by count DESC
- Return zero counts for non-existent features (not 404)
- **Responses**: `2xx Success`, `4xx Client Error` for invalid dates, `401 Unauthorized` for unauthenticated requests

### 3. GET /api/usage/product/{productCode}/stats - Product Statistics

- Return ProductStatsDto with: `productCode`, `totalUsageCount`, `uniqueUserCount`, `uniqueFeatureCount`, `usageByActionType`, `topFeatures`, `topUsers`
- **Query parameters** (optional): `actionType`, `startDate`, `endDate` (ISO 8601 format)
- Return zero counts for non-existent products (not 404)
- **Responses**: `2xx Success`, `4xx Client Error` for invalid dates, `401 Unauthorized` for unauthenticated requests

### 4. Admin Events Endpoints

Return Page<FeatureUsageDto> with filtering and pagination.

- **Security**: Requires ADMIN or PRODUCT_MANAGER role (403 Forbidden for regular users)
- Return empty list for no matches
- **Responses**: `2xx Success`, `4xx Client Error` for invalid dates, `401 Unauthorized` for unauthenticated requests, `403 Forbidden` for insufficient permissions

**GET /api/usage/events** - All Usage Events List
- **Query parameters**: `actionType`, `userId`, `featureCode`, `productCode`, `startDate`, `endDate` (ISO 8601 format), `page` (default 0), `size` (default 20)

**GET /api/usage/feature/{featureCode}/events** - Feature Events List
- **Query parameters**: `actionType`, `startDate`, `endDate`, `page` (default 0), `size` (default 20)

**GET /api/usage/product/{productCode}/events** - Product Events List
- **Query parameters**: `actionType`, `startDate`, `endDate`, `page` (default 0), `size` (default 20)

### 5. GET /api/usage/stats - Overall Usage Statistics

- Return UsageStatsDto with: `totalUsageCount`, `uniqueUserCount`, `uniqueFeatureCount`, `uniqueProductCount`, `usageByActionType`, `topFeatures`, `topProducts`, `topUsers`
- **Query parameters** (optional): `actionType`, `startDate`, `endDate` (ISO 8601 format)
- **Responses**: `2xx Success`, `4xx Client Error` for invalid dates, `401 Unauthorized` for unauthenticated requests

### 6. Top Rankings Endpoints

Return List<TopItemDto> with top items by usage count.

- **Query parameters** (optional): `startDate`, `endDate`, `limit` (default 10)
- **Security**: Requires OAuth2 authentication (any authenticated user)

**GET /api/usage/top-features** - Most Accessed Features List With Feature Usage Counts

**GET /api/usage/top-users** - Most Active Users List With User Activity Counts

### 7. User Events Endpoints

Return Page<FeatureUsageDto> with simple pagination (no filters).

- **Query parameters**: `page` (default 0), `size` (default 20)
- **Security**: Requires OAuth2 authentication (any authenticated user)

**GET /api/usage/user/{userId}** - User Usage Events For Specific User

**GET /api/usage/feature/{featureCode}** - Feature Usage Events For Specific Feature (no filters)

**GET /api/usage/product/{productCode}** - Product Usage Events For Specific Product (no filters)

### 8. Security & Validation

- All endpoints require OAuth2 authentication
- Unauthenticated requests return 401 Unauthorized
- All validation errors (invalid dates, enum values, malformed JSON) return `4xx Client Error` (not `5xx Server Error`)
- Admin Events Endpoints require ADMIN or PRODUCT_MANAGER role (403 Forbidden for USER role)
- AuthorizationDeniedException properly handled to return 403 Forbidden

## Test Coverage

### Positive Cases
- Create usage event with all fields and with minimal data (actionType only)
- Retrieve feature/product stats with and without filters (actionType, date range)
- Retrieve feature/product events lists with and without filters

### Edge Cases
- Non-existent features/products return successful response with empty stats (zero counts) or empty lists
- Invalid dates, malformed JSON, invalid enum values return 4xx client errors
- Unauthenticated requests return 401

## Acceptance Criteria

* POST /api/usage creates events and returns 201 with Location header
* GET /api/usage/feature/{featureCode}/stats returns 2xx success with accurate statistics and supports optional filtering
* GET /api/usage/product/{productCode}/stats returns 2xx success with accurate statistics and supports optional filtering
* GET /api/usage/feature/{featureCode}/events and /product/{productCode}/events return 2xx success with filtered event lists
* All endpoints require authentication (401 for unauthenticated requests)
* Validation errors return 4xx client errors, not 5xx server errors
* Non-existent resources return 2xx success with empty data, not 404
