### PR TITLE
Implement User Notification System: Realtime Unread Count, Filtering by Status, Marking all Read

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.NotificationIntegrationTest",
+      "com.sivalabs.ft.features.api.controllers.NotificationRealtimeIntegrationTest",
+      "com.sivalabs.ft.features.api.controllers.NotificationWebSocketIntegrationTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/ApplicationProperties.java
@@ -11,5 +11,6 @@ public record ApplicationProperties(
         @NotBlank(message = "ft.public-base-url property is required") String publicBaseUrl,
         @NotBlank(message = "ft.mail-from property is required") String mailFrom) {
 
-    public record EventsProperties(String newFeatures, String updatedFeatures, String deletedFeatures) {}
+    public record EventsProperties(
+            String newFeatures, String updatedFeatures, String deletedFeatures, String unreadCount) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationController.java
@@ -17,9 +17,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -50,13 +52,25 @@ class NotificationController {
                                                         schema = @Schema(implementation = NotificationDto.class)))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized")
             })
-    ResponseEntity<Page<NotificationDto>> getNotifications(Pageable pageable) {
+    ResponseEntity<Page<NotificationDto>> getNotifications(
+            @RequestParam(name = "status", required = false) String status, Pageable pageable) {
         String username = SecurityUtils.getCurrentUsername();
         if (username == null) {
             return ResponseEntity.status(401).build();
         }
 
-        Page<NotificationDto> notifications = notificationService.getNotificationsForUser(username, pageable);
+        Boolean read = null;
+        if (status != null && !status.isBlank()) {
+            if ("read".equalsIgnoreCase(status)) {
+                read = true;
+            } else if ("unread".equalsIgnoreCase(status)) {
+                read = false;
+            } else {
+                return ResponseEntity.badRequest().build();
+            }
+        }
+
+        Page<NotificationDto> notifications = notificationService.getNotificationsForUser(username, read, pageable);
         return ResponseEntity.ok(notifications);
     }
 
@@ -121,4 +135,30 @@ class NotificationController {
             return ResponseEntity.notFound().build();
         }
     }
+
+    @PatchMapping("/mark-all-read")
+    @Operation(
+            summary = "Mark all notifications as read",
+            description = "Mark all unread notifications as read for the current user",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = MarkAllReadResponse.class))),
+                @ApiResponse(responseCode = "401", description = "Unauthorized")
+            })
+    ResponseEntity<MarkAllReadResponse> markAllAsRead() {
+        String username = SecurityUtils.getCurrentUsername();
+        if (username == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        long updated = notificationService.markAllAsRead(username);
+        return ResponseEntity.ok(new MarkAllReadResponse(updated));
+    }
+
+    record MarkAllReadResponse(long updated) {}
 }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationTrackingController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/NotificationTrackingController.java
@@ -2,6 +2,7 @@ package com.sivalabs.ft.features.api.controllers;
 
 import com.sivalabs.ft.features.domain.NotificationRepository;
 import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.events.UnreadCountChangedPublisher;
 import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import java.time.Instant;
