### PR TITLE
Implement  User Notification System: Admin & Logging

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.sivalabs.ft.features.api.controllers.EmailDeliveryFailureControllerTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The feature-service microservice manages products, releases and features.
 * Maven, JUnit 5, Testcontainers
 
 ## Prerequisites
-* JDK 21 or later
+* JDK 24 or later
 * Docker ([installation instructions](https://docs.docker.com/engine/install/))
 * [IntelliJ IDEA](https://www.jetbrains.com/idea/)
 * PostgreSQL and Keycloak 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,9 @@
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <springdoc.version>2.8.9</springdoc.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
-        <spotless-maven-plugin.version>2.45.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
+        <palantir-java-format.version>2.74.0</palantir-java-format.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <dockerImageName>sivaprasadreddy/ft-feature-service</dockerImageName>
     </properties>
     <dependencies>
@@ -220,7 +222,7 @@
                         <importOrder />
                         <removeUnusedImports />
                         <palantirJavaFormat>
-                            <version>2.50.0</version>
+                            <version>${palantir-java-format.version}</version>
                         </palantirJavaFormat>
                         <formatAnnotations />
                     </java>

--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -39,6 +40,15 @@ class GlobalExceptionHandler {
         log.error("Bad Request", e);
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
         problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    ProblemDetail handle(AccessDeniedException e) {
+        log.warn("Access denied: {}", e.getMessage());
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(FORBIDDEN, e.getMessage());
+        problemDetail.setTitle("Forbidden");
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;
     }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureController.java
@@ -1,0 +1,123 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.domain.EmailDeliveryFailureService;
+import com.sivalabs.ft.features.domain.dtos.EmailDeliveryFailureDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/email-failures")
+@Tag(name = "Admin Email Delivery Failures API")
+@PreAuthorize("hasRole('ADMIN')")
+class EmailDeliveryFailureController {
+
+    private final EmailDeliveryFailureService emailDeliveryFailureService;
+
+    EmailDeliveryFailureController(EmailDeliveryFailureService emailDeliveryFailureService) {
+        this.emailDeliveryFailureService = emailDeliveryFailureService;
+    }
+
+    @GetMapping()
+    @Operation(
+            summary = "Get email delivery failures",
+            description = "Get paginated list of email delivery failures, sorted by date DESC (newest first). "
+                    + "Optionally filter by date (ISO 8601 format: 2026-01-12)",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array =
+                                                @ArraySchema(
+                                                        schema =
+                                                                @Schema(
+                                                                        implementation =
+                                                                                EmailDeliveryFailureDto.class)))),
+                @ApiResponse(responseCode = "400", description = "Invalid date format"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - ADMIN role required")
+            })
+    ResponseEntity<Page<EmailDeliveryFailureDto>> getEmailFailures(
+            @RequestParam(required = false) String date,
+            @PageableDefault(size = 20, sort = "failedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        if (date != null && !date.isBlank()) {
+            try {
+                LocalDate filterDate = LocalDate.parse(date);
+                return ResponseEntity.ok(emailDeliveryFailureService.getFailuresByDate(filterDate, pageable));
+            } catch (DateTimeParseException e) {
+                return ResponseEntity.badRequest().build();
+            }
+        }
+
+        return ResponseEntity.ok(emailDeliveryFailureService.getAllFailures(pageable));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Get email delivery failure by ID",
+            description = "Get a single email delivery failure record by ID",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = EmailDeliveryFailureDto.class))),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - ADMIN role required"),
+                @ApiResponse(responseCode = "404", description = "Not found")
+            })
+    ResponseEntity<EmailDeliveryFailureDto> getEmailFailureById(@PathVariable UUID id) {
+        return emailDeliveryFailureService
+                .getFailureById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/notification/{notificationId}")
+    @Operation(
+            summary = "Get email delivery failures by notification ID",
+            description = "Get all email delivery failure records for a specific notification, sorted by date DESC",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        array =
+                                                @ArraySchema(
+                                                        schema =
+                                                                @Schema(
+                                                                        implementation =
+                                                                                EmailDeliveryFailureDto.class)))),
+                @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                @ApiResponse(responseCode = "403", description = "Forbidden - ADMIN role required")
+            })
+    ResponseEntity<List<EmailDeliveryFailureDto>> getEmailFailuresByNotificationId(@PathVariable UUID notificationId) {
+        return ResponseEntity.ok(emailDeliveryFailureService.getFailuresByNotificationId(notificationId));
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
+++ b/src/main/java/com/sivalabs/ft/features/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
@@ -13,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 class SecurityConfig {
 
     @Bean

--- a/src/main/java/com/sivalabs/ft/features/domain/EmailDeliveryFailureRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/EmailDeliveryFailureRepository.java
@@ -1,0 +1,32 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.entities.EmailDeliveryFailure;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface EmailDeliveryFailureRepository extends ListCrudRepository<EmailDeliveryFailure, UUID> {
+
+    /**
+     * Find all failures with pagination, ordered by failed_at DESC (newest first)
+     */
+    Page<EmailDeliveryFailure> findAllByOrderByFailedAtDesc(Pageable pageable);
+
+    /**
+     * Find failures within a half-open date range [start, end) in UTC, ordered by failed_at DESC.
+     * Used for date filtering where start = date 00:00 UTC and end = date + 1 day 00:00 UTC.
+     * Half-open interval ensures 23:59:59Z is included but 00:00:00Z next day is excluded.
+     */
+    @Query(
+            "SELECT f FROM EmailDeliveryFailure f WHERE f.failedAt >= :start AND f.failedAt < :end ORDER BY f.failedAt DESC")
+    Page<EmailDeliveryFailure> findByFailedAtInRangeOrderByFailedAtDesc(Instant start, Instant end, Pageable pageable);
+
+    /**
+     * Find all failures for a specific notification, ordered by failed_at DESC
+     */
+    List<EmailDeliveryFailure> findByNotificationIdOrderByFailedAtDesc(UUID notificationId);
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/EmailDeliveryFailureService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/EmailDeliveryFailureService.java
@@ -1,0 +1,119 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.domain.dtos.EmailDeliveryFailureDto;
+import com.sivalabs.ft.features.domain.entities.EmailDeliveryFailure;
+import com.sivalabs.ft.features.domain.mappers.EmailDeliveryFailureMapper;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service for managing email delivery failure records.
+ * Provides methods for logging failures and retrieving failure records for admin review.
+ */
+@Service
+public class EmailDeliveryFailureService {
+    private static final Logger log = LoggerFactory.getLogger(EmailDeliveryFailureService.class);
+
+    private final EmailDeliveryFailureRepository emailDeliveryFailureRepository;
+    private final EmailDeliveryFailureMapper emailDeliveryFailureMapper;
+
+    public EmailDeliveryFailureService(
+            EmailDeliveryFailureRepository emailDeliveryFailureRepository,
+            EmailDeliveryFailureMapper emailDeliveryFailureMapper) {
+        this.emailDeliveryFailureRepository = emailDeliveryFailureRepository;
+        this.emailDeliveryFailureMapper = emailDeliveryFailureMapper;
+    }
+
+    /**
+     * Log an email delivery failure.
+     * If saving fails, logs a warning and continues - failure logging must not interrupt notification flow.
+     * Uses REQUIRES_NEW to run in a separate transaction:
+     * - Failure record is saved even if outer transaction rolls back (valuable for diagnostics)
+     * - Any exception here won't affect the outer transaction
+     */
+    private static final int MAX_ERROR_MESSAGE_LENGTH = 4000;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void logFailure(UUID notificationId, String recipientEmail, String eventType, String errorMessage) {
+        try {
+            EmailDeliveryFailure failure = new EmailDeliveryFailure();
+            failure.setId(UUID.randomUUID());
+            failure.setNotificationId(notificationId);
+            failure.setRecipientEmail(recipientEmail);
+            failure.setEventType(eventType);
+            failure.setErrorMessage(normalizeErrorMessage(errorMessage));
+            failure.setFailedAt(Instant.now());
+
+            emailDeliveryFailureRepository.save(failure);
+            log.debug("Logged email delivery failure for notification {} to {}", notificationId, recipientEmail);
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to log email delivery failure for notification {} to {}: {}",
+                    notificationId,
+                    recipientEmail,
+                    e.getMessage());
+        }
+    }
+
+    private String normalizeErrorMessage(String errorMessage) {
+        if (errorMessage == null || errorMessage.isBlank()) {
+            return "Unknown error";
+        }
+        if (errorMessage.length() > MAX_ERROR_MESSAGE_LENGTH) {
+            return errorMessage.substring(0, MAX_ERROR_MESSAGE_LENGTH);
+        }
+        return errorMessage;
+    }
+
+    /**
+     * Get all failures with pagination, sorted by failed_at DESC (newest first).
+     */
+    @Transactional(readOnly = true)
+    public Page<EmailDeliveryFailureDto> getAllFailures(Pageable pageable) {
+        Page<EmailDeliveryFailure> failures = emailDeliveryFailureRepository.findAllByOrderByFailedAtDesc(pageable);
+        return failures.map(emailDeliveryFailureMapper::toDto);
+    }
+
+    /**
+     * Get failures for a specific date (UTC) with pagination, sorted by failed_at DESC.
+     * Uses range queries for optimal index usage.
+     */
+    @Transactional(readOnly = true)
+    public Page<EmailDeliveryFailureDto> getFailuresByDate(LocalDate date, Pageable pageable) {
+        Instant start = date.atStartOfDay(ZoneOffset.UTC).toInstant();
+        Instant end = date.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+        Page<EmailDeliveryFailure> failures =
+                emailDeliveryFailureRepository.findByFailedAtInRangeOrderByFailedAtDesc(start, end, pageable);
+        return failures.map(emailDeliveryFailureMapper::toDto);
+    }
+
+    /**
+     * Get a single failure by ID.
+     */
+    @Transactional(readOnly = true)
+    public Optional<EmailDeliveryFailureDto> getFailureById(UUID id) {
+        return emailDeliveryFailureRepository.findById(id).map(emailDeliveryFailureMapper::toDto);
+    }
+
+    /**
+     * Get all failures for a specific notification, sorted by failed_at DESC.
+     */
+    @Transactional(readOnly = true)
+    public List<EmailDeliveryFailureDto> getFailuresByNotificationId(UUID notificationId) {
+        List<EmailDeliveryFailure> failures =
+                emailDeliveryFailureRepository.findByNotificationIdOrderByFailedAtDesc(notificationId);
+        return failures.stream().map(emailDeliveryFailureMapper::toDto).toList();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/EmailDeliveryFailureDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/EmailDeliveryFailureDto.java
@@ -1,0 +1,9 @@
+package com.sivalabs.ft.features.domain.dtos;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record EmailDeliveryFailureDto(
+        UUID id, UUID notificationId, String recipientEmail, String eventType, String errorMessage, Instant failedAt)
+        implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/EmailDeliveryFailure.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/EmailDeliveryFailure.java
@@ -1,0 +1,78 @@
+package com.sivalabs.ft.features.domain.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "email_delivery_failures")
+public class EmailDeliveryFailure {
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @NotNull @Column(name = "notification_id", nullable = false)
+    private UUID notificationId;
+
+    @Size(max = 255) @NotNull @Column(name = "recipient_email", nullable = false)
+    private String recipientEmail;
+
+    @Size(max = 50) @NotNull @Column(name = "event_type", nullable = false, length = 50)
+    private String eventType;
+
+    @NotNull @Column(name = "error_message", nullable = false, columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @NotNull @Column(name = "failed_at", nullable = false)
+    private Instant failedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getNotificationId() {
+        return notificationId;
+    }
+
+    public void setNotificationId(UUID notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public String getRecipientEmail() {
+        return recipientEmail;
+    }
+
+    public void setRecipientEmail(String recipientEmail) {
+        this.recipientEmail = recipientEmail;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public Instant getFailedAt() {
+        return failedAt;
+    }
+
+    public void setFailedAt(Instant failedAt) {
+        this.failedAt = failedAt;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/EmailDeliveryFailureMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/EmailDeliveryFailureMapper.java
@@ -1,0 +1,12 @@
+package com.sivalabs.ft.features.domain.mappers;
+
+import com.sivalabs.ft.features.domain.dtos.EmailDeliveryFailureDto;
+import com.sivalabs.ft.features.domain.entities.EmailDeliveryFailure;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface EmailDeliveryFailureMapper {
+    EmailDeliveryFailureDto toDto(EmailDeliveryFailure failure);
+
+    EmailDeliveryFailure toEntity(EmailDeliveryFailureDto dto);
+}

--- a/src/main/resources/db/migration/V10__create_email_delivery_failures_table.sql
+++ b/src/main/resources/db/migration/V10__create_email_delivery_failures_table.sql
@@ -1,0 +1,27 @@
+-- Create email_delivery_failures table to store email delivery failure records
+-- Used for admin troubleshooting and monitoring of failed email notifications
+
+CREATE TABLE email_delivery_failures (
+    id UUID PRIMARY KEY,
+    notification_id UUID NOT NULL,
+    recipient_email VARCHAR(255) NOT NULL,
+    event_type VARCHAR(50) NOT NULL,
+    error_message TEXT NOT NULL,
+    failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_email_failures_notification
+        FOREIGN KEY (notification_id) REFERENCES notifications(id) ON DELETE CASCADE
+);
+
+-- Create indexes for efficient queries
+CREATE INDEX idx_email_failures_notification_id ON email_delivery_failures(notification_id);
+CREATE INDEX idx_email_failures_failed_at ON email_delivery_failures(failed_at);
+
+-- Add comments for documentation
+COMMENT ON TABLE email_delivery_failures IS 'Stores email delivery failure records for admin review and troubleshooting';
+COMMENT ON COLUMN email_delivery_failures.id IS 'Unique failure record identifier (UUID)';
+COMMENT ON COLUMN email_delivery_failures.notification_id IS 'Reference to the notification that failed to send';
+COMMENT ON COLUMN email_delivery_failures.recipient_email IS 'Email address the notification was attempted to send to';
+COMMENT ON COLUMN email_delivery_failures.event_type IS 'Type of notification event that triggered the email';
+COMMENT ON COLUMN email_delivery_failures.error_message IS 'Error message from the failed delivery attempt';
+COMMENT ON COLUMN email_delivery_failures.failed_at IS 'Timestamp when the delivery failure occurred (UTC)';
+

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureControllerTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/EmailDeliveryFailureControllerTests.java
@@ -1,0 +1,489 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.api.models.CreateFeaturePayload;
+import com.sivalabs.ft.features.testsupport.MockJavaMailSenderConfig;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Integration tests for Email Delivery Failure logging and Admin API.
+ */
+@Sql("/test-data.sql")
+@Import(MockJavaMailSenderConfig.class)
+class EmailDeliveryFailureControllerTests extends AbstractIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM email_delivery_failures");
+        jdbcTemplate.execute("DELETE FROM notifications");
+        reset(javaMailSender);
+        when(javaMailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+    }
+
+    // ========== Test 1: Failure is persisted ==========
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldPersistEmailDeliveryFailureWhenEmailSendingFails() throws Exception {
+        // Given - Configure mail sender to throw exception
+        doThrow(new MailSendException("SMTP server unavailable"))
+                .when(javaMailSender)
+                .send(any(MimeMessage.class));
+
+        CreateFeaturePayload payload =
+                new CreateFeaturePayload("intellij", "Failure Test Feature", "Test failure persistence", null, "bob");
+
+        // When - Create feature (email sending will fail)
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))
+                .exchange();
+
+        // Then - Feature should still be created
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+
+        // Wait for email send attempt
+        verify(javaMailSender, timeout(2000).times(1)).send(any(MimeMessage.class));
+
+        // Verify exactly one failure record exists
+        Integer failureCount =
+                jdbcTemplate.queryForObject("SELECT COUNT(*) FROM email_delivery_failures", Integer.class);
+        assertThat(failureCount).isEqualTo(1);
+
+        // Verify all required fields are present and non-null
+        Map<String, Object> failure =
+                jdbcTemplate.queryForMap("SELECT * FROM email_delivery_failures ORDER BY failed_at DESC LIMIT 1");
+        assertThat(failure.get("id")).isNotNull();
+        assertThat(failure.get("notification_id")).isNotNull();
+        assertThat(failure.get("recipient_email")).isEqualTo("bob@company.com");
+        assertThat(failure.get("event_type")).isEqualTo("FEATURE_CREATED");
+        assertThat(failure.get("error_message")).isNotNull();
+        assertThat(failure.get("failed_at")).isNotNull();
+    }
+
+    // ========== Test 2: Admin list with pagination and sorting ==========
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnPaginatedFailuresSortedByDateDesc() throws Exception {
+        // Given - Insert multiple failure records with controlled timestamps
+        UUID notificationId = insertTestNotification();
+        Instant now = Instant.now();
+
+        insertFailure(notificationId, "user1@test.com", "FEATURE_CREATED", "Error 1", now.minus(2, ChronoUnit.HOURS));
+        insertFailure(notificationId, "user2@test.com", "FEATURE_UPDATED", "Error 2", now.minus(1, ChronoUnit.HOURS));
+        insertFailure(notificationId, "user3@test.com", "FEATURE_DELETED", "Error 3", now);
+
+        // When - Call admin listing endpoint
+        var result = mvc.get().uri("/api/admin/email-failures?page=0&size=10").exchange();
+
+        // Then - Verify response
+        assertThat(result).hasStatus(HttpStatus.OK);
+
+        String responseBody = result.getResponse().getContentAsString();
+        Map<String, Object> pageResponse = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        List<Map<String, Object>> failures = (List<Map<String, Object>>) pageResponse.get("content");
+
+        assertThat(failures).hasSize(3);
+        // Verify sorted by failed_at DESC (newest first)
+        assertThat(failures.get(0).get("recipientEmail")).isEqualTo("user3@test.com");
+        assertThat(failures.get(1).get("recipientEmail")).isEqualTo("user2@test.com");
+        assertThat(failures.get(2).get("recipientEmail")).isEqualTo("user1@test.com");
+
+        // Verify pagination metadata
+        assertThat(((Number) pageResponse.get("totalElements")).longValue()).isEqualTo(3L);
+        assertThat(((Number) pageResponse.get("totalPages")).intValue()).isEqualTo(1);
+        assertThat(((Number) pageResponse.get("size")).intValue()).isEqualTo(10);
+        assertThat(((Number) pageResponse.get("number")).intValue()).isEqualTo(0);
+    }
+
+    // ========== Test 3: Date filter in UTC ==========
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldFilterFailuresByDateInUtc() throws Exception {
+        // Given - Insert failure records with specific timestamps
+        UUID notificationId = insertTestNotification();
+
+        // 2026-01-12T00:00:00Z
+        insertFailure(
+                notificationId, "user1@test.com", "FEATURE_CREATED", "Error 1", Instant.parse("2026-01-12T00:00:00Z"));
+        // 2026-01-12T23:59:59Z
+        insertFailure(
+                notificationId, "user2@test.com", "FEATURE_UPDATED", "Error 2", Instant.parse("2026-01-12T23:59:59Z"));
+        // 2026-01-13T00:00:00Z
+        insertFailure(
+                notificationId, "user3@test.com", "FEATURE_DELETED", "Error 3", Instant.parse("2026-01-13T00:00:00Z"));
+
+        // When - Call admin listing endpoint with date filter
+        var result = mvc.get().uri("/api/admin/email-failures?date=2026-01-12").exchange();
+
+        // Then - Only records within 2026-01-12 UTC range should be returned
+        assertThat(result).hasStatus(HttpStatus.OK);
+
+        String responseBody = result.getResponse().getContentAsString();
+        Map<String, Object> pageResponse = objectMapper.readValue(responseBody, new TypeReference<>() {});
+        List<Map<String, Object>> failures = (List<Map<String, Object>>) pageResponse.get("content");
+
+        assertThat(failures).hasSize(2);
+        // Verify only the 2026-01-12 records are returned
+        List<String> emails =
+                failures.stream().map(f -> (String) f.get("recipientEmail")).toList();
+        assertThat(emails).containsExactlyInAnyOrder("user1@test.com", "user2@test.com");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "invalid-date",
+                "2026-13-01", // Invalid month
+                "2026-01-32", // Invalid day
+                "26-01-12", // Wrong year format
+                "2026/01/12", // Wrong separator
+                "2026-01-12T00:00:00Z", // Timestamp instead of date
+                "null" // String "null"
+            })
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn400ForInvalidDateFormat(String invalidDate) throws Exception {
+        // When - Call with invalid date format
+        var result = mvc.get()
+                .uri("/api/admin/email-failures?date={date}", invalidDate)
+                .exchange();
+
+        // Then - Should return 400 Bad Request
+        assertThat(result).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    // ========== Test 4: Admin lookup by notification and by failure ID ==========
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnFailuresByNotificationId() throws Exception {
+        // Given - Insert multiple failures for the same notification
+        UUID notificationId1 = insertTestNotification();
+        UUID notificationId2 = insertTestNotification();
+        Instant now = Instant.now();
+
+        insertFailure(notificationId1, "user1@test.com", "FEATURE_CREATED", "Error 1", now.minus(2, ChronoUnit.HOURS));
+        insertFailure(notificationId1, "user2@test.com", "FEATURE_CREATED", "Error 2", now.minus(1, ChronoUnit.HOURS));
+        insertFailure(notificationId2, "user3@test.com", "FEATURE_UPDATED", "Error 3", now);
+
+        // When - Get failures for notification1
+        var result = mvc.get()
+                .uri("/api/admin/email-failures/notification/{notificationId}", notificationId1)
+                .exchange();
+
+        // Then - Should return only failures for notification1
+        assertThat(result).hasStatus(HttpStatus.OK);
+
+        String responseBody = result.getResponse().getContentAsString();
+        List<Map<String, Object>> failures = objectMapper.readValue(responseBody, new TypeReference<>() {});
+
+        assertThat(failures).hasSize(2);
+
+        // Verify sorted by failed_at DESC
+        assertThat(failures.get(0).get("recipientEmail")).isEqualTo("user2@test.com");
+        assertThat(failures.get(1).get("recipientEmail")).isEqualTo("user1@test.com");
+
+        // Verify isolation: failures from notificationId2 are NOT included
+        List<String> emails =
+                failures.stream().map(f -> (String) f.get("recipientEmail")).toList();
+        assertThat(emails)
+                .containsExactlyInAnyOrder("user1@test.com", "user2@test.com")
+                .doesNotContain("user3@test.com");
+
+        // Verify all returned failures have the correct notificationId
+        for (Map<String, Object> failure : failures) {
+            assertThat(failure.get("notificationId")).isEqualTo(notificationId1.toString());
+        }
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnEmptyListForNonExistentNotificationId() throws Exception {
+        // When - Get failures for non-existent notification
+        var result = mvc.get()
+                .uri("/api/admin/email-failures/notification/{notificationId}", UUID.randomUUID())
+                .exchange();
+
+        // Then - Should return empty list with 200 OK
+        assertThat(result).hasStatus(HttpStatus.OK);
+
+        String responseBody = result.getResponse().getContentAsString();
+        List<Map<String, Object>> failures = objectMapper.readValue(responseBody, new TypeReference<>() {});
+
+        assertThat(failures).isEmpty();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnFailureById() throws Exception {
+        // Given - Insert a failure record
+        UUID notificationId = insertTestNotification();
+        UUID failureId =
+                insertFailure(notificationId, "user@test.com", "FEATURE_CREATED", "Test error message", Instant.now());
+
+        // When - Get failure by ID
+        var result = mvc.get().uri("/api/admin/email-failures/{id}", failureId).exchange();
+
+        // Then - Should return the failure record
+        assertThat(result).hasStatus(HttpStatus.OK);
+
+        String responseBody = result.getResponse().getContentAsString();
+        Map<String, Object> failure = objectMapper.readValue(responseBody, new TypeReference<>() {});
+
+        assertThat(failure.get("id")).isEqualTo(failureId.toString());
+        assertThat(failure.get("notificationId")).isEqualTo(notificationId.toString());
+        assertThat(failure.get("recipientEmail")).isEqualTo("user@test.com");
+        assertThat(failure.get("eventType")).isEqualTo("FEATURE_CREATED");
+        assertThat(failure.get("errorMessage")).isEqualTo("Test error message");
+        assertThat(failure.get("failedAt")).isNotNull();
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn404ForNonExistentFailureId() throws Exception {
+        // When - Get non-existent failure
+        var result = mvc.get()
+                .uri("/api/admin/email-failures/{id}", UUID.randomUUID())
+                .exchange();
+
+        // Then - Should return 404
+        assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    // ========== Test 5: Failure logging does not affect outcome ==========
+
+    @Test
+    @WithMockOAuth2User(username = "alice")
+    void shouldNotAffectOutcomeWhenFailureLoggingFails() throws Exception {
+        // Given - Configure mail sender to throw exception (email send fails)
+        doThrow(new MailSendException("SMTP server unavailable"))
+                .when(javaMailSender)
+                .send(any(MimeMessage.class));
+
+        // AND - Break the email_delivery_failures table so ANY logging attempt fails
+        // This is implementation-agnostic: works regardless of how logging is implemented
+        // Use UUID in name to avoid conflicts if test crashes before finally block
+        String brokenTableName =
+                "email_delivery_failures_broken_" + UUID.randomUUID().toString().replace("-", "");
+        jdbcTemplate.execute("ALTER TABLE email_delivery_failures RENAME TO " + brokenTableName);
+
+        try {
+            CreateFeaturePayload payload = new CreateFeaturePayload(
+                    "intellij",
+                    "Logging Failure Test",
+                    "Test that failure logging doesn't affect outcome",
+                    null,
+                    "bob");
+
+            // When - Create feature (email send fails AND failure logging fails)
+            var result = mvc.post()
+                    .uri("/api/features")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .exchange();
+
+            // Then - Feature should still be created (outcome unchanged)
+            assertThat(result).hasStatus(HttpStatus.CREATED);
+
+            // Wait until email send was attempted - this is our sync point
+            // After this, async processing should have completed
+            verify(javaMailSender, timeout(5000).times(1)).send(any(MimeMessage.class));
+
+            // Now assertions are safe - notification should be saved in database
+            Integer notificationCount = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM notifications WHERE recipient_user_id = ?", Integer.class, "bob");
+            assertThat(notificationCount).isEqualTo(1);
+
+            // Delivery status should be FAILED (email status update still works)
+            String deliveryStatus = jdbcTemplate.queryForObject(
+                    "SELECT delivery_status FROM notifications WHERE recipient_user_id = ?", String.class, "bob");
+            assertThat(deliveryStatus).isEqualTo("FAILED");
+
+            // Key assertion: no exception leaked out, outcome unchanged
+            // The test completing successfully proves failure logging didn't break the flow
+        } finally {
+            // Restore the table for other tests
+            jdbcTemplate.execute("ALTER TABLE " + brokenTableName + " RENAME TO email_delivery_failures");
+        }
+    }
+
+    // ========== Test 6: Admin API authorization ==========
+
+    @Test
+    void shouldReturn401ForUnauthenticatedRequests() throws Exception {
+        // When - Call admin endpoint without authentication
+        var listResult = mvc.get().uri("/api/admin/email-failures").exchange();
+        var byIdResult = mvc.get()
+                .uri("/api/admin/email-failures/{id}", UUID.randomUUID())
+                .exchange();
+        var byNotificationResult = mvc.get()
+                .uri("/api/admin/email-failures/notification/{notificationId}", UUID.randomUUID())
+                .exchange();
+
+        // Then - Should return 401 Unauthorized
+        assertThat(listResult).hasStatus(HttpStatus.UNAUTHORIZED);
+        assertThat(byIdResult).hasStatus(HttpStatus.UNAUTHORIZED);
+        assertThat(byNotificationResult).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "regularuser",
+            roles = {"USER"})
+    void shouldReturn403ForNonAdminUsers() throws Exception {
+        // When - Call admin endpoint as non-admin user
+        var listResult = mvc.get().uri("/api/admin/email-failures").exchange();
+        var byIdResult = mvc.get()
+                .uri("/api/admin/email-failures/{id}", UUID.randomUUID())
+                .exchange();
+        var byNotificationResult = mvc.get()
+                .uri("/api/admin/email-failures/notification/{notificationId}", UUID.randomUUID())
+                .exchange();
+
+        // Then - Should return 403 Forbidden
+        assertThat(listResult).hasStatus(HttpStatus.FORBIDDEN);
+        assertThat(byIdResult).hasStatus(HttpStatus.FORBIDDEN);
+        assertThat(byNotificationResult).hasStatus(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturn200ForAdminUsers() throws Exception {
+        // When - Call admin endpoint as admin user
+        var result = mvc.get().uri("/api/admin/email-failures").exchange();
+
+        // Then - Should return 200 OK
+        assertThat(result).hasStatus(HttpStatus.OK);
+    }
+
+    @Test
+    @WithMockOAuth2User(
+            username = "multiuser",
+            roles = {"USER", "ADMIN"})
+    void shouldAllowAccessWithMultipleRolesIncludingAdmin() throws Exception {
+        // When - Call admin endpoint as user with both USER and ADMIN roles
+        var result = mvc.get().uri("/api/admin/email-failures").exchange();
+
+        // Then - Should return 200 OK (ADMIN role grants access)
+        assertThat(result).hasStatus(HttpStatus.OK);
+    }
+
+    // ========== Test 7: API response contract and data integrity ==========
+
+    @Test
+    @WithMockOAuth2User(
+            username = "admin",
+            roles = {"ADMIN"})
+    void shouldReturnAllRequiredFieldsInApiResponse() throws Exception {
+        // Given - Insert failure with known values
+        UUID notificationId = insertTestNotification();
+        Instant failedAt = Instant.parse("2026-01-12T15:30:45Z");
+        UUID failureId =
+                insertFailure(notificationId, "test@example.com", "FEATURE_CREATED", "Known error message", failedAt);
+
+        // When - Get failure by ID
+        var result = mvc.get().uri("/api/admin/email-failures/{id}", failureId).exchange();
+
+        // Then - Verify ALL fields with exact values
+        assertThat(result).hasStatus(HttpStatus.OK);
+
+        Map<String, Object> failure =
+                objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<>() {});
+
+        assertThat(failure.get("id")).isEqualTo(failureId.toString());
+        assertThat(failure.get("notificationId")).isEqualTo(notificationId.toString());
+        assertThat(failure.get("recipientEmail")).isEqualTo("test@example.com");
+        assertThat(failure.get("eventType")).isEqualTo("FEATURE_CREATED");
+        assertThat(failure.get("errorMessage")).isEqualTo("Known error message");
+        // Parse and compare as Instant to avoid format-specific issues (milliseconds, timezone offset)
+        Instant returnedFailedAt = Instant.parse((String) failure.get("failedAt"));
+        assertThat(returnedFailedAt).isEqualTo(failedAt);
+    }
+
+    // ========== Helper methods ==========
+
+    private UUID insertTestNotification() {
+        UUID id = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO notifications (id, recipient_user_id, recipient_email, event_type, event_details, created_at, read, delivery_status)
+                VALUES (?, 'testuser', 'testuser@example.com', 'FEATURE_CREATED', '{}', NOW(), false, 'PENDING')
+                """,
+                id);
+        return id;
+    }
+
+    private UUID insertFailure(
+            UUID notificationId, String recipientEmail, String eventType, String errorMessage, Instant failedAt) {
+        UUID id = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO email_delivery_failures (id, notification_id, recipient_email, event_type, error_message, failed_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                id,
+                notificationId,
+                recipientEmail,
+                eventType,
+                errorMessage,
+                java.sql.Timestamp.from(failedAt));
+        return id;
+    }
+}


### PR DESCRIPTION
Task Description:

## Objective

Implement persistent storage of email delivery failure records and provide an admin API for reviewing and troubleshooting failed deliveries.

## Requirements

### Email Delivery Failure Logging

Create `email_delivery_failures` table with columns: `id` (is a UUID primary key), `notification_id`, `recipient_email`, `event_type`, `error_message`, `failed_at`. When `NotificationEmailService` fails to send an email, save failure details to this table. **Behaviour:** Failure logging must not change the outcome of notification processing (no additional exceptions, no HTTP status changes).

### Admin API

Provide REST endpoints for administrators to review delivery failures: **GET /api/admin/email-failures**
- Paginated JSON response, sorted by date DESC (newest first)
- Optional `date` parameter for filtering (ISO 8601 format: `2026-01-12`) **GET /api/admin/email-failures/{id}**
- Single failure record by ID, 404 if not found **GET /api/admin/email-failures/notification/{notificationId}**
- All failure records for specific notification, sorted by date DESC

All `/api/admin/email-failures/**` endpoints require ADMIN role. Non-ADMIN authenticated users: HTTP 403 . Unauthenticated requests: HTTP 401 All timestamps and date filters use UTC.

---

## Acceptance Criteria

- Email delivery failures are logged to `email_delivery_failures` table with all required fields
- Failure logging does not affect notification processing outcome
- Admin API endpoints work as specified with proper security (ADMIN role required)
- Date filtering and timestamps use UTC correctly

## Acceptance Criteria

- Email delivery failures are logged to `email_delivery_failures` table with all required fields
- Failure logging does not affect notification processing outcome
- Admin API endpoints work as specified with proper security (ADMIN role required)
- Date filtering and timestamps use UTC correctly