### PR TITLE
React to Application Lifecycle Events for Resource Initialization and Cleanup

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.ApplicationLifecycleEventTests",
+      "com.sivalabs.ft.features.ApplicationLifecycleFailureTests",
+      "com.sivalabs.ft.features.NoAutoCreateTopicsTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ The feature-service microservice manages products, releases and features.
 * Spring Security OAuth 2
 * Maven, JUnit 5, Testcontainers
 
+## Application Lifecycle
+The application listens to Spring context lifecycle events to validate critical dependencies at startup and to
+flush Kafka safely at shutdown.
+
+Startup (ContextRefreshedEvent):
+* Verifies the PostgreSQL connection is usable.
+* Verifies Kafka connectivity and that the three configured topics exist (`new_features`, `updated_features`,
+  `deleted_features`). Topics are not auto-created.
+* Warms up the Kafka producer by fetching metadata for the configured topics.
+
+Shutdown (ContextClosedEvent):
+* Attempts to flush pending Kafka messages before exit.
+* Flush timeout is capped at 10 seconds and also bounded by the configurable total shutdown timeout.
+* Total shutdown timeout is controlled by `ft.shutdown.timeout-seconds` (default 30 seconds).
+* If flush fails or times out, the error is logged and shutdown continues. Database connections are closed
+  by Spring Boot.
+
 ## Prerequisites
 * JDK 24 or later
 * Docker ([installation instructions](https://docs.docker.com/engine/install/))

--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -3,7 +3,9 @@ package com.sivalabs.ft.features;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "ft")
-public record ApplicationProperties(EventsProperties events) {
+public record ApplicationProperties(EventsProperties events, ShutdownProperties shutdown) {
 
     public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
+
+    public record ShutdownProperties(int timeoutSeconds) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/config/ApplicationLifecycleListener.java
+++ b/src/main/java/com/sivalabs/ft/features/config/ApplicationLifecycleListener.java
@@ -1,0 +1,175 @@
+package com.sivalabs.ft.features.config;
+
+import com.sivalabs.ft.features.ApplicationProperties;
+import java.sql.Connection;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.sql.DataSource;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationLifecycleListener {
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationLifecycleListener.class);
+
+    private static final long KAFKA_FLUSH_TIMEOUT_SECONDS = 10;
+    private static final Duration KAFKA_ADMIN_TIMEOUT = Duration.ofSeconds(10);
+
+    private final DataSource dataSource;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationProperties properties;
+
+    private final AtomicBoolean startupExecuted = new AtomicBoolean(false);
+    private final AtomicBoolean shutdownExecuted = new AtomicBoolean(false);
+
+    public ApplicationLifecycleListener(
+            DataSource dataSource, KafkaTemplate<String, Object> kafkaTemplate, ApplicationProperties properties) {
+        this.dataSource = dataSource;
+        this.kafkaTemplate = kafkaTemplate;
+        this.properties = properties;
+    }
+
+    @EventListener
+    public void onApplicationStartup(ContextRefreshedEvent event) {
+        if (!startupExecuted.compareAndSet(false, true)) {
+            log.debug("Startup tasks already executed, skipping duplicate ContextRefreshedEvent.");
+            return;
+        }
+        log.info("Application startup detected. Running initialization tasks...");
+        verifyDatabaseConnectivity();
+        verifyKafkaConnectivity();
+        warmUpKafkaProducer();
+        log.info("Application startup initialization completed successfully.");
+    }
+
+    @EventListener
+    public void onApplicationShutdown(ContextClosedEvent event) {
+        if (!shutdownExecuted.compareAndSet(false, true)) {
+            log.debug("Shutdown tasks already executed, skipping duplicate ContextClosedEvent.");
+            return;
+        }
+        long totalTimeoutSeconds = properties.shutdown().timeoutSeconds();
+        log.info("Application shutdown detected (total timeout: {} s). Running cleanup tasks...", totalTimeoutSeconds);
+
+        ExecutorService shutdownExecutor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> shutdownTask = shutdownExecutor.submit(this::flushKafkaMessages);
+            shutdownTask.get(totalTimeoutSeconds, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            log.error("Shutdown tasks exceeded total timeout of {} seconds. Continuing.", totalTimeoutSeconds);
+        } catch (ExecutionException e) {
+            log.error("Error during shutdown tasks: {}", e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Shutdown was interrupted: {}", e.getMessage());
+        } finally {
+            shutdownExecutor.shutdownNow();
+        }
+
+        log.info("Application shutdown cleanup completed. Database connections will be closed by Spring Boot.");
+    }
+
+    private void verifyDatabaseConnectivity() {
+        log.info("Verifying database connectivity...");
+        try (Connection connection = dataSource.getConnection()) {
+            if (connection.isValid(5)) {
+                log.info("Database connectivity verified successfully.");
+            } else {
+                throw new RuntimeException("Database connection is not valid");
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Database connectivity verification failed: {}", e.getMessage());
+            throw new RuntimeException("Failed to verify database connectivity on startup", e);
+        }
+    }
+
+    private void verifyKafkaConnectivity() {
+        log.info("Verifying Kafka connectivity...");
+        List<String> requiredTopics = List.of(
+                properties.events().newFeatures(),
+                properties.events().updatedFeatures(),
+                properties.events().deletedFeatures());
+
+        try (AdminClient adminClient =
+                AdminClient.create(kafkaTemplate.getProducerFactory().getConfigurationProperties())) {
+            Set<String> existingTopics =
+                    adminClient.listTopics().names().get(KAFKA_ADMIN_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            log.info("Available Kafka topics: {}", existingTopics);
+
+            List<String> missingTopics = requiredTopics.stream()
+                    .filter(t -> !existingTopics.contains(t))
+                    .toList();
+            if (!missingTopics.isEmpty()) {
+                throw new RuntimeException("Required Kafka topics are missing: " + missingTopics);
+            }
+            log.info("All required Kafka topics are accessible: {}", requiredTopics);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Kafka connectivity verification was interrupted", e);
+        } catch (ExecutionException e) {
+            log.error("Kafka connectivity verification failed: {}", e.getMessage());
+            throw new RuntimeException("Failed to verify Kafka connectivity on startup", e);
+        } catch (TimeoutException e) {
+            log.error("Kafka connectivity verification timed out: {}", e.getMessage());
+            throw new RuntimeException("Kafka connectivity verification timed out on startup", e);
+        }
+    }
+
+    private void warmUpKafkaProducer() {
+        log.info("Warming up Kafka producer connection...");
+        List<String> topics = List.of(
+                properties.events().newFeatures(),
+                properties.events().updatedFeatures(),
+                properties.events().deletedFeatures());
+        try {
+            for (String topic : topics) {
+                kafkaTemplate.partitionsFor(topic);
+                log.info("Producer metadata fetched for topic: {}", topic);
+            }
+            log.info("Kafka producer warmed up successfully.");
+        } catch (Exception e) {
+            log.error("Failed to warm up Kafka producer: {}", e.getMessage());
+            throw new RuntimeException("Failed to warm up Kafka producer on startup", e);
+        }
+    }
+
+    private void flushKafkaMessages() {
+        long flushTimeout =
+                Math.min(KAFKA_FLUSH_TIMEOUT_SECONDS, properties.shutdown().timeoutSeconds());
+        log.info("Flushing pending Kafka messages (timeout: {} seconds)...", flushTimeout);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> flushTask = executor.submit(() -> kafkaTemplate.flush());
+            flushTask.get(flushTimeout, TimeUnit.SECONDS);
+            log.info("Kafka messages flushed successfully.");
+        } catch (TimeoutException e) {
+            log.error("Kafka flush timed out after {} seconds. Continuing shutdown.", flushTimeout);
+        } catch (ExecutionException e) {
+            log.error("Failed to flush Kafka messages: {}", e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Kafka flush was interrupted: {}", e.getMessage());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,7 @@ ft.openapi.contact.email=support@sivalabs.in
 ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
+ft.shutdown.timeout-seconds=30
 
 ####### DB Configuration  #########
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:55432/postgres}

--- a/src/test/java/com/sivalabs/ft/features/AbstractIT.java
+++ b/src/test/java/com/sivalabs/ft/features/AbstractIT.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
@@ -14,6 +16,14 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 @Import(TestcontainersConfiguration.class)
 @Sql(scripts = {"/test-data.sql"})
 public abstract class AbstractIT {
+
+    @DynamicPropertySource
+    static void ensureKafkaTopics(DynamicPropertyRegistry registry) {
+        TestcontainersConfiguration.postgres.start();
+        TestcontainersConfiguration.kafka.start();
+        TestcontainersConfiguration.ensureKafkaTopics();
+    }
+
     @Autowired
     protected MockMvcTester mvc;
 }

--- a/src/test/java/com/sivalabs/ft/features/ApplicationLifecycleEventTests.java
+++ b/src/test/java/com/sivalabs/ft/features/ApplicationLifecycleEventTests.java
@@ -1,0 +1,115 @@
+package com.sivalabs.ft.features;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Statistic;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Universal integration tests for application startup lifecycle.
+ * Verifies that the application starts successfully with proper DB and Kafka connectivity,
+ * that the ContextRefreshedEvent is fired exactly once during startup,
+ * and that the Kafka producer was warmed up (i.e., a producer was created during startup).
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, ApplicationLifecycleEventTests.EventCaptureConfig.class})
+class ApplicationLifecycleEventTests {
+
+    @DynamicPropertySource
+    static void ensureKafkaTopics(DynamicPropertyRegistry registry) {
+        TestcontainersConfiguration.postgres.start();
+        TestcontainersConfiguration.kafka.start();
+        TestcontainersConfiguration.ensureKafkaTopics();
+        registry.add("spring.kafka.producer.properties.max.block.ms", () -> "4000");
+    }
+
+    @TestConfiguration
+    static class EventCaptureConfig {
+        static final AtomicInteger refreshCount = new AtomicInteger(0);
+
+        @EventListener
+        public void onRefresh(ContextRefreshedEvent event) {
+            if (event.getApplicationContext().getParent() == null) {
+                refreshCount.incrementAndGet();
+            }
+        }
+    }
+
+    @BeforeAll
+    static void resetCounters() {
+        EventCaptureConfig.refreshCount.set(0);
+    }
+
+    @Autowired
+    ConfigurableApplicationContext applicationContext;
+
+    @Autowired
+    MeterRegistry meterRegistry;
+
+    @Test
+    void contextLoadsSuccessfully() {
+        // If the context loaded, it means:
+        // - Database connectivity was verified successfully
+        // - Kafka connectivity and topic availability were verified
+        assertThat(applicationContext.isRunning()).isTrue();
+    }
+
+    @Test
+    void contextRefreshedEventFiredExactlyOnce() {
+        assertThat(EventCaptureConfig.refreshCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void warmUpProducesKafkaRequests() {
+        // Micrometer exposes Kafka client metrics only after the producer performs a request.
+        boolean hasAnyRequest = false;
+        for (var meter : meterRegistry.getMeters()) {
+            if (!meter.getId().getName().equals("kafka.producer.request.total")) {
+                continue;
+            }
+            for (var sample : meter.measure()) {
+                if (sample.getStatistic() == Statistic.COUNT && sample.getValue() > 0.0) {
+                    hasAnyRequest = true;
+                    break;
+                }
+            }
+        }
+        assertThat(hasAnyRequest)
+                .as("Warm-up should create at least one Kafka producer request " + "(kafka.producer.request.total > 0)")
+                .isTrue();
+
+        if (LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) instanceof Logger root) {
+            @SuppressWarnings("unchecked")
+            ListAppender<ILoggingEvent> appender = (ListAppender<ILoggingEvent>) root.getAppender("KAFKA_GUARD");
+            assertThat(appender)
+                    .as("Expected KAFKA_GUARD ListAppender in logback-test.xml")
+                    .isNotNull();
+            // If warm-up hits a non-existent topic, Kafka returns UNKNOWN_TOPIC_OR_PARTITION.
+            // We treat that as a failed warm-up (metadata error).
+            boolean hasUnknownTopic = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .filter(m -> m != null)
+                    .anyMatch(m -> m.toLowerCase().contains("unknown_topic_or_partition"));
+            assertThat(hasUnknownTopic)
+                    .as("Warm-up metadata lookup should succeed; UNKNOWN_TOPIC_OR_PARTITION means the "
+                            + "requested topic does not exist")
+                    .isFalse();
+        }
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/ApplicationLifecycleFailureTests.java
+++ b/src/test/java/com/sivalabs/ft/features/ApplicationLifecycleFailureTests.java
@@ -1,0 +1,409 @@
+package com.sivalabs.ft.features;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Universal integration tests for application lifecycle failure scenarios and graceful shutdown.
+ */
+class ApplicationLifecycleFailureTests {
+
+    @BeforeAll
+    static void ensureInfrastructure() {
+        TestcontainersConfiguration.postgres.start();
+        TestcontainersConfiguration.kafka.start();
+        createTopicsInBroker(
+                TestcontainersConfiguration.kafka.getBootstrapServers(),
+                List.of("new_features", "updated_features", "deleted_features"));
+    }
+
+    static void createTopicsInBroker(String bootstrapServers, List<String> topicNames) {
+        try (AdminClient admin =
+                AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers))) {
+            admin.createTopics(topicNames.stream()
+                            .map(name -> new NewTopic(name, 1, (short) 1))
+                            .toList())
+                    .all()
+                    .get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            // Topics might already exist, that's fine
+        }
+    }
+
+    static void waitForKafkaReady(String bootstrapServers, List<String> topicNames) {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            try (AdminClient admin =
+                    AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers))) {
+                var existing = admin.listTopics().names().get(3, TimeUnit.SECONDS);
+                if (existing.containsAll(topicNames)) {
+                    return;
+                }
+            } catch (Exception ignored) {
+                // Broker might not be ready yet
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    // ─── arg helpers ───
+
+    /** Standard args using shared postgres, given kafka bootstrap, standard topic names. */
+    private static List<String> args(String kafkaBootstrap, int timeout, String... extra) {
+        return args(
+                TestcontainersConfiguration.postgres.getJdbcUrl(),
+                TestcontainersConfiguration.postgres.getUsername(),
+                TestcontainersConfiguration.postgres.getPassword(),
+                kafkaBootstrap,
+                "new_features",
+                "updated_features",
+                "deleted_features",
+                timeout,
+                extra);
+    }
+
+    /** Fully parameterised arg builder. */
+    private static List<String> args(
+            String dbUrl,
+            String dbUser,
+            String dbPass,
+            String kafkaBootstrap,
+            String topicNew,
+            String topicUpdated,
+            String topicDeleted,
+            int timeout,
+            String... extra) {
+        List<String> list = new ArrayList<>(List.of(
+                "--spring.config.import=",
+                "--spring.datasource.url=" + dbUrl,
+                "--spring.datasource.username=" + dbUser,
+                "--spring.datasource.password=" + dbPass,
+                "--spring.kafka.bootstrap-servers=" + kafkaBootstrap,
+                "--spring.kafka.producer.properties.max.block.ms=4000",
+                "--server.port=0",
+                "--ft.events.new-features=" + topicNew,
+                "--ft.events.updated-features=" + topicUpdated,
+                "--ft.events.deleted-features=" + topicDeleted,
+                "--ft.shutdown.timeout-seconds=" + timeout));
+        list.addAll(List.of(extra));
+        return list;
+    }
+
+    private static ConfigurableApplicationContext start(List<String> argList) {
+        return new SpringApplicationBuilder(FeatureServiceApplication.class).run(argList.toArray(String[]::new));
+    }
+
+    // ─── helpers ───
+
+    private static String fullMessageChain(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        while (t != null) {
+            if (t.getMessage() != null) {
+                sb.append(t.getMessage()).append(" ");
+            }
+            t = t.getCause();
+        }
+        return sb.toString().toLowerCase();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setPhysicalCloseTimeout(ConfigurableApplicationContext ctx) {
+        // Disables automatic flush in producer.close() so the test validates listener-driven flush().
+        ProducerFactory<?, ?> raw = ctx.getBean(ProducerFactory.class);
+        if (raw instanceof DefaultKafkaProducerFactory<?, ?> dpf) {
+            dpf.setPhysicalCloseTimeout(0);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void sendMessage(ConfigurableApplicationContext ctx, String value) {
+        KafkaTemplate<String, Object> tpl = (KafkaTemplate<String, Object>) ctx.getBean(KafkaTemplate.class);
+        tpl.send("new_features", value);
+    }
+
+    // ──────────────────── Startup failure tests ────────────────────
+
+    @Test
+    void shouldFailStartupWhenDatabaseUnavailable() {
+        List<String> a = args(
+                "jdbc:postgresql://localhost:1/nonexistent",
+                "test",
+                "test",
+                TestcontainersConfiguration.kafka.getBootstrapServers(),
+                "new_features",
+                "updated_features",
+                "deleted_features",
+                10,
+                "--spring.datasource.hikari.connection-timeout=3000");
+
+        assertThatThrownBy(() -> start(a).close())
+                .as("Startup should fail when database is unavailable")
+                .satisfies(e -> assertThat(fullMessageChain(e)).containsPattern("(database|datasource|connection)"));
+    }
+
+    @Test
+    void shouldFailStartupWhenKafkaTopicsMissing() {
+        List<String> a = args(
+                TestcontainersConfiguration.postgres.getJdbcUrl(),
+                TestcontainersConfiguration.postgres.getUsername(),
+                TestcontainersConfiguration.postgres.getPassword(),
+                TestcontainersConfiguration.kafka.getBootstrapServers(),
+                "nonexistent_topic_abc",
+                "nonexistent_topic_def",
+                "nonexistent_topic_ghi",
+                10);
+
+        assertThatThrownBy(() -> start(a).close())
+                .as("Startup should fail when required Kafka topics are missing")
+                .satisfies(e -> assertThat(fullMessageChain(e)).containsPattern("(topic|missing)"));
+    }
+
+    /** Two of three topics exist — catches partial-check implementations. */
+    @Test
+    void shouldFailStartupWhenOneKafkaTopicMissing() {
+        String p = "partial_" + System.nanoTime() + "_";
+        createTopicsInBroker(
+                TestcontainersConfiguration.kafka.getBootstrapServers(), List.of(p + "new", p + "updated"));
+
+        List<String> a = args(
+                TestcontainersConfiguration.postgres.getJdbcUrl(),
+                TestcontainersConfiguration.postgres.getUsername(),
+                TestcontainersConfiguration.postgres.getPassword(),
+                TestcontainersConfiguration.kafka.getBootstrapServers(),
+                p + "new",
+                p + "updated",
+                p + "deleted",
+                10);
+
+        assertThatThrownBy(() -> start(a).close())
+                .as("Startup should fail when even one required Kafka topic is missing");
+    }
+
+    @Test
+    void shouldFailStartupWhenKafkaUnavailable() {
+        List<String> a = args(
+                "localhost:1",
+                10,
+                "--spring.kafka.admin.properties.request.timeout.ms=3000",
+                "--spring.kafka.admin.properties.default.api.timeout.ms=3000",
+                "--spring.kafka.properties.request.timeout.ms=3000",
+                "--spring.kafka.properties.default.api.timeout.ms=3000");
+
+        assertThatThrownBy(() -> start(a).close())
+                .as("Startup should fail when Kafka broker is unavailable")
+                .satisfies(e -> assertThat(fullMessageChain(e))
+                        .containsPattern("(kafka|broker|timed.out|timeout|connectivity)"));
+    }
+
+    // ──────────────────── Shutdown tests ────────────────────
+
+    @Test
+    void shutdownCompletesGracefully() {
+        ConfigurableApplicationContext ctx = start(args(TestcontainersConfiguration.kafka.getBootstrapServers(), 10));
+
+        assertThat(ctx.isRunning()).isTrue();
+
+        AtomicInteger closedCount = new AtomicInteger(0);
+        ctx.addApplicationListener(e -> {
+            if (e instanceof ContextClosedEvent) closedCount.incrementAndGet();
+        });
+
+        assertThatCode(ctx::close).doesNotThrowAnyException();
+        assertThat(closedCount.get())
+                .as("ContextClosedEvent should fire exactly once")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void shutdownFlushesKafkaMessages() {
+        String linger = "--spring.kafka.producer.properties.linger.ms=60000";
+        ConfigurableApplicationContext ctx =
+                start(args(TestcontainersConfiguration.kafka.getBootstrapServers(), 10, linger));
+
+        setPhysicalCloseTimeout(ctx);
+
+        String marker = "flush-verify-" + System.nanoTime();
+        sendMessage(ctx, marker);
+        ctx.close();
+
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(Map.of(
+                "bootstrap.servers", TestcontainersConfiguration.kafka.getBootstrapServers(),
+                "group.id", "flush-verify-" + System.nanoTime(),
+                "auto.offset.reset", "earliest",
+                "key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer",
+                "value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer"))) {
+            consumer.subscribe(List.of("new_features"));
+
+            boolean found = false;
+            long deadline = System.currentTimeMillis() + 8_000;
+            while (!found && System.currentTimeMillis() < deadline) {
+                ConsumerRecords<String, String> recs = consumer.poll(Duration.ofSeconds(1));
+                for (var r : recs) {
+                    if (r.value() != null && r.value().contains(marker)) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            assertThat(found)
+                    .as("Message should be flushed by the shutdown listener. "
+                            + "With linger.ms=60000 + physicalCloseTimeout=0, "
+                            + "only an explicit flush() delivers the message.")
+                    .isTrue();
+        }
+    }
+
+    /**
+     * Two contexts with different shutdown timeouts (1 s vs 8 s) on the same dead Kafka.
+     * Verifies:
+     *  1. No exception on shutdown
+     *  2. Error is logged (TD: "log the error and continue shutdown")
+     *  3. ft.shutdown.timeout-seconds is configurable (elapsed_long > elapsed_short * 2)
+     *  4. Flush timeout bounded to ~8 s (elapsed_long < 9 s)
+     */
+    @Test
+    void shutdownContinuesWhenKafkaFlushFails() {
+        try (KafkaContainer tempKafka = new KafkaContainer(DockerImageName.parse("apache/kafka-native:3.8.0"))) {
+            tempKafka.start();
+            createTopicsInBroker(
+                    tempKafka.getBootstrapServers(), List.of("new_features", "updated_features", "deleted_features"));
+            waitForKafkaReady(
+                    tempKafka.getBootstrapServers(), List.of("new_features", "updated_features", "deleted_features"));
+
+            // Disable automatic producer flush to ensure this test validates
+            // the listener's flush() call rather than Kafka client's automatic flush.
+            String linger = "--spring.kafka.producer.properties.linger.ms=60000";
+            ConfigurableApplicationContext ctxShort = start(args(tempKafka.getBootstrapServers(), 1, linger));
+            ConfigurableApplicationContext ctxLong = start(args(tempKafka.getBootstrapServers(), 8, linger));
+
+            assertThat(ctxShort.isRunning()).isTrue();
+            assertThat(ctxLong.isRunning()).isTrue();
+
+            setPhysicalCloseTimeout(ctxShort);
+            setPhysicalCloseTimeout(ctxLong);
+
+            // Buffer messages while Kafka is alive (linger.ms keeps them unsent)
+            sendMessage(ctxShort, "flush-fail-short");
+            sendMessage(ctxLong, "flush-fail-long");
+
+            // Kill Kafka — flush will block until timeout
+            tempKafka.stop();
+
+            ListAppender<ILoggingEvent> appender = null;
+            if (LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) instanceof Logger root) {
+                @SuppressWarnings("unchecked")
+                ListAppender<ILoggingEvent> existing = (ListAppender<ILoggingEvent>) root.getAppender("KAFKA_GUARD");
+                if (existing != null) {
+                    existing.list.clear();
+                    appender = existing;
+                }
+            }
+
+            // ── short-timeout shutdown (1 s) ──
+            long t0 = System.currentTimeMillis();
+            assertThatCode(ctxShort::close).doesNotThrowAnyException();
+            long elapsedShort = System.currentTimeMillis() - t0;
+
+            // ── long-timeout shutdown (8 s) ──
+            long t1 = System.currentTimeMillis();
+            assertThatCode(ctxLong::close).doesNotThrowAnyException();
+            long elapsedLong = System.currentTimeMillis() - t1;
+
+            // ── Configurable timeout ──
+            // Only assert when the short shutdown actually waited (not fail-fast).
+            if (elapsedShort > 500) {
+                assertThat(elapsedLong)
+                        .as(
+                                "timeout=8 should take longer than timeout=1, "
+                                        + "proving ft.shutdown.timeout-seconds is used. "
+                                        + "short=%dms, long=%dms",
+                                elapsedShort, elapsedLong)
+                        .isGreaterThan(elapsedShort * 2);
+            }
+
+            // ── Flush bounded to ~8 s even with total=8 ──
+            assertThat(elapsedLong)
+                    .as("Flush should be bounded to ~8 s max (elapsed=%dms)", elapsedLong)
+                    .isLessThan(9_000);
+
+            // ── Verify error was logged ──
+            if (appender != null) {
+                List<String> warns = new ArrayList<>(appender.list)
+                        .stream()
+                                .filter(e -> e.getLevel().isGreaterOrEqual(Level.WARN))
+                                .filter(e -> {
+                                    String name = e.getLoggerName();
+                                    return name != null && name.startsWith("com.sivalabs.ft.features");
+                                })
+                                .map(ILoggingEvent::getFormattedMessage)
+                                .filter(m -> m != null)
+                                .toList();
+                assertThat(warns)
+                        .as("Shutdown should log an error/warning about flush failure")
+                        .anyMatch(m -> {
+                            String l = m.toLowerCase();
+                            return (l.contains("flush") || l.contains("kafka"))
+                                    && (l.contains("fail")
+                                            || l.contains("error")
+                                            || l.contains("timed")
+                                            || l.contains("timeout")
+                                            || l.contains("exceeded"));
+                        });
+            }
+        }
+    }
+
+    /** Shutdown continues when the DB pool is already closed. */
+    @Test
+    void shutdownContinuesWhenDatabaseAlreadyClosed() {
+        ConfigurableApplicationContext ctx = start(args(TestcontainersConfiguration.kafka.getBootstrapServers(), 10));
+
+        assertThat(ctx.isRunning()).isTrue();
+
+        DataSource ds = ctx.getBean(DataSource.class);
+        if (ds instanceof AutoCloseable c) {
+            try {
+                c.close();
+            } catch (Exception ignored) {
+            }
+        }
+
+        assertThatCode(ctx::close)
+                .as("Shutdown should continue when DB pool is already closed")
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/FeatureServiceApplicationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/FeatureServiceApplicationTests.java
@@ -3,10 +3,19 @@ package com.sivalabs.ft.features;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest
 @Import(TestcontainersConfiguration.class)
 class FeatureServiceApplicationTests {
+
+    @DynamicPropertySource
+    static void ensureKafkaTopics(DynamicPropertyRegistry registry) {
+        TestcontainersConfiguration.postgres.start();
+        TestcontainersConfiguration.kafka.start();
+        TestcontainersConfiguration.ensureKafkaTopics();
+    }
 
     @Test
     void contextLoads() {}

--- a/src/test/java/com/sivalabs/ft/features/NoAutoCreateTopicsTest.java
+++ b/src/test/java/com/sivalabs/ft/features/NoAutoCreateTopicsTest.java
@@ -1,0 +1,122 @@
+package com.sivalabs.ft.features;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class NoAutoCreateTopicsTest {
+
+    // This test uses a dedicated KafkaContainer with auto-create disabled so we can
+    // verify that the application does not auto-create Kafka topics on startup
+
+    @Container
+    private static final KafkaContainer strictKafka = new KafkaContainer(
+                    DockerImageName.parse("apache/kafka-native:3.8.0"))
+            .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+
+    @BeforeAll
+    static void startContainers() {
+        TestcontainersConfiguration.postgres.start();
+    }
+
+    @Test
+    void shouldNotCreateTopicsAutomatically() {
+        Set<String> before = listTopics(strictKafka.getBootstrapServers());
+
+        List<String> args = args(
+                TestcontainersConfiguration.postgres,
+                strictKafka.getBootstrapServers(),
+                "new_features",
+                "updated_features",
+                "deleted_features",
+                10);
+
+        assertThatThrownBy(() -> start(args).close())
+                .as("Startup must fail when required topics are missing and auto-create is disabled")
+                .satisfies(e ->
+                        assertThat(fullMessageChain(e)).containsPattern("(topic|missing|unknown|metadata|timeout)"));
+
+        Set<String> after = listTopics(strictKafka.getBootstrapServers());
+
+        assertThat(after)
+                .as("Application must NOT create Kafka topics automatically")
+                .doesNotContain("new_features", "updated_features", "deleted_features");
+
+        Set<String> newTopics = new HashSet<>(after);
+        newTopics.removeAll(before);
+        newTopics.removeAll(Set.of("__consumer_offsets"));
+        assertThat(newTopics).as("Unexpected topics created: " + newTopics).isEmpty();
+    }
+
+    private static List<String> args(
+            PostgreSQLContainer<?> postgres,
+            String kafkaBootstrap,
+            String topicNew,
+            String topicUpdated,
+            String topicDeleted,
+            int timeout) {
+        return new ArrayList<>(List.of(
+                "--spring.config.import=",
+                "--spring.datasource.url=" + postgres.getJdbcUrl(),
+                "--spring.datasource.username=" + postgres.getUsername(),
+                "--spring.datasource.password=" + postgres.getPassword(),
+                "--spring.kafka.bootstrap-servers=" + kafkaBootstrap,
+                "--spring.kafka.producer.properties.max.block.ms=4000",
+                "--server.port=0",
+                "--ft.events.new-features=" + topicNew,
+                "--ft.events.updated-features=" + topicUpdated,
+                "--ft.events.deleted-features=" + topicDeleted,
+                "--ft.shutdown.timeout-seconds=" + timeout));
+    }
+
+    private static ConfigurableApplicationContext start(List<String> argList) {
+        return new SpringApplicationBuilder(FeatureServiceApplication.class).run(argList.toArray(String[]::new));
+    }
+
+    private static Set<String> listTopics(String bootstrapServers) {
+        long deadline = System.currentTimeMillis() + 10_000;
+        Exception last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try (AdminClient adminClient = AdminClient.create(new java.util.HashMap<>(
+                    java.util.Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)))) {
+                return adminClient.listTopics().names().get(2, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (Exception e) {
+                last = e;
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while waiting for Kafka readiness", ie);
+                }
+            }
+        }
+        throw new RuntimeException("Failed to list Kafka topics within timeout", last);
+    }
+
+    private static String fullMessageChain(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        while (t != null) {
+            if (t.getMessage() != null) {
+                sb.append(t.getMessage()).append(" ");
+            }
+            t = t.getCause();
+        }
+        return sb.toString().toLowerCase();
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/TestcontainersConfiguration.java
+++ b/src/test/java/com/sivalabs/ft/features/TestcontainersConfiguration.java
@@ -1,5 +1,10 @@
 package com.sivalabs.ft.features;
 
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -29,5 +34,37 @@ public class TestcontainersConfiguration {
     @ServiceConnection
     KafkaContainer kafkaContainer() {
         return kafka;
+    }
+
+    static void ensureKafkaTopics() {
+        List<String> topics = List.of("new_features", "updated_features", "deleted_features");
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            try (AdminClient admin = AdminClient.create(
+                    Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers()))) {
+                admin.createTopics(topics.stream()
+                                .map(name -> new NewTopic(name, 1, (short) 1))
+                                .toList())
+                        .all()
+                        .get(5, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (Exception ignored) {
+                // Topics might already exist or broker may not be ready yet.
+            }
+            try (AdminClient admin = AdminClient.create(
+                    Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers()))) {
+                var existing = admin.listTopics().names().get(3, java.util.concurrent.TimeUnit.SECONDS);
+                if (existing.containsAll(topics)) {
+                    return;
+                }
+            } catch (Exception ignored) {
+                // Broker might not be ready yet.
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <!-- ListAppender for capturing log events in memory (used by lifecycle tests
+         to verify error/warning messages, e.g. UNKNOWN_TOPIC_OR_PARTITION). -->
+    <appender name="KAFKA_GUARD" class="ch.qos.logback.core.read.ListAppender"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="KAFKA_GUARD"/>
+    </root>
+</configuration>
+


### PR DESCRIPTION
## Objective

Implement Spring ApplicationContext lifecycle event listeners for `ContextRefreshedEvent` (startup) and
`ContextClosedEvent` (shutdown) in the feature-service to handle critical resource initialization and cleanup.
The implementation should verify database connectivity and warm up Kafka producer connections on startup, and ensure
graceful shutdown with proper resource cleanup.

## Requirements

### Lifecycle Event Listeners

Implement a Spring component with `@EventListener` methods that handle `ContextRefreshedEvent` (startup) and `ContextClosedEvent` (shutdown) to execute initialization and cleanup tasks.

#### Startup tasks

- Database connectivity verification: test PostgreSQL connection is operational.
- Kafka producer warm-up: verify Kafka connectivity and configured topics are accessible by calling partitionsFor() during startup.

#### Startup behavior

- Database unavailable → FAIL (throw exception).
- Kafka unavailable → FAIL (throw exception).

#### Kafka check

- Check all three topics from `ApplicationProperties` (`new_features`, `updated_features`, `deleted_features`).
- Do not create topics automatically.

#### Shutdown/Cleanup tasks

- Flush pending Kafka messages to ensure no data loss.
- Rely on Spring Boot to automatically close database connections via `DisposableBean` mechanism.
- Shutdown should continue even if one task fails.

#### Shutdown behavior

- If flush fails within timeout: log the error and continue shutdown (do not block or retry).
- **Handle InterruptedException correctly by restoring interrupt status to prevent shutdown hangs.**
- Shutdown order: 1) Flush Kafka, 2) Close DB.

#### Shutdown timeouts

- Kafka flush timeout: 10 seconds maximum wait time for pending messages to be flushed.
- Total shutdown timeout: 30 seconds (configurable).

## Testing and Validation

- Use tests that capture lifecycle events to verify the `ContextRefreshedEvent` and `ContextClosedEvent` listener is
  called exactly once during application startup and shutdown, as Spring may publish lifecycle events multiple times
- Test successful and failure database connection during startup and shutdown.
- Test successful Kafka connectivity and failed connectivity during startup and shutdown.
- Verify application startup fails when database or Kafka unavailable.
- Verify application shutdown gracefully even if unable to close the connection or clean the resources.
- Verify appropriate error message/code is returned to indicate the failure.

## Acceptance Criteria

- Listeners handle `ContextRefreshedEvent` (startup) and `ContextClosedEvent` (shutdown).
- Initialization and cleanup logic is correctly executed and log the appropriate error messages.
- Tests validate lifecycle event handling.
- Documentation covers the lifecycle of listeners.

## Implementation Notes

### ApplicationProperties Structure
Create nested configuration records: events properties containing the three topic names, and shutdown properties containing timeout configuration.

### Concurrency Considerations
- Handle duplicate Spring lifecycle events using appropriate synchronization mechanisms
- Restore interrupt status when handling InterruptedException to ensure proper shutdown behavior
- Use thread-safe constructs for exactly-once execution guarantees