@@ -14,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,9 +34,12 @@ class NotificationTrackingController {
             Base64.getDecoder().decode("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
 
     private final NotificationRepository notificationRepository;
+    private final UnreadCountChangedPublisher unreadCountChangedPublisher;
 
-    NotificationTrackingController(NotificationRepository notificationRepository) {
+    NotificationTrackingController(
+            NotificationRepository notificationRepository, UnreadCountChangedPublisher unreadCountChangedPublisher) {
         this.notificationRepository = notificationRepository;
+        this.unreadCountChangedPublisher = unreadCountChangedPublisher;
     }
 
     @GetMapping("/notifications/{id}/read")
@@ -50,12 +56,24 @@ class NotificationTrackingController {
                 .findById(notificationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
 
+        long previousUnreadCount = notificationRepository.countUnread(notification.getRecipientUserId());
+
         // Idempotent: only update if not already read
         if (!Boolean.TRUE.equals(notification.getRead())) {
             notification.setRead(true);
             notification.setReadAt(Instant.now());
             notificationRepository.save(notification);
             log.info("Notification {} marked as read via tracking pixel", notificationId);
+
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    long currentUnreadCount = notificationRepository.countUnread(notification.getRecipientUserId());
+                    if (currentUnreadCount != previousUnreadCount) {
+                        unreadCountChangedPublisher.publish(notification.getRecipientUserId(), currentUnreadCount);
+                    }
+                }
+            });
         } else {
             log.debug("Notification {} already read, skipping update", notificationId);
         }

--- a/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
@@ -3,13 +3,13 @@ package com.sivalabs.ft.features.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -44,7 +44,15 @@ class SecurityConfig {
                 .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .cors(CorsConfigurer::disable)
                 .csrf(CsrfConfigurer::disable)
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+                .oauth2ResourceServer(
+                        oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
         return http.build();
+    }
+
+    @Bean
+    JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setPrincipalClaimName("preferred_username");
+        return converter;
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/config/WebSocketConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package com.sivalabs.ft.features.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final WebSocketProperties properties;
+
+    WebSocketConfig(WebSocketProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint(properties.endpoint()).setAllowedOrigins(properties.allowedOrigins());
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/queue");
+        registry.setUserDestinationPrefix("/user");
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/WebSocketProperties.java
+++ b/src/main/java/com/sivalabs/ft/features/config/WebSocketProperties.java
@@ -1,0 +1,16 @@
+package com.sivalabs.ft.features.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "app.websocket")
+@Validated
+public record WebSocketProperties(
+        @NotBlank(message = "app.websocket.endpoint property is required") String endpoint, String allowedOrigins) {
+    public WebSocketProperties {
+        if (allowedOrigins == null || allowedOrigins.isBlank()) {
+            allowedOrigins = "*";
+        }
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationRepository.java
@@ -19,6 +19,14 @@ public interface NotificationRepository extends ListCrudRepository<Notification,
     Page<Notification> findByRecipientUserIdOrderByCreatedAtDesc(String recipientUserId, Pageable pageable);
 
     /**
+     * Find notifications by recipient and read state
+     */
+    @Query(
+            "SELECT n FROM Notification n WHERE n.recipientUserId = :recipientUserId AND n.read = :read ORDER BY n.createdAt DESC")
+    Page<Notification> findByRecipientUserIdAndReadOrderByCreatedAtDesc(
+            String recipientUserId, Boolean read, Pageable pageable);
+
+    /**
      * Mark notification as read
      */
     @Modifying
@@ -35,9 +43,23 @@ public interface NotificationRepository extends ListCrudRepository<Notification,
     int markAsUnread(UUID id, String recipientUserId);
 
     /**
+     * Mark all notifications as read for a user
+     */
+    @Modifying
+    @Query(
+            "UPDATE Notification n SET n.read = true, n.readAt = :readAt WHERE n.recipientUserId = :recipientUserId AND n.read = false")
+    int markAllAsRead(String recipientUserId, Instant readAt);
+
+    /**
      * Update delivery status (used for FAILED status when email sending fails)
      */
     @Modifying
     @Query("UPDATE Notification n SET n.deliveryStatus = :deliveryStatus WHERE n.id = :id")
     int updateDeliveryStatus(UUID id, DeliveryStatus deliveryStatus);
+
+    /**
+     * Count unread notifications for a user
+     */
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.recipientUserId = :recipientUserId AND n.read = false")
+    long countUnread(String recipientUserId);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/NotificationService.java
@@ -2,6 +2,7 @@ package com.sivalabs.ft.features.domain;
 
 import com.sivalabs.ft.features.domain.dtos.NotificationDto;
 import com.sivalabs.ft.features.domain.entities.Notification;
+import com.sivalabs.ft.features.domain.events.UnreadCountChangedPublisher;
 import com.sivalabs.ft.features.domain.exceptions.ResourceNotFoundException;
 import com.sivalabs.ft.features.domain.mappers.NotificationMapper;
 import com.sivalabs.ft.features.domain.models.DeliveryStatus;
@@ -26,14 +27,17 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final NotificationMapper notificationMapper;
     private final NotificationEmailService notificationEmailService;
+    private final UnreadCountChangedPublisher unreadCountChangedPublisher;
 
     public NotificationService(
             NotificationRepository notificationRepository,
             NotificationMapper notificationMapper,
-            NotificationEmailService notificationEmailService) {
+            NotificationEmailService notificationEmailService,
+            UnreadCountChangedPublisher unreadCountChangedPublisher) {
         this.notificationRepository = notificationRepository;
         this.notificationMapper = notificationMapper;
         this.notificationEmailService = notificationEmailService;
+        this.unreadCountChangedPublisher = unreadCountChangedPublisher;
     }
 
     /**
@@ -46,6 +50,8 @@ public class NotificationService {
             NotificationEventType eventType,
             String eventDetails,
             String link) {
+
+        long previousUnreadCount = notificationRepository.countUnread(recipientUserId);
 
         var notification = new Notification();
         notification.setRecipientUserId(recipientUserId);
@@ -67,6 +73,7 @@ public class NotificationService {
             @Override
             public void afterCommit() {
                 notificationEmailService.sendNotificationEmail(savedNotification);
+                publishUnreadCountIfChanged(recipientUserId, previousUnreadCount);
             }
         });
 
@@ -106,6 +113,7 @@ public class NotificationService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
+                publishUnreadCountForBatch(savedNotifications);
                 for (Notification savedNotification : savedNotifications) {
                     notificationEmailService.sendNotificationEmail(savedNotification);
                 }
@@ -130,8 +138,18 @@ public class NotificationService {
      */
     @Transactional(readOnly = true)
     public Page<NotificationDto> getNotificationsForUser(String recipientUserId, Pageable pageable) {
-        Page<Notification> notifications =
-                notificationRepository.findByRecipientUserIdOrderByCreatedAtDesc(recipientUserId, pageable);
+        return getNotificationsForUser(recipientUserId, null, pageable);
+    }
+
+    /**
+     * Get notifications for a user with pagination and optional read status
+     */
+    @Transactional(readOnly = true)
+    public Page<NotificationDto> getNotificationsForUser(String recipientUserId, Boolean read, Pageable pageable) {
+        Page<Notification> notifications = read == null
+                ? notificationRepository.findByRecipientUserIdOrderByCreatedAtDesc(recipientUserId, pageable)
+                : notificationRepository.findByRecipientUserIdAndReadOrderByCreatedAtDesc(
+                        recipientUserId, read, pageable);
         return notifications.map(notificationMapper::toDto);
     }
 
@@ -141,6 +159,7 @@ public class NotificationService {
      */
     @Transactional
     public NotificationDto markAsRead(UUID notificationId, String recipientUserId) {
+        long previousUnreadCount = notificationRepository.countUnread(recipientUserId);
         Instant readAt = Instant.now();
         int updated = notificationRepository.markAsRead(notificationId, recipientUserId, readAt);
 
@@ -155,6 +174,8 @@ public class NotificationService {
 
         log.info("Marked notification {} as read for user {}", notificationId, recipientUserId);
 
+        publishUnreadCountAfterCommit(recipientUserId, previousUnreadCount);
+
         return notificationMapper.toDto(notification);
     }
 
@@ -164,6 +185,7 @@ public class NotificationService {
      */
     @Transactional
     public NotificationDto markAsUnread(UUID notificationId, String recipientUserId) {
+        long previousUnreadCount = notificationRepository.countUnread(recipientUserId);
         int updated = notificationRepository.markAsUnread(notificationId, recipientUserId);
 
         if (updated == 0) {
@@ -177,6 +199,47 @@ public class NotificationService {
 
         log.info("Marked notification {} as unread for user {}", notificationId, recipientUserId);
 
+        publishUnreadCountAfterCommit(recipientUserId, previousUnreadCount);
+
         return notificationMapper.toDto(notification);
+    }
+
+    /**
+     * Mark all notifications as read for a user
+     */
+    @Transactional
+    public long markAllAsRead(String recipientUserId) {
+        long previousUnreadCount = notificationRepository.countUnread(recipientUserId);
+        Instant readAt = Instant.now();
+        long updated = notificationRepository.markAllAsRead(recipientUserId, readAt);
+        publishUnreadCountAfterCommit(recipientUserId, previousUnreadCount);
+        log.info("Marked {} notifications as read for user {}", updated, recipientUserId);
+        return updated;
+    }
+
+    void publishUnreadCountAfterCommit(String recipientUserId, long previousUnreadCount) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                publishUnreadCountIfChanged(recipientUserId, previousUnreadCount);
+            }
+        });
+    }
+
+    void publishUnreadCountIfChanged(String recipientUserId, long previousUnreadCount) {
+        long currentUnreadCount = notificationRepository.countUnread(recipientUserId);
+        if (currentUnreadCount != previousUnreadCount) {
+            unreadCountChangedPublisher.publish(recipientUserId, currentUnreadCount);
+        }
+    }
+
+    void publishUnreadCountForBatch(List<Notification> savedNotifications) {
+        savedNotifications.stream()
+                .map(Notification::getRecipientUserId)
+                .distinct()
+                .forEach(recipientUserId -> {
+                    long currentUnreadCount = notificationRepository.countUnread(recipientUserId);
+                    unreadCountChangedPublisher.publish(recipientUserId, currentUnreadCount);
+                });
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountChangedConsumer.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountChangedConsumer.java
@@ -1,0 +1,22 @@
+package com.sivalabs.ft.features.domain.events;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UnreadCountChangedConsumer {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public UnreadCountChangedConsumer(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @KafkaListener(
+            topics = "${ft.events.unread-count}",
+            groupId = "${ft.events.unread-count.group-id:${spring.application.name}-${random.uuid}}")
+    public void onUnreadCountChanged(UnreadCountChangedEvent event) {
+        UnreadCountMessage message = new UnreadCountMessage(event.type(), event.unreadCount());
+        messagingTemplate.convertAndSendToUser(event.recipientUserId(), "/queue/notifications", message);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountChangedEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountChangedEvent.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.events;
+
+public record UnreadCountChangedEvent(String type, String recipientUserId, long unreadCount) {
+    public static UnreadCountChangedEvent of(String recipientUserId, long unreadCount) {
+        return new UnreadCountChangedEvent("UnreadCountChanged", recipientUserId, unreadCount);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountChangedPublisher.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountChangedPublisher.java
@@ -1,0 +1,29 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.ApplicationProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UnreadCountChangedPublisher {
+    private static final Logger log = LoggerFactory.getLogger(UnreadCountChangedPublisher.class);
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationProperties properties;
+
+    public UnreadCountChangedPublisher(KafkaTemplate<String, Object> kafkaTemplate, ApplicationProperties properties) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.properties = properties;
+    }
+
+    public void publish(String recipientUserId, long unreadCount) {
+        UnreadCountChangedEvent event = UnreadCountChangedEvent.of(recipientUserId, unreadCount);
+        kafkaTemplate.send(properties.events().unreadCount(), event).whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.warn("Failed to publish unread count event for user {}", recipientUserId, ex);
+            }
+        });
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountMessage.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/UnreadCountMessage.java
@@ -1,0 +1,3 @@
+package com.sivalabs.ft.features.domain.events;
+
+public record UnreadCountMessage(String type, long unreadCount) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ ft.openapi.contact.email=support@sivalabs.in
 ft.events.new-features=new_features
 ft.events.updated-features=updated_features
 ft.events.deleted-features=deleted_features
+ft.events.unread-count=unread_count_changed
+ft.events.unread-count.group-id=${spring.application.name}-${random.uuid}
 ft.public-base-url=http://localhost:8081
 ft.mail-from=noreply@feature-service.com
 
@@ -50,5 +52,10 @@ spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.Str
 #spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
 spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
 spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
-spring.kafka.producer.properties.spring.json.add.type.headers=true
 spring.kafka.consumer.properties.spring.json.trusted.packages=*
+spring.kafka.consumer.properties.spring.json.value.default.type=com.sivalabs.ft.features.domain.events.UnreadCountChangedEvent
+spring.kafka.consumer.properties.spring.json.use.type.headers=false
+
+######## WebSocket Configuration  #########
+app.websocket.endpoint=/ws
+app.websocket.allowed-origins=*

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationIntegrationTest.java
@@ -9,6 +9,7 @@ import com.sivalabs.ft.features.AbstractIT;
 import com.sivalabs.ft.features.MockOAuth2UserContextFactory;
 import com.sivalabs.ft.features.WithMockOAuth2User;
 import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -27,6 +29,7 @@ import org.springframework.test.context.jdbc.Sql;
  * Tests that notifications are created synchronously when features are created/updated/deleted
  */
 @Sql("/test-data.sql")
+@Import(MockJavaMailSenderConfig.class)
 class NotificationIntegrationTest extends AbstractIT {
 
     @Autowired
@@ -159,12 +162,12 @@ class NotificationIntegrationTest extends AbstractIT {
     @Test
     void shouldMarkNotificationAsRead() throws Exception {
         // Given - Create a feature as creator, assigned to assignee
-        setAuthenticationContext("creator");
         CreateFeaturePayload payload =
                 new CreateFeaturePayload("intellij", "Read Test Feature", "Test read functionality", null, "assignee");
 
         mvc.post()
                 .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(payload))
                 .exchange();
@@ -202,12 +205,12 @@ class NotificationIntegrationTest extends AbstractIT {
     @Test
     void shouldMarkNotificationAsUnread() throws Exception {
         // Given - Create a feature as creator, assigned to assignee
-        setAuthenticationContext("creator");
         CreateFeaturePayload payload = new CreateFeaturePayload(
                 "intellij", "Unread Test Feature", "Test unread functionality", null, "assignee");
 
         mvc.post()
                 .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(payload))
                 .exchange();
@@ -264,6 +267,150 @@ class NotificationIntegrationTest extends AbstractIT {
                 Integer.class,
                 notificationId);
         assertThat(unreadCount).isEqualTo(1);
+    }
+
+    @Test
+    void shouldFilterNotificationsByStatus() throws Exception {
+        // Given - Create two notifications for assignee
+        CreateFeaturePayload payload1 =
+                new CreateFeaturePayload("intellij", "Filter Feature 1", "Test filter 1", null, "assignee");
+        CreateFeaturePayload payload2 =
+                new CreateFeaturePayload("intellij", "Filter Feature 2", "Test filter 2", null, "assignee");
+
+        mvc.post()
+                .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload1))
+                .exchange();
+        mvc.post()
+                .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload2))
+                .exchange();
+
+        // Mark one as read
+        UUID notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1",
+                UUID.class,
+                "assignee");
+
+        mvc.put()
+                .uri("/api/notifications/{id}/read", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+
+        // When - filter read
+        var readResponse = mvc.get()
+                .uri("/api/notifications?status=read")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+        assertThat(readResponse).hasStatus2xxSuccessful();
+
+        Map<String, Object> readPage =
+                objectMapper.readValue(readResponse.getResponse().getContentAsString(), new TypeReference<>() {});
+        List<Map<String, Object>> readNotifications = (List<Map<String, Object>>) readPage.get("content");
+
+        assertThat(readNotifications).hasSize(1);
+        assertThat(readNotifications.get(0).get("read")).isEqualTo(true);
+
+        // When - filter unread
+        var unreadResponse = mvc.get()
+                .uri("/api/notifications?status=unread")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+        assertThat(unreadResponse).hasStatus2xxSuccessful();
+
+        Map<String, Object> unreadPage =
+                objectMapper.readValue(unreadResponse.getResponse().getContentAsString(), new TypeReference<>() {});
+        List<Map<String, Object>> unreadNotifications = (List<Map<String, Object>>) unreadPage.get("content");
+
+        assertThat(unreadNotifications).hasSize(1);
+        assertThat(unreadNotifications.get(0).get("read")).isEqualTo(false);
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidStatusFilter() throws Exception {
+        var response = mvc.get()
+                .uri("/api/notifications?status=invalid")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+
+        assertThat(response).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void shouldMarkAllNotificationsAsRead() throws Exception {
+        // Given - Create two notifications for assignee
+        CreateFeaturePayload payload1 =
+                new CreateFeaturePayload("intellij", "Mark All 1", "Test mark all 1", null, "assignee");
+        CreateFeaturePayload payload2 =
+                new CreateFeaturePayload("intellij", "Mark All 2", "Test mark all 2", null, "assignee");
+
+        mvc.post()
+                .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload1))
+                .exchange();
+        mvc.post()
+                .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload2))
+                .exchange();
+
+        // Capture notification ids before mark-all-read (to compare read_at timestamps).
+        List<UUID> notificationIds = jdbcTemplate.queryForList(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC",
+                UUID.class,
+                "assignee");
+        assertThat(notificationIds).hasSize(2);
+
+        // When - mark all as read
+        var response = mvc.patch()
+                .uri("/api/notifications/mark-all-read")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+
+        assertThat(response).hasStatus2xxSuccessful();
+
+        Map<String, Object> body =
+                objectMapper.readValue(response.getResponse().getContentAsString(), new TypeReference<>() {});
+        assertThat(body.get("updated")).isEqualTo(2);
+
+        Integer unreadCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ? AND read = false",
+                Integer.class,
+                "assignee");
+        assertThat(unreadCount).isEqualTo(0);
+
+        // All notifications should share the same read_at timestamp for a mark-all-read update.
+        List<java.time.Instant> readAts = jdbcTemplate.queryForList(
+                "SELECT read_at FROM notifications WHERE id IN (?, ?) ORDER BY read_at ASC",
+                java.time.Instant.class,
+                notificationIds.get(0),
+                notificationIds.get(1));
+        assertThat(readAts).hasSize(2);
+        assertThat(readAts.get(0)).isNotNull();
+        assertThat(readAts.get(0)).isEqualTo(readAts.get(1));
+
+        // When - mark all again (idempotent)
+        var response2 = mvc.patch()
+                .uri("/api/notifications/mark-all-read")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "assignee")))
+                .exchange();
+
+        Map<String, Object> body2 =
+                objectMapper.readValue(response2.getResponse().getContentAsString(), new TypeReference<>() {});
+        assertThat(body2.get("updated")).isEqualTo(0);
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenMarkAllReadWithoutAuth() {
+        var response = mvc.patch().uri("/api/notifications/mark-all-read").exchange();
+        assertThat(response).hasStatus(HttpStatus.UNAUTHORIZED);
     }
 
     @Test

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationRealtimeIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationRealtimeIntegrationTest.java
@@ -1,0 +1,395 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.kafka.KafkaContainer;
+
+@Import(MockJavaMailSenderConfig.class)
+@TestPropertySource(properties = "spring.kafka.consumer.auto-offset-reset=earliest")
+class NotificationRealtimeIntegrationTest extends AbstractIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private KafkaContainer kafkaContainer;
+
+    @Value("${ft.events.unread-count}")
+    private String unreadCountTopic;
+
+    private KafkaConsumer<String, String> unreadCountConsumer;
+
+    @BeforeEach
+    void setupConsumer() throws InterruptedException {
+        assertThat(unreadCountTopic).isNotNull();
+
+        unreadCountConsumer = createConsumer();
+
+        List<TopicPartition> partitions = waitForPartitions(unreadCountConsumer, unreadCountTopic);
+        unreadCountConsumer.assign(partitions);
+        unreadCountConsumer.seekToEnd(partitions);
+
+        // Materialize the seek position before producing events
+        unreadCountConsumer.poll(Duration.ofMillis(100));
+    }
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.execute("DELETE FROM notifications");
+        jdbcTemplate.execute("DELETE FROM users");
+    }
+
+    @Test
+    void shouldPublishUnreadCountEventsToKafka() throws Exception {
+        // Given - create a unique recipient user to avoid cross-test event collisions
+        String testRecipientUserId = "assignee_" + UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (username, email) VALUES (?, ?)",
+                testRecipientUserId,
+                testRecipientUserId + "@company.com");
+
+        // Given - create a notification (unread)
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("productCode", "intellij");
+        payload.put("title", "Realtime Feature");
+        payload.put("description", "Test realtime");
+        payload.put("releaseCode", null);
+        payload.put("assignedTo", testRecipientUserId);
+        var createResult = mvc.post()
+                .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                .contentType("application/json")
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+        assertThat(createResult).hasStatus2xxSuccessful();
+
+        // First event: unread count becomes 1
+        JsonNode first = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(first.path("type").asText()).isEqualTo("UnreadCountChanged");
+        assertThat(first.path("recipientUserId").asText()).isEqualTo(testRecipientUserId);
+        assertThat(first.path("unreadCount").asInt()).isEqualTo(1);
+
+        // When - mark as read
+        var notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1",
+                java.util.UUID.class,
+                testRecipientUserId);
+
+        mvc.put()
+                .uri("/api/notifications/{id}/read", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", testRecipientUserId)))
+                .exchange();
+
+        // Then - unread count becomes 0
+        JsonNode second = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(second.path("type").asText()).isEqualTo("UnreadCountChanged");
+        assertThat(second.path("unreadCount").asInt()).isEqualTo(0);
+
+        // When - mark as read again (no change)
+        mvc.put()
+                .uri("/api/notifications/{id}/read", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", testRecipientUserId)))
+                .exchange();
+
+        // No new events expected (idempotent read should not change unread count)
+        verifyNoMoreNotificationsForRecipient(testRecipientUserId);
+    }
+
+    @Test
+    void shouldPublishUnreadCountEventWhenTrackingPixelMarksAsRead() throws Exception {
+        // Given - create a unique recipient user
+        String testRecipientUserId = "tracking_user_" + UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (username, email) VALUES (?, ?)",
+                testRecipientUserId,
+                testRecipientUserId + "@company.com");
+
+        // Create a notification
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("productCode", "intellij");
+        payload.put("title", "Tracking Pixel Test");
+        payload.put("description", "Test tracking pixel");
+        payload.put("releaseCode", null);
+        payload.put("assignedTo", testRecipientUserId);
+        mvc.post()
+                .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                .contentType("application/json")
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Consume the creation event
+        JsonNode createEvent = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(createEvent.path("unreadCount").asInt()).isEqualTo(1);
+
+        // When - mark as read via tracking pixel (public endpoint, no auth)
+        var notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1",
+                java.util.UUID.class,
+                testRecipientUserId);
+
+        var trackingResult =
+                mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+        assertThat(trackingResult).hasStatus2xxSuccessful();
+
+        // Then - unread count event should be published (1 -> 0)
+        JsonNode trackingEvent = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(trackingEvent.path("type").asText()).isEqualTo("UnreadCountChanged");
+        assertThat(trackingEvent.path("unreadCount").asInt()).isEqualTo(0);
+
+        // Verify idempotency: second call should not produce another event
+        mvc.get().uri("/notifications/{id}/read", notificationId).exchange();
+        verifyNoMoreNotificationsForRecipient(testRecipientUserId);
+    }
+
+    @Test
+    void shouldPublishUnreadCountEventWhenMarkedUnread() throws Exception {
+        String testRecipientUserId = "unread_user_" + UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (username, email) VALUES (?, ?)",
+                testRecipientUserId,
+                testRecipientUserId + "@company.com");
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("productCode", "intellij");
+        payload.put("title", "Unread Test Feature");
+        payload.put("description", "Test unread transition");
+        payload.put("releaseCode", null);
+        payload.put("assignedTo", testRecipientUserId);
+        var createResult = mvc.post()
+                .uri("/api/features")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                .contentType("application/json")
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+        assertThat(createResult).hasStatus2xxSuccessful();
+
+        JsonNode event1 = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(event1.get("unreadCount").asInt()).isEqualTo(1);
+
+        var notificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE recipient_user_id = ? ORDER BY created_at DESC LIMIT 1",
+                java.util.UUID.class,
+                testRecipientUserId);
+
+        mvc.put()
+                .uri("/api/notifications/{id}/read", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", testRecipientUserId)))
+                .exchange();
+        // Expect unread count to drop to 0 after marking as read.
+        JsonNode event2 = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(event2.get("unreadCount").asInt()).isEqualTo(0);
+
+        mvc.put()
+                .uri("/api/notifications/{id}/unread", notificationId)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", testRecipientUserId)))
+                .exchange();
+        // Expect unread count to go back to 1 after marking as unread.
+        JsonNode event3 = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(event3.get("unreadCount").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldPublishUnreadCountEventWhenMarkAllRead() throws Exception {
+        String testRecipientUserId = "markall_user_" + UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (username, email) VALUES (?, ?)",
+                testRecipientUserId,
+                testRecipientUserId + "@company.com");
+
+        for (int i = 0; i < 2; i++) {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("productCode", "intellij");
+            payload.put("title", "MarkAll Test Feature " + i);
+            payload.put("description", "Test mark-all-read");
+            payload.put("releaseCode", null);
+            payload.put("assignedTo", testRecipientUserId);
+            var createResult = mvc.post()
+                    .uri("/api/features")
+                    .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "creator")))
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(payload))
+                    .exchange();
+            assertThat(createResult).hasStatus2xxSuccessful();
+        }
+
+        JsonNode count1 = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(count1.get("unreadCount").asInt()).isEqualTo(1);
+
+        JsonNode count2 = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(count2.get("unreadCount").asInt()).isEqualTo(2);
+
+        mvc.patch()
+                .uri("/api/notifications/mark-all-read")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", testRecipientUserId)))
+                .exchange();
+
+        // Final event after mark-all-read should set unread count to 0.
+        JsonNode finalEvent = pollNextNotificationForRecipient(testRecipientUserId);
+        assertThat(finalEvent.get("unreadCount").asInt()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldPublishSingleEventForBatchCreation() throws Exception {
+        String recipient = "batch_user_" + UUID.randomUUID();
+        String creator = "creator_" + UUID.randomUUID();
+        jdbcTemplate.update("INSERT INTO users (username, email) VALUES (?, ?)", recipient, recipient + "@company.com");
+        jdbcTemplate.update("INSERT INTO users (username, email) VALUES (?, ?)", creator, creator + "@company.com");
+
+        // Create a release via API to trigger batch notifications on status change.
+        Map<String, Object> releasePayload = new HashMap<>();
+        releasePayload.put("productCode", "intellij");
+        releasePayload.put("code", "R" + UUID.randomUUID());
+        releasePayload.put("description", "Batch notification test");
+        var createRelease = mvc.post()
+                .uri("/api/releases")
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", creator)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(releasePayload))
+                .exchange();
+        assertThat(createRelease).hasStatus2xxSuccessful();
+
+        String location = createRelease.getMvcResult().getResponse().getHeader("Location");
+        assertThat(location).isNotBlank();
+        String releaseCode = location.substring(location.lastIndexOf('/') + 1);
+
+        // Create two features in the same release assigned to the same recipient.
+        for (int i = 0; i < 2; i++) {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("productCode", "intellij");
+            payload.put("title", "Batch Feature " + i);
+            payload.put("description", "Feature for batch notification");
+            payload.put("releaseCode", releaseCode);
+            payload.put("assignedTo", recipient);
+            var createResult = mvc.post()
+                    .uri("/api/features")
+                    .with(jwt().jwt(jwt -> jwt.claim("preferred_username", creator)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .exchange();
+            assertThat(createResult).hasStatus2xxSuccessful();
+        }
+
+        // Drain/skip unread-count events caused by feature creation.
+        unreadCountConsumer.poll(Duration.ofMillis(100));
+        unreadCountConsumer.commitSync();
+        unreadCountConsumer.poll(Duration.ofMillis(100));
+
+        long currentUnread = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ? AND read = false",
+                Long.class,
+                recipient);
+
+        // Move release through valid transitions to RELEASED to trigger batch notifications.
+        updateReleaseStatus(releaseCode, "PLANNED");
+        updateReleaseStatus(releaseCode, "IN_PROGRESS");
+        updateReleaseStatus(releaseCode, "RELEASED");
+
+        // Only one unread-count event should be emitted for the recipient for this batch.
+        JsonNode first = pollNextNotificationForRecipient(recipient);
+        assertThat(first.get("unreadCount").asInt()).isEqualTo(currentUnread + 1);
+
+        verifyNoMoreNotificationsForRecipient(recipient);
+    }
+
+    private void updateReleaseStatus(String releaseCode, String status) throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("description", "Status update to " + status);
+        payload.put("status", status);
+        payload.put("releasedAt", Instant.now().toString());
+        var result = mvc.put()
+                .uri("/api/releases/{code}", releaseCode)
+                .with(jwt().jwt(jwt -> jwt.claim("preferred_username", "releaseManager")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+        assertThat(result).hasStatus2xxSuccessful();
+    }
+
+    private KafkaConsumer<String, String> createConsumer() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "unread-count-test-" + UUID.randomUUID());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        // Increase timeouts for Testcontainers environment
+        props.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 60000);
+        props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);
+        return new KafkaConsumer<>(props);
+    }
+
+    private List<TopicPartition> waitForPartitions(KafkaConsumer<String, String> consumer, String topic)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < deadline) {
+            List<PartitionInfo> infos = consumer.partitionsFor(topic);
+            if (infos != null && !infos.isEmpty()) {
+                List<TopicPartition> partitions = new java.util.ArrayList<>();
+                for (PartitionInfo info : infos) {
+                    partitions.add(new TopicPartition(info.topic(), info.partition()));
+                }
+                return partitions;
+            }
+            Thread.sleep(200);
+        }
+        throw new IllegalStateException("Kafka topic has no partitions: " + topic);
+    }
+
+    private JsonNode pollNextNotificationForRecipient(String recipientUserId) throws Exception {
+        JsonNode event = pollForRecipient(recipientUserId, 10000);
+        assertThat(event).isNotNull();
+        return event;
+    }
+
+    private void verifyNoMoreNotificationsForRecipient(String recipientUserId) throws Exception {
+        JsonNode event = pollForRecipient(recipientUserId, 2000);
+        assertThat(event).isNull();
+    }
+
+    private JsonNode pollForRecipient(String recipientUserId, int timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            var records = unreadCountConsumer.poll(Duration.ofMillis(500));
+            for (var record : records) {
+                JsonNode event = objectMapper.readTree(record.value());
+                // Guard against double-serialization bug (JSON wrapped in a JSON string)
+                assertThat(event.isTextual())
+                        .as("Kafka message should be a JSON object, not a JSON-encoded string")
+                        .isFalse();
+                if (recipientUserId.equals(event.path("recipientUserId").asText())) {
+                    return event;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationWebSocketIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/NotificationWebSocketIntegrationTest.java
@@ -1,0 +1,320 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+@Import({MockJavaMailSenderConfig.class, NotificationWebSocketIntegrationTest.TestJwtDecoderConfig.class})
+@TestPropertySource(properties = "spring.kafka.consumer.auto-offset-reset=earliest")
+class NotificationWebSocketIntegrationTest extends AbstractIT {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @WithMockOAuth2User(username = "creator")
+    void shouldReceiveUnreadCountOverWebSocket() throws Exception {
+        // Ensure a clean state so unread count starts from zero.
+        jdbcTemplate.execute("DELETE FROM notifications");
+
+        String wsUrl = "ws://localhost:" + port + "/ws";
+        WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        CompletableFuture<Map<String, Object>> messageFuture = new CompletableFuture<>();
+
+        WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
+        handshakeHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer user1");
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer user1");
+
+        StompSession session = null;
+        try {
+            session = stompClient
+                    .connectAsync(wsUrl, handshakeHeaders, connectHeaders, new StompSessionHandlerAdapter() {})
+                    .get(5, TimeUnit.SECONDS);
+            final StompSession connectedSession = session;
+
+            // Subscribe to user-scoped queue where unread-count updates are delivered.
+            session.subscribe("/user/queue/notifications", new StompFrameHandler() {
+                @Override
+                public Type getPayloadType(StompHeaders headers) {
+                    return Object.class;
+                }
+
+                @Override
+                public void handleFrame(StompHeaders headers, Object payload) {
+                    try {
+                        if (payload instanceof Map<?, ?> map) {
+                            messageFuture.complete((Map<String, Object>) map);
+                            return;
+                        }
+                        if (payload instanceof String text) {
+                            Map<String, Object> parsed = objectMapper.readValue(text, Map.class);
+                            messageFuture.complete(parsed);
+                            return;
+                        }
+                        if (payload instanceof byte[] bytes) {
+                            Map<String, Object> parsed = objectMapper.readValue(bytes, Map.class);
+                            messageFuture.complete(parsed);
+                            return;
+                        }
+                        Map<String, Object> parsed = objectMapper.convertValue(payload, Map.class);
+                        messageFuture.complete(parsed);
+                    } catch (Exception e) {
+                        messageFuture.completeExceptionally(e);
+                    }
+                }
+            });
+            await().pollDelay(Duration.ofMillis(200))
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(connectedSession.isConnected()).isTrue());
+
+            // Trigger the end-to-end path: API -> DB -> Kafka -> WebSocket.
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("productCode", "intellij");
+            payload.put("title", "Realtime Feature");
+            payload.put("description", "Test realtime");
+            payload.put("releaseCode", null);
+            payload.put("assignedTo", "user1");
+            var result = mvc.post()
+                    .uri("/api/features")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .exchange();
+            assertThat(result).hasStatus2xxSuccessful();
+
+            // Verify the WebSocket client receives the unread-count update.
+            Map<String, Object> message;
+            try {
+                message = messageFuture.get(10, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                throw new AssertionError(
+                        "Expected unread-count WebSocket message for preferred_username 'user1' but none arrived", e);
+            }
+            assertThat(message.get("type")).isEqualTo("UnreadCountChanged");
+            assertThat(((Number) message.get("unreadCount")).longValue()).isEqualTo(1L);
+        } finally {
+            if (session != null && session.isConnected()) {
+                session.disconnect();
+            }
+            stompClient.stop();
+        }
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "creator")
+    void shouldUsePreferredUsernameForWebSocketPrincipal() throws Exception {
+        jdbcTemplate.execute("DELETE FROM notifications");
+
+        String wsUrl = "ws://localhost:" + port + "/ws";
+        WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        CompletableFuture<Map<String, Object>> messageFuture = new CompletableFuture<>();
+
+        // Token format: sub.<sub>.preferred_username.<preferred> (HTTP header-safe)
+        String token = "sub.internal-123.preferred_username.user1";
+        WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
+        handshakeHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+
+        StompSession session = null;
+        try {
+            session = stompClient
+                    .connectAsync(wsUrl, handshakeHeaders, connectHeaders, new StompSessionHandlerAdapter() {})
+                    .get(5, TimeUnit.SECONDS);
+
+            session.subscribe("/user/queue/notifications", new StompFrameHandler() {
+                @Override
+                public Type getPayloadType(StompHeaders headers) {
+                    return Object.class;
+                }
+
+                @Override
+                public void handleFrame(StompHeaders headers, Object payload) {
+                    try {
+                        if (payload instanceof Map<?, ?> map) {
+                            messageFuture.complete((Map<String, Object>) map);
+                            return;
+                        }
+                        if (payload instanceof String text) {
+                            Map<String, Object> parsed = objectMapper.readValue(text, Map.class);
+                            messageFuture.complete(parsed);
+                            return;
+                        }
+                        if (payload instanceof byte[] bytes) {
+                            Map<String, Object> parsed = objectMapper.readValue(bytes, Map.class);
+                            messageFuture.complete(parsed);
+                            return;
+                        }
+                        Map<String, Object> parsed = objectMapper.convertValue(payload, Map.class);
+                        messageFuture.complete(parsed);
+                    } catch (Exception e) {
+                        messageFuture.completeExceptionally(e);
+                    }
+                }
+            });
+
+            // Trigger the event for user1 (preferred_username).
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("productCode", "intellij");
+            payload.put("title", "Realtime Feature");
+            payload.put("description", "Test realtime");
+            payload.put("releaseCode", null);
+            payload.put("assignedTo", "user1");
+            var result = mvc.post()
+                    .uri("/api/features")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .exchange();
+            assertThat(result).hasStatus2xxSuccessful();
+
+            Map<String, Object> message = waitForMessage(messageFuture, 5, TimeUnit.SECONDS);
+            assertThat(message.get("type")).isEqualTo("UnreadCountChanged");
+            assertThat(((Number) message.get("unreadCount")).longValue()).isEqualTo(1L);
+        } finally {
+            if (session != null && session.isConnected()) {
+                session.disconnect();
+            }
+            stompClient.stop();
+        }
+    }
+
+    @Test
+    void shouldRejectUnauthorizedWebSocketHandshake() throws Exception {
+        String wsUrl = "ws://localhost:" + port + "/ws";
+        WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        try {
+            var future = stompClient.connectAsync(wsUrl, new StompSessionHandlerAdapter() {});
+            StompSession session = null;
+            try {
+                session = future.get(5, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
+                // Handshake rejected due to missing auth is an acceptable outcome.
+                return;
+            }
+
+            // Some implementations allow the WebSocket handshake but reject unauthenticated STOMP usage later.
+            // In that case, verify that an anonymous session does NOT receive user-specific updates.
+            CompletableFuture<Map<String, Object>> messageFuture = new CompletableFuture<>();
+            session.subscribe("/user/queue/notifications", new StompFrameHandler() {
+                @Override
+                public Type getPayloadType(StompHeaders headers) {
+                    return Map.class;
+                }
+
+                @Override
+                public void handleFrame(StompHeaders headers, Object payload) {
+                    messageFuture.complete((Map<String, Object>) payload);
+                }
+            });
+
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("productCode", "intellij");
+            payload.put("title", "Realtime Feature");
+            payload.put("description", "Test realtime");
+            payload.put("releaseCode", null);
+            payload.put("assignedTo", "user1");
+            mvc.post()
+                    .uri("/api/features")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .exchange();
+
+            try {
+                Map<String, Object> message = messageFuture.get(2, TimeUnit.SECONDS);
+                throw new AssertionError(
+                        "Expected unauthenticated WebSocket session to be rejected, but received: " + message);
+            } catch (TimeoutException e) {
+                // Expected: no message delivered to anonymous session.
+            } finally {
+                session.disconnect();
+            }
+        } finally {
+            stompClient.stop();
+        }
+    }
+
+    private Map<String, Object> waitForMessage(
+            CompletableFuture<Map<String, Object>> messageFuture, long timeout, TimeUnit unit) throws Exception {
+        try {
+            return messageFuture.get(timeout, unit);
+        } catch (TimeoutException e) {
+            throw new AssertionError(
+                    "Expected unread-count WebSocket message for preferred_username 'user1' but none arrived", e);
+        }
+    }
+
+    @TestConfiguration
+    static class TestJwtDecoderConfig {
+        @Bean
+        JwtDecoder jwtDecoder() {
+            return token -> {
+                Instant now = Instant.now();
+                Map<String, Object> headers = Map.of("alg", "none");
+                Map<String, Object> claims = parseTokenClaims(token);
+                return new Jwt(token, now, now.plusSeconds(300), headers, claims);
+            };
+        }
+
+        private Map<String, Object> parseTokenClaims(String token) {
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("sub", token);
+            claims.put("preferred_username", token);
+            claims.put("realm_access", Map.of("roles", List.of("ROLE_USER")));
+
+            if (token != null && token.startsWith("sub.")) {
+                String[] parts = token.split("\\.");
+                for (int i = 0; i + 1 < parts.length; i += 2) {
+                    claims.put(parts[i], parts[i + 1]);
+                }
+            }
+            return claims;
+        }
+    }
+}


### PR DESCRIPTION
# Realtime Unread Count, Filtering by Status, Marking all Read

This task should be implemented on top of #122 

## Objective

Add server-side filtering for notification list by read status, add a mark-all-read endpoint, and support realtime unread count updates over WebSocket.

## REST API

### 1) List notifications — add server-side filtering by status
**GET** `/api/notifications`

#### New Query Parameter
- `status` (optional): `read` | `unread` — filters by read state (`read` → read only, `unread` → unread only).

#### Expected Behavior
- When `status` is omitted, return all notifications.
- When `status` is invalid, return **HTTP 400 Bad Request**.
- Must remain scoped to the current authenticated user.

### 2) Mark all notifications as read
**PATCH** `/api/notifications/mark-all-read`

#### Response
```json
{ "updated": 12 }
```

#### Behavior
- Affects only unread notifications of the current user.
- Sets `read=true` and `readAt=now` for updated records.
- **Idempotent:** if nothing to update, returns `{ "updated": 0 }`.

## Unread notifications count - WebSocket API

Support providing unread notifications count in real time without polling.
STOMP over WebSocket + Spring’s in-memory simple broker should be used.

### Websocket API
- WebSocket endpoint MUST be: `GET /ws`
- The endpoint MUST support a native WebSocket handshake.
- `/ws` requires authentication (no anonymous access).
  - JWT is provided via a standard Bearer token during handshake.

### Subscriptions (user-scoped)
- Client subscribes to: `/user/queue/notifications`
- Server sends user-scoped messages to: `/user/queue/notifications`

The authenticated user information must be derived from the JWT token.

### Message format
Every message body MUST be a single JSON object:
```json
{
  "type": "UnreadCountChanged",
  "unreadCount": 5
}
```

### Cross-instance synchronization
To support multi-instance deployments, unread-count updates must be published to Kafka:
- Each unread-count change must publish a Kafka event.
- Each instance must consume these events and push the WebSocket message to connected users (Kafka → WebSocket bridge).

Kafka publish failures must not block or fail the originating HTTP request.

Kafka topic configuration:
- `ft.events.unread-count=unread_count_changed`

Kafka message format:
```json
{
  "type": "UnreadCountChanged",
  "recipientUserId": "user123",
  "unreadCount": 5
}
```

### Trigger conditions
The backend MUST push an event to that user over WebSocket whenever **unread count changes**, including:
- when a new notification is created for the user
- when a notification is marked as read
- when a notification is marked as unread
- when mark-all-read is executed
- when a notification is marked as read via `/notifications/{id}/read`

If the unread count does not change, no event should be sent.
If multiple notifications are created in a single operation for the same user, a single event with the final unread count must be sent.

## Acceptance Criteria

- `GET /api/notifications` supports `status` filter; invalid values return HTTP 400.
- `PATCH /api/notifications/mark-all-read` is implemented, idempotent, and returns the number of updated rows.
- Unread count updates are pushed in real time over STOMP/WebSocket on `/user/queue/notifications` when the count changes.
- WebSocket endpoint is `/ws`, requires authentication, and uses native WebSocket handshake.
- Unread-count changes are published to Kafka topic `ft.events.unread-count` and consumed by instances to deliver WebSocket updates.
